### PR TITLE
Add audio focus management for Android Auto playback

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/SendSpinPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/SendSpinPlayer.kt
@@ -739,7 +739,10 @@ class SendSpinPlayer : Player {
     // Player Interface - Audio
     // ========================================================================
 
-    override fun getAudioAttributes(): AudioAttributes = AudioAttributes.DEFAULT
+    override fun getAudioAttributes(): AudioAttributes = AudioAttributes.Builder()
+        .setUsage(C.USAGE_MEDIA)
+        .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+        .build()
 
     override fun setAudioAttributes(audioAttributes: AudioAttributes, handleAudioFocus: Boolean) {
         // No-op - audio attributes are handled by SyncAudioPlayer


### PR DESCRIPTION
Without requesting audio focus, Android Auto's infotainment system
doesn't know the app wants to produce audio, so it never hands over
the audio output channel from whatever is currently playing (FM radio,
other apps, etc.).

- Request AUDIOFOCUS_GAIN with USAGE_MEDIA/CONTENT_TYPE_MUSIC when
  playback starts (tied to acquirePlaybackLocks lifecycle)
- Abandon focus when playback stops/pauses/disconnects
- Handle focus change events (pause on loss, resume on gain)
- Fix SendSpinPlayer.getAudioAttributes() to report music attributes
  instead of DEFAULT, so MediaSession correctly identifies the content

https://claude.ai/code/session_01X18mmv3ByNcwun9N5DsDXE