### PR TITLE
feat: add queue actions menu to browse folders

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseContentScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseContentScreen.kt
@@ -16,12 +16,18 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -30,6 +36,9 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -141,7 +150,9 @@ private fun BrowseItemsList(
             if (item is MaBrowseFolder) {
                 BrowseFolderItem(
                     folder = item,
-                    onClick = { onFolderClick(item) }
+                    onClick = { onFolderClick(item) },
+                    onAppendToQueue = { onAddToQueue(item) },
+                    onReplaceQueue = { onItemClick(item) }
                 )
             } else {
                 SearchResultItem(
@@ -157,19 +168,31 @@ private fun BrowseItemsList(
 }
 
 /**
- * A folder row item showing folder icon (or thumbnail), name, and chevron.
+ * A folder row item showing folder icon (or thumbnail), name, and overflow menu.
+ *
+ * Tapping the row navigates into the folder.
+ * The 3-dot menu offers queue actions for the folder's playable contents.
  */
 @Composable
 private fun BrowseFolderItem(
     folder: MaBrowseFolder,
     onClick: () -> Unit,
+    onAppendToQueue: () -> Unit,
+    onReplaceQueue: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var showMenu by remember { mutableStateOf(false) }
+
     Row(
         modifier = modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(
+                start = 16.dp,
+                end = 4.dp,
+                top = 12.dp,
+                bottom = 12.dp
+            ),
         verticalAlignment = Alignment.CenterVertically
     ) {
         // Folder thumbnail or icon
@@ -203,13 +226,45 @@ private fun BrowseFolderItem(
             modifier = Modifier.weight(1f)
         )
 
-        // Chevron
-        Icon(
-            painter = painterResource(R.drawable.ic_chevron_right),
-            contentDescription = null,
-            modifier = Modifier.size(24.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        // Overflow menu
+        Box {
+            IconButton(
+                onClick = { showMenu = true },
+                modifier = Modifier.size(40.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.MoreVert,
+                    contentDescription = "More options",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            DropdownMenu(
+                expanded = showMenu,
+                onDismissRequest = { showMenu = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.append_to_queue)) },
+                    leadingIcon = {
+                        Icon(Icons.Filled.Add, contentDescription = null)
+                    },
+                    onClick = {
+                        showMenu = false
+                        onAppendToQueue()
+                    }
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.replace_queue)) },
+                    leadingIcon = {
+                        Icon(Icons.Filled.PlayArrow, contentDescription = null)
+                    },
+                    onClick = {
+                        showMenu = false
+                        onReplaceQueue()
+                    }
+                )
+            }
+        }
     }
 }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -697,6 +697,8 @@
     <string name="action_yes">Yes</string>
     <string name="action_no">No</string>
     <string name="add_to_queue">Add to Queue</string>
+    <string name="append_to_queue">Append to Queue</string>
+    <string name="replace_queue">Replace Queue</string>
     <string name="unit_ms">ms</string>
 
     <!-- Accessibility - common -->


### PR DESCRIPTION
## Summary
- Replaces the `>` chevron on browse folder items with a 3-dot overflow menu
- Menu offers two actions: **Append to Queue** (adds folder contents to end of queue) and **Replace Queue** (clears queue and plays folder contents)
- Tapping the folder row still navigates into it as before

## Test plan
- [ ] Open Library -> Browse tab
- [ ] Verify folder rows show a 3-dot menu instead of a chevron
- [ ] Tap a folder row -- should navigate into the folder
- [ ] Tap the 3-dot menu on a folder -- should show "Append to Queue" and "Replace Queue"
- [ ] Select "Append to Queue" -- folder contents should be added to the end of the current queue
- [ ] Select "Replace Queue" -- queue should be cleared and folder contents should start playing