### PR TITLE
fix: friendly error when player queue unavailable after idle

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
+++ b/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
@@ -586,7 +586,11 @@ object MusicAssistantManager {
     // Helper to resolve the effective queue ID through the command client
     private suspend fun resolveQueueId(): String {
         val playerId = UserSettings.getPlayerId()
-        return commandClient.getEffectiveQueueId(playerId)
+        try {
+            return commandClient.getEffectiveQueueId(playerId)
+        } catch (e: PlayerUnavailableException) {
+            throw Exception("Player is not available. Try reconnecting to the server.")
+        }
     }
 
     /**

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -809,6 +809,7 @@
     <string name="error_play_failed">Failed to play: %s</string>
     <string name="error_queue_failed">Failed to add to queue: %s</string>
     <string name="error_play_next_failed">Failed to play next: %s</string>
+    <string name="error_player_unavailable">Player is not available. Try reconnecting to the server.</string>
     <string name="success_added_to_queue">Added to queue: %s</string>
     <string name="success_playing_next">Playing next: %s</string>
     <string name="success_added_to_playlist">Added to %s</string>

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/MaCommandClient.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/MaCommandClient.kt
@@ -171,11 +171,17 @@ class MaCommandClient(private val settings: MaSettingsProvider) {
             val players = parsePlayers(response)
             val thisPlayer = players.find { it.playerId == devicePlayerId }
 
+            if (thisPlayer != null && !thisPlayer.available) {
+                throw PlayerUnavailableException(devicePlayerId)
+            }
+
             val effectiveId = thisPlayer?.syncedTo ?: devicePlayerId
             if (effectiveId != devicePlayerId) {
-                Log.d(TAG, "Player is grouped — using leader queue: $effectiveId (our ID: $devicePlayerId)")
+                Log.d(TAG, "Player is grouped -- using leader queue: $effectiveId (our ID: $devicePlayerId)")
             }
             effectiveId
+        } catch (e: PlayerUnavailableException) {
+            throw e
         } catch (e: Exception) {
             Log.w(TAG, "Failed to resolve group leader, using own player ID", e)
             devicePlayerId

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/PlayerUnavailableException.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/PlayerUnavailableException.kt
@@ -1,0 +1,12 @@
+package com.sendspindroid.musicassistant
+
+/**
+ * Thrown when the MA server reports that the player is not available.
+ *
+ * This typically happens when the device temporarily disconnected from the
+ * server, causing the server to destroy the player's queue. The command
+ * WebSocket may still be alive, but queue operations will fail.
+ */
+class PlayerUnavailableException(
+    val playerId: String
+) : Exception("Player $playerId is not available on the server")


### PR DESCRIPTION
## Summary
- Detect unavailable players early in `getEffectiveQueueId()` (the single chokepoint for all 9 queue operations) and throw a new `PlayerUnavailableException`
- Translate the exception in `resolveQueueId()` to a user-friendly message: "Player is not available. Try reconnecting to the server."
- Previously showed raw API error: "MA API error 10: Queue b886fbdb-... is not available"
- Added `error_player_unavailable` string resource for future localization

## Test plan
- [ ] Build: `./gradlew assembleDebug`
- [ ] Open app, connect to server, let it idle until player queue is destroyed server-side
- [ ] Tap a track -- should show "Failed to play: Player is not available. Try reconnecting to the server." instead of raw API error
- [ ] Verify normal playback still works when player is available