### PR TITLE
feat: duration-based buffer capacity calculation

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -78,16 +78,6 @@ class SendSpinClient(
         private const val MAX_RECONNECT_DELAY_MS = 10000L // 10 seconds (was 30s)
         private const val HIGH_POWER_RECONNECT_DELAY_MS = 30_000L // 30s steady-state for high power mode
 
-        /**
-         * Gets the appropriate buffer capacity based on low memory mode setting.
-         */
-        fun getBufferCapacity(): Int {
-            return if (UserSettings.lowMemoryMode) {
-                SendSpinProtocol.Buffer.CAPACITY_LOW_MEM
-            } else {
-                SendSpinProtocol.Buffer.CAPACITY_NORMAL
-            }
-        }
     }
 
     /**
@@ -208,7 +198,7 @@ class SendSpinClient(
 
     override fun getTimeFilter(): SendspinTimeFilter = timeFilter
 
-    override fun getBufferCapacity(): Int = Companion.getBufferCapacity()
+    override fun isLowMemoryMode(): Boolean = UserSettings.lowMemoryMode
 
     override fun getClientId(): String = clientId
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -59,9 +59,9 @@ abstract class SendSpinProtocolHandler(
     abstract fun getTimeFilter(): SendspinTimeFilter
 
     /**
-     * Get the buffer capacity for this connection.
+     * Whether the device is in low-memory mode (smaller buffer target).
      */
-    protected abstract fun getBufferCapacity(): Int
+    protected abstract fun isLowMemoryMode(): Boolean
 
     /**
      * Get the client ID for this connection.
@@ -149,14 +149,24 @@ abstract class SendSpinProtocolHandler(
 
     /**
      * Send client/hello message to start handshake.
+     *
+     * Buffer capacity is computed from the format list and target duration
+     * so the wire-byte cap scales with the highest PCM bitrate we advertise.
      */
     protected fun sendClientHello() {
+        val formats = getSupportedFormats()
+        val bufferDuration = if (isLowMemoryMode()) {
+            SendSpinProtocol.Buffer.DURATION_LOW_MEM_SEC
+        } else {
+            SendSpinProtocol.Buffer.DURATION_NORMAL_SEC
+        }
+        val bufferCapacity = MessageBuilder.calculateBufferCapacity(formats, bufferDuration)
         val text = MessageBuilder.buildClientHello(
             clientId = getClientId(),
             deviceName = getDeviceName(),
-            bufferCapacity = getBufferCapacity(),
+            bufferCapacity = bufferCapacity,
             manufacturer = getManufacturer(),
-            supportedFormats = getSupportedFormats()
+            supportedFormats = formats
         )
         sendTextMessage(text)
         Log.d(tag, "Sent client/hello: ${text.take(500)}")

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilderTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilderTest.kt
@@ -183,6 +183,99 @@ class MessageBuilderTest {
         assertEquals(16, formats[4].bitDepth)
     }
 
+    // --- calculateBufferCapacity ---
+
+    @Test
+    fun calculateBufferCapacity_16bitStereo35sec() {
+        val formats = listOf(
+            MessageBuilder.FormatEntry("pcm", 48000, 2, 16),
+            MessageBuilder.FormatEntry("pcm", 48000, 1, 16)
+        )
+        // 35 * 48000 * 2 * 2 = 6,720,000
+        assertEquals(6_720_000, MessageBuilder.calculateBufferCapacity(formats, 35))
+    }
+
+    @Test
+    fun calculateBufferCapacity_32bitStereo35sec() {
+        val formats = listOf(
+            MessageBuilder.FormatEntry("pcm", 48000, 2, 32),
+            MessageBuilder.FormatEntry("pcm", 48000, 1, 32),
+            MessageBuilder.FormatEntry("pcm", 48000, 2, 16),
+            MessageBuilder.FormatEntry("pcm", 48000, 1, 16)
+        )
+        // Uses max PCM entry: 35 * 48000 * 2 * 4 = 13,440,000
+        assertEquals(13_440_000, MessageBuilder.calculateBufferCapacity(formats, 35))
+    }
+
+    @Test
+    fun calculateBufferCapacity_lowMemory16bit() {
+        val formats = listOf(
+            MessageBuilder.FormatEntry("pcm", 48000, 2, 16),
+            MessageBuilder.FormatEntry("pcm", 48000, 1, 16)
+        )
+        // 10 * 48000 * 2 * 2 = 1,920,000
+        assertEquals(1_920_000, MessageBuilder.calculateBufferCapacity(formats, 10))
+    }
+
+    @Test
+    fun calculateBufferCapacity_ignoresCompressedCodecs() {
+        val formats = listOf(
+            MessageBuilder.FormatEntry("flac", 48000, 2, 16),
+            MessageBuilder.FormatEntry("opus", 48000, 2, 16),
+            MessageBuilder.FormatEntry("pcm", 48000, 2, 16),
+            MessageBuilder.FormatEntry("pcm", 48000, 1, 16)
+        )
+        // Only PCM entries matter: 35 * 48000 * 2 * 2 = 6,720,000
+        assertEquals(6_720_000, MessageBuilder.calculateBufferCapacity(formats, 35))
+    }
+
+    @Test
+    fun calculateBufferCapacity_fallbackWhenNoPcm() {
+        val formats = listOf(
+            MessageBuilder.FormatEntry("flac", 48000, 2, 16)
+        )
+        // Fallback: 35 * 48000 * 2 * 2 = 6,720,000
+        assertEquals(6_720_000, MessageBuilder.calculateBufferCapacity(formats, 35))
+    }
+
+    // --- buildClientHello field names ---
+
+    @Test
+    fun buildClientHello_usesV1FieldNames() {
+        val formats = listOf(
+            MessageBuilder.FormatEntry("pcm", 48000, 2, 16)
+        )
+        val text = MessageBuilder.buildClientHello(
+            clientId = "test-id",
+            deviceName = "Test Device",
+            bufferCapacity = 6_720_000,
+            manufacturer = "Test",
+            supportedFormats = formats
+        )
+        val payload = Json.parseToJsonElement(text).jsonObject["payload"]!!.jsonObject
+        assertNotNull("player@v1_support should be present", payload["player@v1_support"])
+        assertNotNull("artwork@v1_support should be present", payload["artwork@v1_support"])
+        assertNull("legacy player_support should not be present", payload["player_support"])
+        assertNull("legacy artwork_support should not be present", payload["artwork_support"])
+    }
+
+    @Test
+    fun buildClientHello_hasCorrectBufferCapacity() {
+        val formats = listOf(
+            MessageBuilder.FormatEntry("pcm", 48000, 2, 16)
+        )
+        val text = MessageBuilder.buildClientHello(
+            clientId = "test-id",
+            deviceName = "Test Device",
+            bufferCapacity = 6_720_000,
+            manufacturer = "Test",
+            supportedFormats = formats
+        )
+        val payload = Json.parseToJsonElement(text).jsonObject["payload"]!!.jsonObject
+        val playerSupport = payload["player@v1_support"]!!.jsonObject
+        assertEquals(6_720_000, playerSupport["buffer_capacity"]?.jsonPrimitive?.int)
+    }
+
     // --- No serialize needed (returns String directly) ---
 
     @Test

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
@@ -41,11 +41,17 @@ object SendSpinProtocol {
     }
 
     /**
-     * Buffer capacity constants.
+     * Buffer duration targets (seconds).
+     *
+     * The server's BufferTracker paces delivery by wire bytes; we calculate
+     * the byte cap from these durations using the highest-bitrate PCM format
+     * we advertise. This keeps decoded-PCM memory bounded regardless of codec:
+     * - PCM: ~DURATION seconds in memory
+     * - FLAC (~50% compression): ~2x DURATION seconds, still reasonable
      */
     object Buffer {
-        const val CAPACITY_NORMAL = 32_000_000    // 32MB (~2.8 min at 48kHz stereo)
-        const val CAPACITY_LOW_MEM = 8_000_000    // 8MB (~40 sec at 48kHz stereo)
+        const val DURATION_NORMAL_SEC = 35    // 30s target + 5s sync headroom
+        const val DURATION_LOW_MEM_SEC = 10
     }
 
     /**

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -39,7 +39,7 @@ object MessageBuilder {
                     put("manufacturer", manufacturer)
                     put("software_version", "1.0.0")
                 })
-                put("player_support", buildJsonObject {
+                put("player@v1_support", buildJsonObject {
                     put("supported_formats", buildJsonArray {
                         for (fmt in supportedFormats) {
                             add(buildJsonObject {
@@ -56,7 +56,7 @@ object MessageBuilder {
                         add(kotlinx.serialization.json.JsonPrimitive("mute"))
                     })
                 })
-                put("artwork_support", buildJsonObject {
+                put("artwork@v1_support", buildJsonObject {
                     put("channels", buildJsonArray {
                         add(buildJsonObject {
                             put("source", "album")
@@ -116,6 +116,23 @@ object MessageBuilder {
             })
         }
         return message.toString()
+    }
+
+    /**
+     * Calculate buffer_capacity (wire bytes) from target duration and format list.
+     *
+     * Uses the highest-bitrate PCM entry we advertise as the basis, so the cap
+     * is tight for PCM and gives compressed codecs proportionally more seconds
+     * of look-ahead (but bounded decoded memory).
+     */
+    fun calculateBufferCapacity(formats: List<FormatEntry>, durationSec: Int): Int {
+        val maxPcmBytesPerSec = formats
+            .filter { it.codec == "pcm" }
+            .maxOfOrNull { it.sampleRate * it.channels * (it.bitDepth / 8) }
+            ?: (SendSpinProtocol.AudioFormat.SAMPLE_RATE
+                    * SendSpinProtocol.AudioFormat.CHANNELS
+                    * (SendSpinProtocol.AudioFormat.BIT_DEPTH / 8))
+        return durationSec * maxPcmBytesPerSec
     }
 
     fun buildSupportedFormats(


### PR DESCRIPTION
## Summary

- Replace flat 32MB/8MB `buffer_capacity` constants with duration-based calculation (35s normal, 10s low-memory) using the highest-bitrate PCM format advertised
- This bounds decoded-PCM memory regardless of codec: PCM gets ~35s, FLAC ~70s, instead of potentially hundreds of MB for compressed codecs
- Update deprecated JSON field names: `player_support` -> `player@v1_support`, `artwork_support` -> `artwork@v1_support`

## Test plan

- [x] `./gradlew assembleDebug` builds successfully
- [x] `MessageBuilderTest` passes (7 new tests for `calculateBufferCapacity` and field names)
- [x] Connect to server, verify `client/hello` contains `player@v1_support` and correct `buffer_capacity` (~6.7MB for 16-bit, ~13.4MB for 32-bit)
- [x] Verify low-memory mode produces smaller `buffer_capacity` (~1.9MB)
- [x] Play audio -- no underruns or behavioral changes