### PR TITLE
feat: persist album artists only filter across sessions

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -44,6 +44,7 @@ object UserSettings {
     const val KEY_KEEP_SCREEN_ON = "keep_screen_on"
     const val KEY_HIGH_POWER_MODE = "high_power_mode"
     const val KEY_MINI_PLAYER_POSITION = "mini_player_position"
+    const val KEY_ALBUM_ARTISTS_ONLY = "album_artists_only"
 
     // Network-specific codec preference keys
     const val KEY_CODEC_WIFI = "codec_wifi"
@@ -277,6 +278,10 @@ object UserSettings {
      */
     val highPowerMode: Boolean
         get() = prefs?.getBoolean(KEY_HIGH_POWER_MODE, false) ?: false
+
+    var albumArtistsOnly: Boolean
+        get() = prefs?.getBoolean(KEY_ALBUM_ARTISTS_ONLY, false) ?: false
+        set(value) { prefs?.edit()?.putBoolean(KEY_ALBUM_ARTISTS_ONLY, value)?.apply() }
 
     /**
      * Position of the mini player in the navigation content area.

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/LibraryViewModel.kt
@@ -3,6 +3,7 @@ package com.sendspindroid.ui.navigation.library
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.sendspindroid.UserSettings
 import com.sendspindroid.musicassistant.MusicAssistantManager
 import com.sendspindroid.musicassistant.model.MaLibraryItem
 import com.sendspindroid.musicassistant.model.MaMediaType
@@ -103,7 +104,7 @@ class LibraryViewModel : ViewModel() {
     private val _albumsState = MutableStateFlow(TabState())
     val albumsState: StateFlow<TabState> = _albumsState.asStateFlow()
 
-    private val _artistsState = MutableStateFlow(TabState())
+    private val _artistsState = MutableStateFlow(TabState(albumArtistsOnly = UserSettings.albumArtistsOnly))
     val artistsState: StateFlow<TabState> = _artistsState.asStateFlow()
 
     private val _playlistsState = MutableStateFlow(TabState())
@@ -300,6 +301,7 @@ class LibraryViewModel : ViewModel() {
         if (currentState.albumArtistsOnly == enabled) return
 
         Log.d(TAG, "Setting album artists only: $enabled")
+        UserSettings.albumArtistsOnly = enabled
 
         loadedTabs.remove(ContentType.ARTISTS)
         stateFlow.value = currentState.copy(albumArtistsOnly = enabled)


### PR DESCRIPTION
## Summary

Makes the "Album Artists Only" filter chip in the Library Artists tab sticky -- once enabled, it stays enabled across app restarts, navigation, and ViewModel recreation.

**Changes:**
- Add `albumArtistsOnly` boolean preference to `UserSettings` (SharedPreferences)
- Initialize `LibraryViewModel._artistsState` with the saved value
- Persist when the user toggles the filter chip

No UI changes -- the existing Material 3 `FilterChip` already provides clear selected/unselected visual feedback and tap-to-toggle interaction.

## Test plan

- [ ] Enable "Album Artists Only" filter, leave the Artists tab, come back -- filter should still be active
- [ ] Enable filter, kill the app, reopen -- filter should still be active
- [ ] Disable filter -- should persist as disabled