### PR TITLE
fix: add @Volatile to pendingExitDraining for thread safety

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -126,7 +126,7 @@ class PlaybackService : MediaLibraryService() {
     // When true, the next state/group message should call exitDraining() AFTER processing.
     // This ensures the DRAINING check in onStateChanged/onGroupUpdate fires while still
     // in DRAINING state, before transitioning back to PLAYING.
-    private var pendingExitDraining = false
+    @Volatile private var pendingExitDraining = false
     private var currentCodec: String = "pcm"  // Track current stream codec for stats
 
     // Current server connection info (for MA integration)


### PR DESCRIPTION
## Summary

- `pendingExitDraining` is written from the WebSocket IO thread (`onReconnecting`) and read/written from the main thread (`onReconnected`, `completePendingExitDraining`). Without `@Volatile`, the JVM has no memory visibility guarantee for the cross-thread access, which could cause a stale read and skip the `exitDraining()` call after reconnection.
- Adds `@Volatile` annotation to ensure writes are immediately visible across threads, consistent with the existing `@Volatile` on `syncAudioPlayer` (line 123).

## Test plan

- [x] Verified the project compiles with `./gradlew assembleDebug`
- [ ] Manual test: connect to a server, trigger reconnection, verify playback resumes correctly after reconnect