### PR TITLE
fix: remove redundant scaleArtwork() call

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -1366,13 +1366,12 @@ class PlaybackService : MediaLibraryService() {
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     private fun updateMediaSessionArtwork(bitmap: Bitmap) {
         val state = _playbackState.value
-        val scaled = scaleArtwork(bitmap)
 
         forwardingPlayer?.updateMetadata(
             title = state.title,
             artist = state.artist,
             album = state.album,
-            artwork = scaled,
+            artwork = bitmap,
             artworkUri = state.artworkUrl?.let { android.net.Uri.parse(it) }
         )
 


### PR DESCRIPTION
## Summary
- Both callers of `updateMediaSessionArtwork()` (`onArtwork` and `fetchArtwork`) already call `scaleArtwork()` before passing the bitmap in
- `updateMediaSessionArtwork()` then called `scaleArtwork()` again on the already-scaled bitmap, causing an unnecessary bitmap allocation
- Removed the redundant second call so the pre-scaled bitmap is used directly

## Test plan
- [ ] Verify artwork displays correctly on lock screen / notification
- [ ] Verify artwork displays correctly on Android Auto
- [ ] Confirm no StrictMode violations for oversized bitmaps