### PR TITLE
Remove dead isAvailable stub from MusicAssistantManager

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
+++ b/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
@@ -37,7 +37,7 @@ private fun ConnectionMode.toMaMode(): MaConnectionMode = when (this) {
  * Global singleton managing Music Assistant API availability.
  *
  * Provides a single source of truth for whether MA features should be
- * shown in the UI. Components observe [isAvailable] to conditionally
+ * shown in the UI. Components observe [connectionState] to conditionally
  * show features like:
  * - Browse Library
  * - Queue Management
@@ -68,16 +68,6 @@ object MusicAssistantManager {
      * different scenarios (error messages, re-login prompts, etc.).
      */
     val connectionState: StateFlow<MaConnectionState> = _connectionState.asStateFlow()
-
-    /**
-     * Simple boolean availability check.
-     * True only when fully connected and authenticated to MA API.
-     * Use this for simple visibility toggles.
-     */
-    val isAvailable: StateFlow<Boolean> = MutableStateFlow(false).also { flow ->
-        // This is a derived flow - updated when connectionState changes
-        // Actual implementation uses connectionState.map { it.isAvailable }
-    }
 
     // Current server info (when connected)
     private var currentServer: UnifiedServer? = null


### PR DESCRIPTION
## Summary

- Removed `MusicAssistantManager.isAvailable`, a `StateFlow<Boolean>` that was permanently hardcoded to `false` and never wired to `connectionState`
- All call sites already use `connectionState.value.isAvailable` (the property on `MaConnectionState`), so this stub had zero consumers
- Updated the class-level KDoc to reference `connectionState` instead of the deleted property

## Test plan

- [x] Verified no callers of `MusicAssistantManager.isAvailable` exist in the codebase (all usage is `connectionState.value.isAvailable`)
- [x] `./gradlew assembleDebug` builds successfully
- [x] Existing unit tests in `MaConnectionStateIsAvailableTest` still pass (they test `MaConnectionState.isAvailable`, not the removed property)