### PR TITLE
fix: move bitmap decoding off main thread in onArtwork

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -85,6 +85,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Background playback service for SendSpinDroid.
@@ -1046,12 +1047,14 @@ class PlaybackService : MediaLibraryService() {
                 return
             }
 
-            mainHandler.post {
+            serviceScope.launch {
                 Log.d(TAG, "Artwork received: ${imageData.size} bytes")
                 try {
-                    val bitmap = BitmapFactory.decodeByteArray(imageData, 0, imageData.size)
-                    if (bitmap != null) {
-                        val scaled = scaleArtwork(bitmap)
+                    val scaled = withContext(Dispatchers.IO) {
+                        val bitmap = BitmapFactory.decodeByteArray(imageData, 0, imageData.size)
+                        bitmap?.let { scaleArtwork(it) }
+                    }
+                    if (scaled != null) {
                         currentArtwork = scaled
                         updateMediaSessionArtwork(scaled)
                     }


### PR DESCRIPTION
## Summary

- Moves `BitmapFactory.decodeByteArray` and `scaleArtwork` from `mainHandler.post` to `Dispatchers.IO` via the existing `serviceScope` coroutine
- State assignment (`currentArtwork`) and `updateMediaSessionArtwork` remain on the main thread since `serviceScope` uses `Dispatchers.Main`
- Prevents UI jank when large artwork images are received over the wire

## Test plan

- [ ] Connect to a SendSpin server that sends binary artwork data
- [ ] Verify artwork appears in the notification and lock screen controls
- [ ] Verify no ANR or frame drops during artwork transitions
- [ ] Verify artwork clears correctly when server sends empty payload