### PR TITLE
fix: make scanning poll loop lifecycle-aware

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/MainActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/MainActivity.kt
@@ -86,7 +86,9 @@ import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -894,10 +896,13 @@ class MainActivity : AppCompatActivity() {
         // Cancel any previous poll job to prevent duplicates on config change.
         scanningPollJob?.cancel()
         scanningPollJob = lifecycleScope.launch {
-            // Update scanning state when discovery starts/stops
-            while (true) {
-                composeIsScanning.value = discoveryManager?.isDiscovering() == true
-                delay(1000)
+            // Update scanning state when discovery starts/stops.
+            // repeatOnLifecycle ensures polling stops when the activity is not visible.
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                while (true) {
+                    composeIsScanning.value = discoveryManager?.isDiscovering() == true
+                    delay(1000)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Wrapped the `while(true)` scanning poll loop in `MainActivity.kt` with `repeatOnLifecycle(Lifecycle.State.STARTED)` so it automatically pauses when the activity is stopped and resumes when started.
- Previously, this coroutine ran indefinitely via `lifecycleScope.launch` without lifecycle awareness, continuing to poll `isDiscovering()` even when the activity was not visible.

## Test plan
- [ ] Verify scanning state still updates correctly when on the server list screen
- [ ] Verify the polling stops when the app is backgrounded (check via logging or debugger)
- [ ] Verify no regressions in discovery behavior after returning to the app