### PR TITLE
fix: move pendingExitDraining access to main thread in onReconnecting

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -1248,12 +1248,13 @@ class PlaybackService : MediaLibraryService() {
 
         override fun onReconnecting(attempt: Int, serverName: String) {
             android.util.Log.i(TAG, "Reconnecting to $serverName (attempt $attempt) - entering DRAINING mode")
-            // Enter draining mode SYNCHRONOUSLY before any mainHandler posts
-            // This ensures disconnect handlers see DRAINING state when they check
-            // DRAINING state allows playback to continue from buffer during reconnection
-            pendingExitDraining = false  // Clear any stale flag
+            // enterDraining() is thread-safe (guarded by stateLock) so it is safe to call
+            // from the WebSocket IO thread. We call it here rather than inside mainHandler.post
+            // so that the state change is visible immediately -- any disconnect handler that
+            // subsequently runs on the main thread will already see DRAINING state.
             syncAudioPlayer?.enterDraining()
             mainHandler.post {
+                pendingExitDraining = false  // Clear any stale flag (main-thread only)
 
                 // Update connection state for UI (shows "Reconnecting..." indicator)
                 _connectionState.value = ConnectionState.Reconnecting(serverName, attempt)


### PR DESCRIPTION
## Summary

- Fixes a data race in `onReconnecting()` where `pendingExitDraining` was written from the WebSocket IO thread, while all other accesses are on the main thread
- Moves the `pendingExitDraining = false` assignment into the `mainHandler.post` block
- `enterDraining()` remains outside the post block since it is already thread-safe (guarded by `SyncAudioPlayer.stateLock`), preserving the intent that disconnect handlers immediately see DRAINING state

## Test plan

- [ ] Verify reconnection behavior: disconnect server, confirm audio drains from buffer and resumes after reconnect
- [ ] Verify no race conditions: rapidly toggle network connectivity during playback