### PR TITLE
fix: guard against TOCTOU race on syncAudioPlayer from WebSocket thread

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -1180,6 +1180,10 @@ class PlaybackService : MediaLibraryService() {
             // Guard: don't try to decode if the decoder is being replaced (race with onStreamStart)
             if (!decoderReady) return
 
+            // Capture local reference to avoid TOCTOU race: the main thread can null
+            // and release syncAudioPlayer between a null-check and method call.
+            val player = syncAudioPlayer ?: return
+
             // Decode compressed data to PCM (pass-through for PCM codec)
             val pcmData = try {
                 audioDecoder?.decode(audioData) ?: audioData
@@ -1188,7 +1192,7 @@ class PlaybackService : MediaLibraryService() {
                 return
             }
             // Queue decoded PCM - SyncAudioPlayer handles threading internally
-            syncAudioPlayer?.queueChunk(serverTimeMicros, pcmData)
+            player.queueChunk(serverTimeMicros, pcmData)
         }
 
         override fun onVolumeChanged(volume: Int) {

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -1046,6 +1046,7 @@ class SyncAudioPlayer(
      * @param pcmData Raw PCM audio data
      */
     fun queueChunk(serverTimeMicros: Long, pcmData: ByteArray) {
+        if (isReleased.get()) return
         chunksReceived++
 
         // Buffer chunks until time sync is ready
@@ -2770,6 +2771,10 @@ class SyncAudioPlayer(
      * @return true if successfully entered draining, false if not applicable
      */
     fun enterDraining(): Boolean {
+        if (isReleased.get()) {
+            Log.w(TAG, "Cannot enter DRAINING - player has been released")
+            return false
+        }
         stateLock.withLock {
             // Only enter draining if we're currently playing or have buffer
             if (playbackState != PlaybackState.PLAYING && playbackState != PlaybackState.WAITING_FOR_START) {


### PR DESCRIPTION
## Summary

- In `onAudioChunk` (WebSocket thread), capture `syncAudioPlayer` into a local val before decoding and queuing, preventing the main thread from nulling/releasing it mid-call
- Add `isReleased` early-return guard to `SyncAudioPlayer.queueChunk()` so calls on a released player are safely ignored
- Add `isReleased` early-return guard to `SyncAudioPlayer.enterDraining()` for the same reason (called from `onReconnecting` on the WebSocket thread)

## Test plan

- [ ] Verify build compiles cleanly (`assembleDebug` passes)
- [ ] Stress test: rapidly connect/disconnect while audio is streaming to exercise the race window
- [ ] Confirm no crashes or `IllegalStateException` from AudioTrack after player release