### PR TITLE
feat: add HEADUNIT form factor with dedicated Now Playing layout

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/MainActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/MainActivity.kt
@@ -831,10 +831,31 @@ class MainActivity : AppCompatActivity() {
 
         overlay.setContent {
             val windowSizeClass = androidx.compose.material3.windowsizeclass.calculateWindowSizeClass(this)
-            val formFactor = com.sendspindroid.ui.adaptive.determineFormFactor(
+            val detectedFormFactor = com.sendspindroid.ui.adaptive.determineFormFactor(
                 windowSizeClass = windowSizeClass,
                 isTv = isTvDevice
             )
+            // Observe layout mode reactively so changes in Settings take effect immediately
+            val layoutModeState = androidx.compose.runtime.remember {
+                androidx.compose.runtime.mutableStateOf(UserSettings.layoutMode)
+            }
+            androidx.compose.runtime.DisposableEffect(Unit) {
+                val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+                    if (key == UserSettings.KEY_LAYOUT_MODE) {
+                        layoutModeState.value = UserSettings.layoutMode
+                    }
+                }
+                androidx.preference.PreferenceManager.getDefaultSharedPreferences(this@MainActivity)
+                    .registerOnSharedPreferenceChangeListener(listener)
+                onDispose {
+                    androidx.preference.PreferenceManager.getDefaultSharedPreferences(this@MainActivity)
+                        .unregisterOnSharedPreferenceChangeListener(listener)
+                }
+            }
+            val formFactor = when (layoutModeState.value) {
+                UserSettings.LayoutMode.HEADUNIT -> FormFactor.HEADUNIT
+                UserSettings.LayoutMode.AUTO -> detectedFormFactor
+            }
 
             SendSpinTheme {
                 CompositionLocalProvider(LocalFormFactor provides formFactor) {

--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -45,6 +45,7 @@ object UserSettings {
     const val KEY_HIGH_POWER_MODE = "high_power_mode"
     const val KEY_MINI_PLAYER_POSITION = "mini_player_position"
     const val KEY_ALBUM_ARTISTS_ONLY = "album_artists_only"
+    const val KEY_LAYOUT_MODE = "layout_mode"
 
     // Network-specific codec preference keys
     const val KEY_CODEC_WIFI = "codec_wifi"
@@ -282,6 +283,26 @@ object UserSettings {
     var albumArtistsOnly: Boolean
         get() = prefs?.getBoolean(KEY_ALBUM_ARTISTS_ONLY, false) ?: false
         set(value) { prefs?.edit()?.putBoolean(KEY_ALBUM_ARTISTS_ONLY, value)?.apply() }
+
+    /**
+     * Layout mode override for adaptive UI.
+     * AUTO uses automatic detection; HEADUNIT forces head unit layout.
+     */
+    enum class LayoutMode {
+        AUTO,
+        HEADUNIT
+    }
+
+    var layoutMode: LayoutMode
+        get() {
+            val value = prefs?.getString(KEY_LAYOUT_MODE, "AUTO")
+            return try {
+                LayoutMode.valueOf(value ?: "AUTO")
+            } catch (e: Exception) {
+                LayoutMode.AUTO
+            }
+        }
+        set(value) { prefs?.edit()?.putString(KEY_LAYOUT_MODE, value.name)?.apply() }
 
     /**
      * Position of the mini player in the navigation content area.

--- a/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
+++ b/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
@@ -576,11 +576,7 @@ object MusicAssistantManager {
     // Helper to resolve the effective queue ID through the command client
     private suspend fun resolveQueueId(): String {
         val playerId = UserSettings.getPlayerId()
-        try {
-            return commandClient.getEffectiveQueueId(playerId)
-        } catch (e: PlayerUnavailableException) {
-            throw Exception("Player is not available. Try reconnecting to the server.")
-        }
+        return commandClient.getEffectiveQueueId(playerId)
     }
 
     /**
@@ -603,8 +599,10 @@ object MusicAssistantManager {
     ): Result<Unit> {
         val effectiveMode = enqueueMode ?: if (enqueue) EnqueueMode.ADD else EnqueueMode.PLAY
         return withContext(Dispatchers.IO) {
-            val queueId = resolveQueueId()
-            commandClient.playMedia(uri, queueId, mediaType, effectiveMode)
+            runCatching { resolveQueueId() }.fold(
+                onSuccess = { queueId -> commandClient.playMedia(uri, queueId, mediaType, effectiveMode) },
+                onFailure = { Result.failure(it) }
+            )
         }
     }
 
@@ -613,8 +611,10 @@ object MusicAssistantManager {
      */
     suspend fun getQueueItems(limit: Int = 200, offset: Int = 0): Result<MaQueueState> {
         return withContext(Dispatchers.IO) {
-            val queueId = resolveQueueId()
-            commandClient.getQueueItems(queueId, limit, offset)
+            runCatching { resolveQueueId() }.fold(
+                onSuccess = { queueId -> commandClient.getQueueItems(queueId, limit, offset) },
+                onFailure = { Result.failure(it) }
+            )
         }
     }
 
@@ -623,8 +623,10 @@ object MusicAssistantManager {
      */
     suspend fun clearQueue(): Result<Unit> {
         return withContext(Dispatchers.IO) {
-            val queueId = resolveQueueId()
-            commandClient.clearQueue(queueId)
+            runCatching { resolveQueueId() }.fold(
+                onSuccess = { queueId -> commandClient.clearQueue(queueId) },
+                onFailure = { Result.failure(it) }
+            )
         }
     }
 
@@ -633,8 +635,10 @@ object MusicAssistantManager {
      */
     suspend fun playQueueItem(queueItemId: String): Result<Unit> {
         return withContext(Dispatchers.IO) {
-            val queueId = resolveQueueId()
-            commandClient.playQueueItem(queueId, queueItemId)
+            runCatching { resolveQueueId() }.fold(
+                onSuccess = { queueId -> commandClient.playQueueItem(queueId, queueItemId) },
+                onFailure = { Result.failure(it) }
+            )
         }
     }
 
@@ -643,8 +647,10 @@ object MusicAssistantManager {
      */
     suspend fun removeQueueItem(queueItemId: String): Result<Unit> {
         return withContext(Dispatchers.IO) {
-            val queueId = resolveQueueId()
-            commandClient.removeQueueItem(queueId, queueItemId)
+            runCatching { resolveQueueId() }.fold(
+                onSuccess = { queueId -> commandClient.removeQueueItem(queueId, queueItemId) },
+                onFailure = { Result.failure(it) }
+            )
         }
     }
 
@@ -653,8 +659,10 @@ object MusicAssistantManager {
      */
     suspend fun moveQueueItem(queueItemId: String, newIndex: Int): Result<Unit> {
         return withContext(Dispatchers.IO) {
-            val queueId = resolveQueueId()
-            commandClient.moveQueueItem(queueId, queueItemId, newIndex)
+            runCatching { resolveQueueId() }.fold(
+                onSuccess = { queueId -> commandClient.moveQueueItem(queueId, queueItemId, newIndex) },
+                onFailure = { Result.failure(it) }
+            )
         }
     }
 
@@ -663,8 +671,10 @@ object MusicAssistantManager {
      */
     suspend fun setQueueShuffle(enabled: Boolean): Result<Unit> {
         return withContext(Dispatchers.IO) {
-            val queueId = resolveQueueId()
-            commandClient.setQueueShuffle(queueId, enabled)
+            runCatching { resolveQueueId() }.fold(
+                onSuccess = { queueId -> commandClient.setQueueShuffle(queueId, enabled) },
+                onFailure = { Result.failure(it) }
+            )
         }
     }
 
@@ -673,8 +683,10 @@ object MusicAssistantManager {
      */
     suspend fun setQueueRepeat(mode: String): Result<Unit> {
         return withContext(Dispatchers.IO) {
-            val queueId = resolveQueueId()
-            commandClient.setQueueRepeat(queueId, mode)
+            runCatching { resolveQueueId() }.fold(
+                onSuccess = { queueId -> commandClient.setQueueRepeat(queueId, mode) },
+                onFailure = { Result.failure(it) }
+            )
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
@@ -454,7 +454,8 @@ private fun ConnectedShell(
     val queueViewModel: QueueViewModel = viewModel()
     val showQueueViewModel = (AdaptiveDefaults.showInlineQueuePanel(formFactor) ||
          AdaptiveDefaults.hasTvQueueSidebar(formFactor) ||
-         AdaptiveDefaults.showBrowseQueueSidebar(formFactor)) && isMaConnected
+         AdaptiveDefaults.showBrowseQueueSidebar(formFactor) ||
+         formFactor == FormFactor.HEADUNIT) && isMaConnected
 
     // Content composable shared between both layouts
     val contentArea: @Composable (PaddingValues) -> Unit = { innerPadding ->
@@ -616,6 +617,8 @@ private fun ConnectedShell(
             configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
         val navSuiteType = if (isPhoneLandscape) {
             NavigationSuiteType.NavigationRail
+        } else if (formFactor == FormFactor.HEADUNIT) {
+            NavigationSuiteType.NavigationBar
         } else {
             NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
         }

--- a/android/app/src/main/java/com/sendspindroid/ui/adaptive/AdaptiveDefaults.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/adaptive/AdaptiveDefaults.kt
@@ -30,6 +30,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 3
         FormFactor.TABLET_10 -> 4
         FormFactor.TV -> 5
+        FormFactor.HEADUNIT -> 3
     }
 
     // -- Card Sizes --
@@ -40,6 +41,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 180.dp
         FormFactor.TABLET_10 -> 200.dp
         FormFactor.TV -> 220.dp
+        FormFactor.HEADUNIT -> 200.dp
     }
 
     // -- Screen Padding --
@@ -50,6 +52,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 24.dp
         FormFactor.TABLET_10 -> 32.dp
         FormFactor.TV -> 48.dp  // Overscan-safe margin
+        FormFactor.HEADUNIT -> 24.dp
     }
 
     // -- Text Sizes --
@@ -60,6 +63,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 28.sp
         FormFactor.TABLET_10 -> 32.sp
         FormFactor.TV -> 36.sp
+        FormFactor.HEADUNIT -> 32.sp
     }
 
     /** Body text size (e.g., artist name, metadata) */
@@ -68,6 +72,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 14.sp
         FormFactor.TABLET_10 -> 16.sp
         FormFactor.TV -> 20.sp  // 10-foot UI minimum
+        FormFactor.HEADUNIT -> 18.sp
     }
 
     /** Caption/label text size */
@@ -76,6 +81,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 12.sp
         FormFactor.TABLET_10 -> 14.sp
         FormFactor.TV -> 16.sp
+        FormFactor.HEADUNIT -> 14.sp
     }
 
     // -- Playback Controls --
@@ -86,6 +92,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 80.dp
         FormFactor.TABLET_10 -> 88.dp
         FormFactor.TV -> 96.dp
+        FormFactor.HEADUNIT -> 96.dp
     }
 
     /** Small playback button size (prev/next/group) */
@@ -94,6 +101,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 64.dp
         FormFactor.TABLET_10 -> 72.dp
         FormFactor.TV -> 80.dp
+        FormFactor.HEADUNIT -> 80.dp
     }
 
     // -- Album Art --
@@ -104,6 +112,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 320.dp
         FormFactor.TABLET_10 -> 400.dp
         FormFactor.TV -> 500.dp
+        FormFactor.HEADUNIT -> 400.dp
     }
 
     // -- Layout Decisions --
@@ -115,6 +124,7 @@ object AdaptiveDefaults {
             FormFactor.TABLET_7 -> true  // Always side-by-side on 7" tablets
             FormFactor.TABLET_10 -> true
             FormFactor.TV -> true
+            FormFactor.HEADUNIT -> false  // Portrait layout, stacked vertically
         }
 
     /** Art width fraction when using side-by-side layout */
@@ -123,11 +133,12 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 0.40f
         FormFactor.TABLET_10 -> 0.45f
         FormFactor.TV -> 0.55f
+        FormFactor.HEADUNIT -> 0.45f
     }
 
-    /** Whether to show the mini player (TV doesn't need it) */
+    /** Whether to show the mini player (TV and head unit don't need it) */
     fun showMiniPlayer(formFactor: FormFactor): Boolean =
-        formFactor != FormFactor.TV
+        formFactor != FormFactor.TV && formFactor != FormFactor.HEADUNIT
 
     /**
      * Whether to show the mini player as a side panel (phone landscape only).
@@ -177,6 +188,7 @@ object AdaptiveDefaults {
         FormFactor.TABLET_7 -> 48.dp
         FormFactor.TABLET_10 -> 48.dp
         FormFactor.TV -> 64.dp
+        FormFactor.HEADUNIT -> 64.dp
     }
 
     // -- Browse Queue Sidebar --
@@ -193,5 +205,6 @@ object AdaptiveDefaults {
         FormFactor.TABLET_10 -> 320.dp
         FormFactor.TV -> 350.dp
         FormFactor.PHONE -> 0.dp  // Not shown
+        FormFactor.HEADUNIT -> 0.dp  // Not shown
     }
 }

--- a/android/app/src/main/java/com/sendspindroid/ui/adaptive/FormFactor.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/adaptive/FormFactor.kt
@@ -24,7 +24,10 @@ enum class FormFactor {
     TABLET_10,
 
     /** Android TV / Fire TV - 10-foot UI with D-pad navigation */
-    TV
+    TV,
+
+    /** Car head unit - large portrait touchscreen with oversized touch targets */
+    HEADUNIT
 }
 
 /**

--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
@@ -1,0 +1,443 @@
+package com.sendspindroid.ui.main
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.sendspindroid.R
+import com.sendspindroid.musicassistant.MaQueueItem
+import com.sendspindroid.ui.adaptive.AdaptiveDefaults
+import com.sendspindroid.ui.adaptive.FormFactor
+import com.sendspindroid.ui.main.components.AlbumArtCard
+import com.sendspindroid.ui.main.components.TvTrackProgressBar
+import com.sendspindroid.ui.queue.QueueUiState
+import com.sendspindroid.ui.queue.QueueViewModel
+
+/**
+ * Head unit Now Playing layout for large portrait car touchscreens.
+ *
+ * Vertical layout optimized for glanceable car use:
+ * - Large album art at top
+ * - Track info + visual progress bar with time labels
+ * - Single row of 5 oversized controls: shuffle, prev, play, next, favorite
+ * - "Up Next" queue peek showing next 3 tracks
+ */
+@Composable
+fun NowPlayingHeadUnit(
+    metadata: TrackMetadata,
+    groupName: String,
+    artworkSource: ArtworkSource?,
+    isBuffering: Boolean,
+    isPlaying: Boolean,
+    controlsEnabled: Boolean,
+    accentColor: Color?,
+    isMaConnected: Boolean,
+    positionMs: Long,
+    durationMs: Long,
+    positionUpdatedAt: Long = 0L,
+    onPreviousClick: () -> Unit,
+    onPlayPauseClick: () -> Unit,
+    onNextClick: () -> Unit,
+    onSwitchGroupClick: () -> Unit,
+    onFavoriteClick: () -> Unit,
+    queueViewModel: QueueViewModel? = null,
+    modifier: Modifier = Modifier
+) {
+    val formFactor = FormFactor.HEADUNIT
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = AdaptiveDefaults.screenPadding(formFactor)),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Album Art - large, centered
+        AlbumArtCard(
+            artworkSource = artworkSource,
+            isBuffering = isBuffering,
+            maxWidth = AdaptiveDefaults.albumArtMaxSize(formFactor),
+            modifier = Modifier.fillMaxWidth(0.65f)
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // Track Title
+        Text(
+            text = metadata.title.ifEmpty { stringResource(R.string.not_playing) },
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            fontSize = AdaptiveDefaults.titleTextSize(formFactor),
+            letterSpacing = (-0.02).sp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { liveRegion = LiveRegionMode.Polite }
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // Artist / Album
+        val metadataText = buildHeadUnitMetadata(metadata.artist, metadata.album)
+        if (metadataText.isNotEmpty()) {
+            Text(
+                text = metadataText,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.9f),
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontSize = AdaptiveDefaults.bodyTextSize(formFactor),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        // Group Name
+        if (groupName.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = stringResource(R.string.group_label, groupName),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Visual progress bar with time labels
+        TvTrackProgressBar(
+            positionMs = positionMs,
+            durationMs = durationMs,
+            isPlaying = isPlaying,
+            accentColor = accentColor,
+            positionUpdatedAt = positionUpdatedAt,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Playback Controls -- single row: shuffle, prev, PLAY, next, favorite
+        HeadUnitControls(
+            isPlaying = isPlaying,
+            controlsEnabled = controlsEnabled,
+            isMaConnected = isMaConnected,
+            accentColor = accentColor,
+            onSwitchGroupClick = onSwitchGroupClick,
+            onPreviousClick = onPreviousClick,
+            onPlayPauseClick = onPlayPauseClick,
+            onNextClick = onNextClick,
+            onFavoriteClick = onFavoriteClick
+        )
+
+        // Up Next queue peek (when MA connected and queue available)
+        if (isMaConnected && queueViewModel != null) {
+            // Load queue on first composition and refresh when track changes
+            androidx.compose.runtime.LaunchedEffect(metadata.title) {
+                queueViewModel.loadQueue(showLoading = false)
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            UpNextQueuePeek(queueViewModel = queueViewModel)
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+/**
+ * Head unit control row: shuffle - prev - PLAY - next - favorite
+ * All in a single row with oversized touch targets.
+ */
+@Composable
+private fun HeadUnitControls(
+    isPlaying: Boolean,
+    controlsEnabled: Boolean,
+    isMaConnected: Boolean,
+    accentColor: Color?,
+    onSwitchGroupClick: () -> Unit,
+    onPreviousClick: () -> Unit,
+    onPlayPauseClick: () -> Unit,
+    onNextClick: () -> Unit,
+    onFavoriteClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val playSize = 80.dp
+    val transportSize = 64.dp
+    val secondarySize = 54.dp
+    val playIconSize = 36.dp
+    val transportIconSize = 30.dp
+    val secondaryIconSize = 24.dp
+    val buttonAccent = accentColor ?: MaterialTheme.colorScheme.primary
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Shuffle / Switch Group
+        IconButton(
+            onClick = onSwitchGroupClick,
+            enabled = controlsEnabled,
+            modifier = Modifier.size(secondarySize)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_shuffle),
+                contentDescription = stringResource(R.string.accessibility_switch_group_button),
+                modifier = Modifier.size(secondaryIconSize),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.width(10.dp))
+
+        // Previous
+        IconButton(
+            onClick = onPreviousClick,
+            enabled = controlsEnabled,
+            modifier = Modifier.size(transportSize)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_skip_previous),
+                contentDescription = stringResource(R.string.accessibility_previous_button),
+                modifier = Modifier.size(transportIconSize),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.width(10.dp))
+
+        // Play/Pause - accent colored, largest button
+        FilledIconButton(
+            onClick = onPlayPauseClick,
+            enabled = controlsEnabled,
+            modifier = Modifier.size(playSize),
+            shape = CircleShape,
+            colors = IconButtonDefaults.filledIconButtonColors(
+                containerColor = buttonAccent,
+                contentColor = Color.Black
+            )
+        ) {
+            Icon(
+                painter = painterResource(
+                    if (isPlaying) R.drawable.ic_pause else R.drawable.ic_play
+                ),
+                contentDescription = stringResource(R.string.accessibility_play_button),
+                modifier = Modifier.size(playIconSize)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(10.dp))
+
+        // Next
+        IconButton(
+            onClick = onNextClick,
+            enabled = controlsEnabled,
+            modifier = Modifier.size(transportSize)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_skip_next),
+                contentDescription = stringResource(R.string.accessibility_next_button),
+                modifier = Modifier.size(transportIconSize),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.width(10.dp))
+
+        // Favorite
+        if (isMaConnected) {
+            IconButton(
+                onClick = onFavoriteClick,
+                enabled = controlsEnabled,
+                modifier = Modifier.size(secondarySize)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_favorite_border),
+                    contentDescription = stringResource(R.string.accessibility_favorite_track),
+                    modifier = Modifier.size(secondaryIconSize),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Compact "Up Next" section showing the next few tracks in the queue.
+ * Designed for quick glanceable reference while driving.
+ */
+@Composable
+private fun UpNextQueuePeek(
+    queueViewModel: QueueViewModel,
+    maxItems: Int = 3,
+    modifier: Modifier = Modifier
+) {
+    val uiState by queueViewModel.uiState.collectAsState()
+    val successState = uiState as? QueueUiState.Success ?: return
+    val upNext = successState.upNextItems.take(maxItems)
+    if (upNext.isEmpty()) return
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Divider with label
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            HorizontalDivider(
+                modifier = Modifier.weight(1f),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+            )
+            Text(
+                text = stringResource(R.string.headunit_up_next),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.sp,
+                modifier = Modifier.padding(horizontal = 12.dp)
+            )
+            HorizontalDivider(
+                modifier = Modifier.weight(1f),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        // Queue items
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+            userScrollEnabled = false
+        ) {
+            itemsIndexed(upNext) { index, item ->
+                UpNextItem(index = index + 1, item = item)
+            }
+        }
+    }
+}
+
+/**
+ * Single queue peek item: number, thumbnail, title, artist, duration.
+ */
+@Composable
+private fun UpNextItem(
+    index: Int,
+    item: MaQueueItem,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Track number
+        Text(
+            text = "$index",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.width(24.dp),
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        // Thumbnail
+        AsyncImage(
+            model = item.imageUri ?: R.drawable.placeholder_album,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(44.dp)
+                .clip(RoundedCornerShape(8.dp))
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        // Track info
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = item.name,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            val artistName = item.artist
+            if (!artistName.isNullOrEmpty()) {
+                Text(
+                    text = artistName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        // Duration
+        item.duration?.let { seconds ->
+            val mins = seconds / 60
+            val secs = seconds % 60
+            Text(
+                text = "%d:%02d".format(mins, secs),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+            )
+        }
+    }
+}
+
+private fun buildHeadUnitMetadata(artist: String, album: String): String {
+    return buildString {
+        if (artist.isNotEmpty()) append(artist)
+        if (album.isNotEmpty()) {
+            if (isNotEmpty()) append(" -- ")
+            append(album)
+        }
+    }
+}

--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
@@ -142,6 +142,28 @@ fun NowPlayingScreen(
 
     Box(modifier = modifier.fillMaxSize()) {
         when {
+            // Head unit: portrait layout with large touch targets + queue peek
+            formFactor == FormFactor.HEADUNIT -> {
+                NowPlayingHeadUnit(
+                    metadata = metadata,
+                    groupName = groupName,
+                    artworkSource = artworkSource,
+                    isBuffering = isBuffering,
+                    isPlaying = isPlaying,
+                    controlsEnabled = controlsEnabled,
+                    accentColor = accentColor,
+                    isMaConnected = isMaConnected,
+                    positionMs = positionMs,
+                    durationMs = durationMs,
+                    positionUpdatedAt = positionUpdatedAt,
+                    onPreviousClick = onPreviousClick,
+                    onPlayPauseClick = onPlayPauseClick,
+                    onNextClick = onNextClick,
+                    onSwitchGroupClick = onSwitchGroupClick,
+                    onFavoriteClick = onFavoriteClick,
+                    queueViewModel = queueViewModel
+                )
+            }
             // TV with MA connected: cinematic layout with toggleable queue sidebar
             formFactor == FormFactor.TV && isMaConnected -> {
                 NowPlayingTv(

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -75,6 +75,7 @@ fun SettingsScreen(
     val fullscreenMode by viewModel.fullscreenMode.collectAsState()
     val keepScreenOn by viewModel.keepScreenOn.collectAsState()
     val miniPlayerPosition by viewModel.miniPlayerPosition.collectAsState()
+    val layoutMode by viewModel.layoutMode.collectAsState()
     val syncOffset by viewModel.syncOffset.collectAsState()
     val preferredCodec by viewModel.preferredCodec.collectAsState()
     val wifiCodec by viewModel.wifiCodec.collectAsState()
@@ -146,6 +147,16 @@ fun SettingsScreen(
                 ),
                 selectedOption = miniPlayerPosition,
                 onOptionSelected = { viewModel.setMiniPlayerPosition(it) }
+            )
+            SegmentedButtonPreference(
+                title = stringResource(R.string.pref_layout_mode_title),
+                summary = stringResource(R.string.pref_layout_mode_summary),
+                options = listOf(
+                    stringResource(R.string.pref_layout_mode_auto) to UserSettings.LayoutMode.AUTO,
+                    stringResource(R.string.pref_layout_mode_headunit) to UserSettings.LayoutMode.HEADUNIT
+                ),
+                selectedOption = layoutMode,
+                onOptionSelected = { viewModel.setLayoutMode(it) }
             )
 
             // Audio Category

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsViewModel.kt
@@ -56,6 +56,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val _miniPlayerPosition = MutableStateFlow(UserSettings.miniPlayerPosition)
     val miniPlayerPosition: StateFlow<UserSettings.MiniPlayerPosition> = _miniPlayerPosition.asStateFlow()
 
+    private val _layoutMode = MutableStateFlow(UserSettings.layoutMode)
+    val layoutMode: StateFlow<UserSettings.LayoutMode> = _layoutMode.asStateFlow()
+
     // Audio settings
     private val _syncOffset = MutableStateFlow(UserSettings.getSyncOffsetMs())
     val syncOffset: StateFlow<Int> = _syncOffset.asStateFlow()
@@ -136,6 +139,11 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun setMiniPlayerPosition(position: UserSettings.MiniPlayerPosition) {
         UserSettings.setMiniPlayerPosition(position)
         _miniPlayerPosition.value = position
+    }
+
+    fun setLayoutMode(mode: UserSettings.LayoutMode) {
+        UserSettings.layoutMode = mode
+        _layoutMode.value = mode
     }
 
     // Audio settings

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="album_art">Album artwork</string>
     <string name="now_playing">Now Playing</string>
     <string name="not_playing">Not Playing</string>
+    <string name="headunit_up_next">UP NEXT</string>
     <string name="available_servers">Available Servers</string>
     <string name="connecting">Connecting…</string>
     <string name="connected_to">Connected to %s</string>
@@ -155,6 +156,10 @@
     <string name="pref_mini_player_position_summary">Where the mini player appears when browsing</string>
     <string name="pref_mini_player_position_top">Top</string>
     <string name="pref_mini_player_position_bottom">Bottom</string>
+    <string name="pref_layout_mode_title">Layout Mode</string>
+    <string name="pref_layout_mode_summary">Override automatic layout detection for specialized displays</string>
+    <string name="pref_layout_mode_auto">Auto</string>
+    <string name="pref_layout_mode_headunit">Head Unit</string>
     <string name="pref_player_name_title">Player Name</string>
     <string name="pref_player_name_summary">Name shown to SendSpin server</string>
     <string name="pref_category_audio">Audio Sync</string>


### PR DESCRIPTION
## Summary

- Adds a new **HEADUNIT** form factor optimized for large portrait car touchscreens (13.6" Phoenix Automotive)
- Dedicated `NowPlayingHeadUnit` composable with 5 oversized inline controls: shuffle, prev, play/pause, next, favorite
- **Up Next** queue peek showing the next 3 tracks below the controls
- New **Layout Mode** setting (Auto / Head Unit) in Settings with reactive observation via `SharedPreferences` listener
- Forces bottom navigation bar for HEADUNIT (instead of the rail that tablets normally get)
- Wraps all `MusicAssistantManager.resolveQueueId()` callers with `runCatching` to prevent crashes when queue ID resolution fails

## Files changed

| File | Change |
|------|--------|
| `NowPlayingHeadUnit.kt` | New dedicated head unit layout with custom controls and Up Next queue peek |
| `MainActivity.kt` | Reactive layout mode observation via `DisposableEffect` + `mutableStateOf` |
| `UserSettings.kt` | `LayoutMode` enum (AUTO, HEADUNIT) and `KEY_LAYOUT_MODE` constant |
| `AppShell.kt` | Bottom nav override for HEADUNIT; include HEADUNIT in queueViewModel condition |
| `AdaptiveDefaults.kt` | HEADUNIT-specific sizing (album art, text, padding) |
| `FormFactor.kt` | New `HEADUNIT` enum value |
| `NowPlayingScreen.kt` | Route HEADUNIT form factor to `NowPlayingHeadUnit` |
| `SettingsScreen.kt` | Layout Mode dropdown in Settings |
| `SettingsViewModel.kt` | Layout mode preference read/write |
| `MusicAssistantManager.kt` | `runCatching` wraps around `resolveQueueId()` in 8 callers |
| `strings.xml` | New string resources for head unit UI |

## Test plan

- [ ] Set Layout Mode to "Head Unit" in Settings and verify the Now Playing screen switches to the head unit layout immediately
- [ ] Verify 5 inline controls render: shuffle, prev, play/pause, next, favorite
- [ ] Verify Up Next queue peek shows next 3 tracks when connected to Music Assistant
- [ ] Verify bottom navigation bar appears (not left rail)
- [ ] Set Layout Mode back to "Auto" and verify standard layout returns
- [ ] Test on phone-sized device to ensure Auto mode is unaffected
- [ ] Verify no crash when queue ID resolution fails (disconnect from MA mid-playback)