### PR TITLE
Add stable keys to LazyColumn/LazyRow items

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
@@ -351,7 +351,10 @@ private fun UpNextQueuePeek(
             verticalArrangement = Arrangement.spacedBy(2.dp),
             userScrollEnabled = false
         ) {
-            itemsIndexed(upNext) { index, item ->
+            itemsIndexed(
+                items = upNext,
+                key = { _, item -> item.queueItemId }
+            ) { index, item ->
                 UpNextItem(index = index + 1, item = item)
             }
         }

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseListScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseListScreen.kt
@@ -194,7 +194,10 @@ private fun FilterAndSortChipsRow(
 
         // Sort chips (only when multiple options available)
         if (sortOptions.size > 1) {
-            items(sortOptions) { sortOption ->
+            items(
+                items = sortOptions,
+                key = { it.name }
+            ) { sortOption ->
                 FilterChip(
                     selected = sortOption == selectedSort,
                     onClick = { onSortChange(sortOption) },

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/search/SearchScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/search/SearchScreen.kt
@@ -238,7 +238,10 @@ private fun FilterChipsRow(
         contentPadding = PaddingValues(horizontal = 12.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        items(filterOptions) { (type, labelRes) ->
+        items(
+            items = filterOptions,
+            key = { (type, _) -> type.name }
+        ) { (type, labelRes) ->
             FilterChip(
                 selected = activeFilters.contains(type),
                 onClick = { onFilterToggle(type, !activeFilters.contains(type)) },


### PR DESCRIPTION
## Summary
- Added `key` lambdas to three `items`/`itemsIndexed` calls that were missing them, preventing unnecessary recomposition of every visible item on list changes.
- **NowPlayingHeadUnit**: queue peek `itemsIndexed` now uses `queueItemId` as key.
- **SearchScreen**: filter chip `items` now uses the media type enum name as key.
- **BrowseListScreen**: sort chip `items` now uses the sort option enum name as key.

All other `items`/`itemsIndexed` calls across the codebase already had stable keys.

## Test plan
- [ ] Open the head unit Now Playing screen with a queue and verify up-next items render correctly
- [ ] Change tracks and confirm the up-next list updates without visual glitches
- [ ] Open the search screen, toggle filter chips, and verify correct selection state
- [ ] Open the library browse screen and verify sort chips render and toggle correctly