### PR TITLE
perf: use lifecycle-aware flow collection in Compose UI

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/StatsBottomSheet.kt
+++ b/android/app/src/main/java/com/sendspindroid/StatsBottomSheet.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
@@ -54,7 +54,7 @@ class StatsBottomSheet : BottomSheetDialogFragment() {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                val statsState by viewModel.statsState.collectAsState()
+                val statsState by viewModel.statsState.collectAsStateWithLifecycle()
 
                 SendSpinTheme {
                     // Surface sets LocalContentColor so all child Text composables

--- a/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
@@ -41,7 +41,7 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -147,7 +147,7 @@ fun AppShell(
     onShowUndoSnackbar: (message: String, onUndo: () -> Unit, onDismissed: () -> Unit) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val connectionState by viewModel.connectionState.collectAsState()
+    val connectionState by viewModel.connectionState.collectAsStateWithLifecycle()
 
     when (connectionState) {
         is AppConnectionState.ServerList,
@@ -240,8 +240,8 @@ private fun ConnectedShell(
     modifier: Modifier = Modifier
 ) {
     val formFactor = LocalFormFactor.current
-    val isMaConnected by viewModel.isMaConnected.collectAsState()
-    val connectionState by viewModel.connectionState.collectAsState()
+    val isMaConnected by viewModel.isMaConnected.collectAsStateWithLifecycle()
+    val connectionState by viewModel.connectionState.collectAsStateWithLifecycle()
 
     // Which screen to show. null = Now Playing, non-null = browse tab.
     // Starts as HOME when MA is connected, null otherwise.
@@ -277,7 +277,7 @@ private fun ConnectedShell(
     val playerViewModel: PlayerViewModel = viewModel()
 
     // Detail navigation state
-    val currentDetail by viewModel.currentDetail.collectAsState()
+    val currentDetail by viewModel.currentDetail.collectAsStateWithLifecycle()
 
     val browseNavTabs = remember {
         listOf(
@@ -490,7 +490,7 @@ private fun ConnectedShell(
             val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
             val useSideMiniPlayer = AdaptiveDefaults.showSideMiniPlayer(configuration.smallestScreenWidthDp, isLandscape)
 
-            val miniPlayerPosition by viewModel.miniPlayerPosition.collectAsState()
+            val miniPlayerPosition by viewModel.miniPlayerPosition.collectAsStateWithLifecycle()
             val showBottomMiniPlayer = !useSideMiniPlayer && AdaptiveDefaults.showMiniPlayer(formFactor)
             val miniPlayerReturnToNowPlaying: () -> Unit = {
                 viewModel.clearDetailNavigation()
@@ -557,7 +557,7 @@ private fun ConnectedShell(
                                         .width(AdaptiveDefaults.browseQueueSidebarWidth(formFactor))
                                         .fillMaxHeight()
                                 ) {
-                                    val metadata by viewModel.metadata.collectAsState()
+                                    val metadata by viewModel.metadata.collectAsStateWithLifecycle()
                                     QueueSheetContent(
                                         viewModel = queueViewModel,
                                         onBrowseLibrary = {
@@ -1295,12 +1295,12 @@ private fun MiniPlayerBar(
     onNextClick: () -> Unit,
     onReturnToNowPlaying: () -> Unit
 ) {
-    val metadata by viewModel.metadata.collectAsState()
-    val artworkSource by viewModel.artworkSource.collectAsState()
-    val isPlaying by viewModel.isPlaying.collectAsState()
-    val positionMs by viewModel.positionMs.collectAsState()
-    val durationMs by viewModel.durationMs.collectAsState()
-    val positionUpdatedAt by viewModel.positionUpdatedAt.collectAsState()
+    val metadata by viewModel.metadata.collectAsStateWithLifecycle()
+    val artworkSource by viewModel.artworkSource.collectAsStateWithLifecycle()
+    val isPlaying by viewModel.isPlaying.collectAsStateWithLifecycle()
+    val positionMs by viewModel.positionMs.collectAsStateWithLifecycle()
+    val durationMs by viewModel.durationMs.collectAsStateWithLifecycle()
+    val positionUpdatedAt by viewModel.positionUpdatedAt.collectAsStateWithLifecycle()
 
     // Slide from top or bottom depending on position setting
     val isTop = position == UserSettings.MiniPlayerPosition.TOP
@@ -1338,12 +1338,12 @@ private fun SideMiniPlayerBar(
     onPlayPauseClick: () -> Unit,
     onReturnToNowPlaying: () -> Unit
 ) {
-    val metadata by viewModel.metadata.collectAsState()
-    val artworkSource by viewModel.artworkSource.collectAsState()
-    val isPlaying by viewModel.isPlaying.collectAsState()
-    val positionMs by viewModel.positionMs.collectAsState()
-    val durationMs by viewModel.durationMs.collectAsState()
-    val positionUpdatedAt by viewModel.positionUpdatedAt.collectAsState()
+    val metadata by viewModel.metadata.collectAsStateWithLifecycle()
+    val artworkSource by viewModel.artworkSource.collectAsStateWithLifecycle()
+    val isPlaying by viewModel.isPlaying.collectAsStateWithLifecycle()
+    val positionMs by viewModel.positionMs.collectAsStateWithLifecycle()
+    val durationMs by viewModel.durationMs.collectAsStateWithLifecycle()
+    val positionUpdatedAt by viewModel.positionUpdatedAt.collectAsStateWithLifecycle()
 
     AnimatedVisibility(
         visible = !metadata.isEmpty,

--- a/android/app/src/main/java/com/sendspindroid/ui/detail/AlbumDetailScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/detail/AlbumDetailScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -60,7 +60,7 @@ fun AlbumDetailScreen(
         viewModel.loadAlbum(albumId)
     }
 
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Box(modifier = Modifier.fillMaxSize()) {
         when (val state = uiState) {

--- a/android/app/src/main/java/com/sendspindroid/ui/detail/ArtistDetailScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/detail/ArtistDetailScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,7 +65,7 @@ fun ArtistDetailScreen(
         viewModel.loadArtist(artistId)
     }
 
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Box(modifier = Modifier.fillMaxSize()) {
         when (val state = uiState) {

--- a/android/app/src/main/java/com/sendspindroid/ui/detail/AudiobookDetailScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/detail/AudiobookDetailScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -68,7 +68,7 @@ fun AudiobookDetailScreen(
     audiobookAuthor: String? = null,
     viewModel: AudiobookDetailViewModel = viewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val pullToRefreshState = rememberPullToRefreshState()
 
     LaunchedEffect(audiobookId) {

--- a/android/app/src/main/java/com/sendspindroid/ui/detail/PlaylistDetailScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/detail/PlaylistDetailScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -64,7 +64,7 @@ fun PlaylistDetailScreen(
         viewModel.loadPlaylist(playlistId)
     }
 
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showAddTracks by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/android/app/src/main/java/com/sendspindroid/ui/detail/PodcastDetailScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/detail/PodcastDetailScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,7 +58,7 @@ fun PodcastDetailScreen(
     totalEpisodes: Int = 0,
     viewModel: PodcastDetailViewModel = viewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val pullToRefreshState = rememberPullToRefreshState()
 
     LaunchedEffect(podcastId) {

--- a/android/app/src/main/java/com/sendspindroid/ui/main/MiniPlayerComposeView.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/MiniPlayerComposeView.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.AbstractComposeView
@@ -37,12 +37,12 @@ class MiniPlayerComposeView @JvmOverloads constructor(
     override fun Content() {
         val vm = viewModel ?: return
 
-        val metadata by vm.metadata.collectAsState()
-        val artworkSource by vm.artworkSource.collectAsState()
-        val isPlaying by vm.isPlaying.collectAsState()
-        val positionMs by vm.positionMs.collectAsState()
-        val durationMs by vm.durationMs.collectAsState()
-        val positionUpdatedAt by vm.positionUpdatedAt.collectAsState()
+        val metadata by vm.metadata.collectAsStateWithLifecycle()
+        val artworkSource by vm.artworkSource.collectAsStateWithLifecycle()
+        val isPlaying by vm.isPlaying.collectAsStateWithLifecycle()
+        val positionMs by vm.positionMs.collectAsStateWithLifecycle()
+        val durationMs by vm.durationMs.collectAsStateWithLifecycle()
+        val positionUpdatedAt by vm.positionUpdatedAt.collectAsStateWithLifecycle()
 
         SendSpinTheme {
             MiniPlayer(

--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -314,7 +314,7 @@ private fun UpNextQueuePeek(
     maxItems: Int = 3,
     modifier: Modifier = Modifier
 ) {
-    val uiState by queueViewModel.uiState.collectAsState()
+    val uiState by queueViewModel.uiState.collectAsStateWithLifecycle()
     val successState = uiState as? QueueUiState.Success ?: return
     val upNext = successState.upNextItems.take(maxItems)
     if (upNext.isEmpty()) return

--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -93,19 +93,19 @@ fun NowPlayingScreen(
     inlineQueueVisible: Boolean = true,
     modifier: Modifier = Modifier
 ) {
-    val connectionState by viewModel.connectionState.collectAsState()
-    val isPlaying by viewModel.isPlaying.collectAsState()
-    val playbackState by viewModel.playbackState.collectAsState()
-    val metadata by viewModel.metadata.collectAsState()
-    val groupName by viewModel.groupName.collectAsState()
-    val artworkSource by viewModel.artworkSource.collectAsState()
-    val volume by viewModel.volume.collectAsState()
-    val reconnectingState by viewModel.reconnectingState.collectAsState()
-    val isMaConnected by viewModel.isMaConnected.collectAsState()
-    val playerColors by viewModel.playerColors.collectAsState()
-    val positionMs by viewModel.positionMs.collectAsState()
-    val durationMs by viewModel.durationMs.collectAsState()
-    val positionUpdatedAt by viewModel.positionUpdatedAt.collectAsState()
+    val connectionState by viewModel.connectionState.collectAsStateWithLifecycle()
+    val isPlaying by viewModel.isPlaying.collectAsStateWithLifecycle()
+    val playbackState by viewModel.playbackState.collectAsStateWithLifecycle()
+    val metadata by viewModel.metadata.collectAsStateWithLifecycle()
+    val groupName by viewModel.groupName.collectAsStateWithLifecycle()
+    val artworkSource by viewModel.artworkSource.collectAsStateWithLifecycle()
+    val volume by viewModel.volume.collectAsStateWithLifecycle()
+    val reconnectingState by viewModel.reconnectingState.collectAsStateWithLifecycle()
+    val isMaConnected by viewModel.isMaConnected.collectAsStateWithLifecycle()
+    val playerColors by viewModel.playerColors.collectAsStateWithLifecycle()
+    val positionMs by viewModel.positionMs.collectAsStateWithLifecycle()
+    val durationMs by viewModel.durationMs.collectAsStateWithLifecycle()
+    val positionUpdatedAt by viewModel.positionUpdatedAt.collectAsStateWithLifecycle()
     // Don't show buffering spinner when paused -- SendSpin's audio stream stops on
     // pause, so Media3 reports STATE_BUFFERING even though the user intentionally paused.
     val isBuffering = playbackState == PlaybackState.BUFFERING && !metadata.isEmpty && isPlaying

--- a/android/app/src/main/java/com/sendspindroid/ui/main/ServerListScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/ServerListScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,9 +52,9 @@ fun ServerListScreen(
     onAddServerClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val saved by savedServers.collectAsState()
-    val discovered by discoveredServers.collectAsState()
-    val onlineIds by onlineSavedServerIds.collectAsState()
+    val saved by savedServers.collectAsStateWithLifecycle()
+    val discovered by discoveredServers.collectAsStateWithLifecycle()
+    val onlineIds by onlineSavedServerIds.collectAsStateWithLifecycle()
 
     ServerListScreenContent(
         savedServers = saved,

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/home/HomeScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -57,13 +57,13 @@ fun HomeScreen(
     }
 
     // Observe all section states via StateFlow
-    val recentlyPlayedState by viewModel.recentlyPlayed.collectAsState()
-    val recentlyAddedState by viewModel.recentlyAdded.collectAsState()
-    val albumsState by viewModel.albums.collectAsState()
-    val artistsState by viewModel.artists.collectAsState()
-    val playlistsState by viewModel.playlists.collectAsState()
-    val radioState by viewModel.radioStations.collectAsState()
-    val isRefreshing by viewModel.isRefreshing.collectAsState()
+    val recentlyPlayedState by viewModel.recentlyPlayed.collectAsStateWithLifecycle()
+    val recentlyAddedState by viewModel.recentlyAdded.collectAsStateWithLifecycle()
+    val albumsState by viewModel.albums.collectAsStateWithLifecycle()
+    val artistsState by viewModel.artists.collectAsStateWithLifecycle()
+    val playlistsState by viewModel.playlists.collectAsStateWithLifecycle()
+    val radioState by viewModel.radioStations.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
 
     HomeScreenContent(
         recentlyPlayedState = recentlyPlayedState,

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseContentScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseContentScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -73,7 +73,7 @@ fun BrowseContentScreen(
     onAddToQueue: (MaLibraryItem) -> Unit = {},
     onPlayNext: (MaLibraryItem) -> Unit = {}
 ) {
-    val state by viewModel.browseState.collectAsState()
+    val state by viewModel.browseState.collectAsStateWithLifecycle()
     val pullToRefreshState = rememberPullToRefreshState()
 
     // Intercept back button when not at root

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseListScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseListScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -86,7 +86,7 @@ fun BrowseListScreen(
     onPlayNext: (MaLibraryItem) -> Unit = {},
     onAlbumArtistsOnlyChange: ((Boolean) -> Unit)? = null
 ) {
-    val state by stateFlow.collectAsState()
+    val state by stateFlow.collectAsStateWithLifecycle()
     val pullToRefreshState = rememberPullToRefreshState()
     val listState = rememberLazyListState()
 

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/playlists/PlaylistsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/playlists/PlaylistsScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -68,7 +68,7 @@ fun PlaylistsScreen(
         viewModel.loadPlaylists()
     }
 
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showCreateDialog by remember { mutableStateOf(false) }
 
     Box(modifier = modifier.fillMaxSize()) {

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/search/SearchScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/search/SearchScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -79,7 +79,7 @@ fun SearchScreen(
     onAddToQueue: (MaLibraryItem) -> Unit = {},
     onPlayNext: (MaLibraryItem) -> Unit = {}
 ) {
-    val state by viewModel.searchState.collectAsState()
+    val state by viewModel.searchState.collectAsStateWithLifecycle()
 
     SearchScreenContent(
         state = state,

--- a/android/app/src/main/java/com/sendspindroid/ui/player/PlayerSheetContent.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/player/PlayerSheetContent.kt
@@ -28,7 +28,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,8 +58,8 @@ fun PlayerSheetContent(
     viewModel: PlayerViewModel,
     modifier: Modifier = Modifier
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-    val togglingPlayerId by viewModel.togglingPlayerId.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val togglingPlayerId by viewModel.togglingPlayerId.collectAsStateWithLifecycle()
 
     // Load players when sheet opens
     LaunchedEffect(Unit) {

--- a/android/app/src/main/java/com/sendspindroid/ui/queue/QueueSheetContent.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/queue/QueueSheetContent.kt
@@ -41,7 +41,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -77,7 +77,7 @@ fun QueueSheetContent(
     modifier: Modifier = Modifier,
     currentTrackTitle: String? = null
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showSaveDialog by remember { mutableStateOf(false) }
 
     // Load queue when content first appears (with loading spinner),

--- a/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
@@ -12,7 +12,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.fragment.app.FragmentActivity
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.lifecycleScope
 import com.sendspindroid.R
@@ -116,7 +116,7 @@ class AddServerWizardActivity : FragmentActivity() {
 
         setContent {
             SendSpinTheme {
-                val state by viewModel.wizardState.collectAsState()
+                val state by viewModel.wizardState.collectAsStateWithLifecycle()
 
                 // Auto-start discovery when entering a FindServer step
                 androidx.compose.runtime.LaunchedEffect(state.currentStep) {

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -71,21 +71,21 @@ fun SettingsScreen(
     onExportLogs: () -> Unit,
     onRestartApp: () -> Unit
 ) {
-    val playerName by viewModel.playerName.collectAsState()
-    val fullscreenMode by viewModel.fullscreenMode.collectAsState()
-    val keepScreenOn by viewModel.keepScreenOn.collectAsState()
-    val miniPlayerPosition by viewModel.miniPlayerPosition.collectAsState()
-    val layoutMode by viewModel.layoutMode.collectAsState()
-    val syncOffset by viewModel.syncOffset.collectAsState()
-    val preferredCodec by viewModel.preferredCodec.collectAsState()
-    val wifiCodec by viewModel.wifiCodec.collectAsState()
-    val cellularCodec by viewModel.cellularCodec.collectAsState()
-    val lowMemoryMode by viewModel.lowMemoryMode.collectAsState()
-    val highPowerMode by viewModel.highPowerMode.collectAsState()
-    val batteryOptExempt by viewModel.batteryOptExempt.collectAsState()
-    val debugLogging by viewModel.debugLogging.collectAsState()
-    val debugSampleCount by viewModel.debugSampleCount.collectAsState()
-    val appVersion by viewModel.appVersion.collectAsState()
+    val playerName by viewModel.playerName.collectAsStateWithLifecycle()
+    val fullscreenMode by viewModel.fullscreenMode.collectAsStateWithLifecycle()
+    val keepScreenOn by viewModel.keepScreenOn.collectAsStateWithLifecycle()
+    val miniPlayerPosition by viewModel.miniPlayerPosition.collectAsStateWithLifecycle()
+    val layoutMode by viewModel.layoutMode.collectAsStateWithLifecycle()
+    val syncOffset by viewModel.syncOffset.collectAsStateWithLifecycle()
+    val preferredCodec by viewModel.preferredCodec.collectAsStateWithLifecycle()
+    val wifiCodec by viewModel.wifiCodec.collectAsStateWithLifecycle()
+    val cellularCodec by viewModel.cellularCodec.collectAsStateWithLifecycle()
+    val lowMemoryMode by viewModel.lowMemoryMode.collectAsStateWithLifecycle()
+    val highPowerMode by viewModel.highPowerMode.collectAsStateWithLifecycle()
+    val batteryOptExempt by viewModel.batteryOptExempt.collectAsStateWithLifecycle()
+    val debugLogging by viewModel.debugLogging.collectAsStateWithLifecycle()
+    val debugSampleCount by viewModel.debugSampleCount.collectAsStateWithLifecycle()
+    val appVersion by viewModel.appVersion.collectAsStateWithLifecycle()
 
     var showPlayerNameDialog by remember { mutableStateOf(false) }
     var showSyncOffsetDialog by remember { mutableStateOf(false) }


### PR DESCRIPTION
## Summary
- Replaced all `collectAsState()` calls with `collectAsStateWithLifecycle()` across 20 Compose UI files
- Flows now stop collecting when composables are not visible (e.g., app backgrounded), reducing unnecessary CPU and memory usage
- The `lifecycle-runtime-compose` dependency was already present in build.gradle.kts

## Test plan
- [ ] Verify app launches and all screens render correctly
- [ ] Background the app and confirm no unnecessary flow collection via profiler/logcat
- [ ] Test NowPlaying, Settings, ServerList, Home, Search, and detail screens for correct state updates
- [ ] Test mini player and queue sheet update correctly
- [ ] Verify Android Auto head unit view still works