### PR TITLE
fix: reset clock sync state on reconnect

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -221,7 +221,7 @@ class SendSpinClient(
 
         if (timeFilter.isFrozen) {
             timeFilter.thaw()
-            Log.i(TAG, "Time filter thawed after reconnection - sync preserved")
+            Log.i(TAG, "Time filter thawed after reconnection - re-syncing with increased covariance")
         }
 
         reconnecting.set(false)

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/SendspinTimeFilter.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/SendspinTimeFilter.kt
@@ -489,14 +489,23 @@ class SendspinTimeFilter {
         offset = frozen.offset
         drift = frozen.drift
 
-        // Increase covariance by 10x to allow faster adaptation
-        // while preserving the general sync estimate
-        p00 = frozen.p00 * 10.0
-        p01 = frozen.p01 * 3.0
-        p10 = frozen.p10 * 3.0
-        p11 = frozen.p11 * 10.0
+        // Increase covariance by 100x to allow rapid re-convergence after
+        // reconnection. The old offset is a reasonable starting point but may
+        // be stale if the server restarted or network conditions changed
+        // significantly. Large covariance lets the filter quickly adopt new
+        // measurements while still benefiting from the prior estimate.
+        p00 = frozen.p00 * 100.0
+        p01 = frozen.p01 * 10.0
+        p10 = frozen.p10 * 10.0
+        p11 = frozen.p11 * 100.0
 
-        measurementCount = frozen.measurementCount
+        // Reset measurement count to MIN_MEASUREMENTS so that:
+        // 1. isReady remains true (playback continues from buffer)
+        // 2. isConverged returns false (forces aggressive burst sync)
+        // 3. addMeasurement() takes the Kalman update path (not init path)
+        // This ensures TimeSyncManager uses fast burst parameters until
+        // the filter actually reconverges with fresh measurements.
+        measurementCount = MIN_MEASUREMENTS
         baselineClientTime = frozen.baselineClientTime
 
         // Restore outlier rejection state (offsets are still valid reference)
@@ -509,6 +518,11 @@ class SendspinTimeFilter {
         innovationWindowIndex = 0
         innovationWindowCount = 0
         adaptiveProcessNoise = BASE_PROCESS_NOISE_OFFSET
+
+        // Reset convergence tracking so it gets re-logged after re-sync
+        hasLoggedConvergence = false
+        convergenceTimeMs = 0
+        firstMeasurementTimeMs = 0
 
         frozenState = null
     }


### PR DESCRIPTION
## Summary

- After WebSocket reconnection, the Kalman time filter's `thaw()` was restoring the full pre-disconnect measurement count, causing `isConverged` to return true immediately. This made `TimeSyncManager` use the slow converged burst strategy (3s interval, 3 bursts) instead of the aggressive initial strategy needed to re-establish accurate sync with the server.
- Fixed by resetting `measurementCount` to `MIN_MEASUREMENTS` (2) on thaw so `isReady` stays true (playback continues) but `isConverged` returns false (forces fast re-sync).
- Increased covariance inflation from 10x to 100x so the filter adapts faster to potentially changed conditions after reconnection.
- Reset convergence tracking so reconvergence milestones get logged for diagnostics.

## Test plan

- [ ] Connect to a server and let sync converge (verify in Stats for Nerds)
- [ ] Kill the server or disconnect WiFi briefly to trigger reconnection
- [ ] Verify in logs that time filter thaw message appears and sync reconverges with aggressive burst strategy
- [ ] Verify playback resumes without audible sync drift after reconnection
- [ ] Verify initial connection flow is unaffected (no regression)
- [ ] Run existing unit tests: `./gradlew :shared:testAndroidHostTest --tests "com.sendspindroid.sendspin.SendspinTimeFilterTest"` (pre-existing stabilityScore test failure is unrelated)