### PR TITLE
refactor: extract magic numbers into named constants

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -6,6 +6,7 @@ import android.media.AudioTimestamp
 import android.media.AudioTrack
 import android.util.Log
 import com.sendspindroid.debug.FileLogger
+import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -189,9 +190,9 @@ interface SyncAudioPlayerCallback {
  */
 class SyncAudioPlayer(
     private val timeFilter: SendspinTimeFilter,
-    private val sampleRate: Int = 48000,
-    private val channels: Int = 2,
-    private val bitDepth: Int = 16
+    private val sampleRate: Int = SendSpinProtocol.AudioFormat.SAMPLE_RATE,
+    private val channels: Int = SendSpinProtocol.AudioFormat.CHANNELS,
+    private val bitDepth: Int = SendSpinProtocol.AudioFormat.BIT_DEPTH
 ) {
     companion object {
         private const val TAG = "SyncAudioPlayer"

--- a/android/app/src/main/java/com/sendspindroid/sendspin/decoder/AudioDecoderFactory.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/decoder/AudioDecoderFactory.kt
@@ -5,6 +5,7 @@ import android.media.AudioTrack
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.util.Log
+import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 
 /**
  * Factory for creating audio decoders based on codec type.
@@ -87,7 +88,7 @@ object AudioDecoderFactory {
         if (android.os.Build.VERSION.SDK_INT >= 31) {
             try {
                 val minBuf = AudioTrack.getMinBufferSize(
-                    48000, AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_32BIT
+                    SendSpinProtocol.AudioFormat.SAMPLE_RATE, AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_32BIT
                 )
                 if (minBuf > 0) depths.add(32)
             } catch (e: Exception) {
@@ -99,7 +100,7 @@ object AudioDecoderFactory {
         if (android.os.Build.VERSION.SDK_INT >= 31) {
             try {
                 val minBuf = AudioTrack.getMinBufferSize(
-                    48000, AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_24BIT_PACKED
+                    SendSpinProtocol.AudioFormat.SAMPLE_RATE, AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_24BIT_PACKED
                 )
                 if (minBuf > 0) depths.add(24)
             } catch (e: Exception) {

--- a/android/app/src/main/java/com/sendspindroid/sendspin/decoder/OpusDecoder.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/decoder/OpusDecoder.kt
@@ -25,6 +25,9 @@ class OpusDecoder : MediaCodecDecoder(MediaFormat.MIMETYPE_AUDIO_OPUS) {
 
         // Default seek pre-roll in nanoseconds (80ms)
         private const val DEFAULT_SEEK_PRE_ROLL_NS: Long = 80_000_000
+
+        // Size of a minimal OpusHead structure (RFC 7845) without channel mapping table
+        private const val OPUS_HEAD_SIZE = 19
     }
 
     override fun configureFormat(
@@ -81,7 +84,7 @@ class OpusDecoder : MediaCodecDecoder(MediaFormat.MIMETYPE_AUDIO_OPUS) {
      * Create a minimal OpusHead structure for the given parameters.
      */
     private fun createDefaultOpusHead(channels: Int, sampleRate: Int): ByteArray {
-        val buffer = ByteBuffer.allocate(19)
+        val buffer = ByteBuffer.allocate(OPUS_HEAD_SIZE)
             .order(ByteOrder.LITTLE_ENDIAN)
 
         // Magic signature

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/message/BinaryMessageParserExt.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/message/BinaryMessageParserExt.kt
@@ -1,12 +1,13 @@
 package com.sendspindroid.sendspin.protocol.message
 
+import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import java.nio.ByteBuffer
 
 /**
  * Extension to parse from Java-WebSocket ByteBuffer (used by SendSpinServer).
  */
 fun BinaryMessageParser.parse(bytes: ByteBuffer): BinaryMessageParser.BinaryMessage? {
-    if (bytes.remaining() < 9) return null
+    if (bytes.remaining() < SendSpinProtocol.BINARY_HEADER_SIZE_BYTES) return null
 
     val array = ByteArray(bytes.remaining())
     bytes.get(array)

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
@@ -10,6 +10,11 @@ object SendSpinProtocol {
     const val ENDPOINT_PATH = "/sendspin"
 
     /**
+     * Binary message header: 1 byte type + 8 bytes big-endian int64 timestamp.
+     */
+    const val BINARY_HEADER_SIZE_BYTES = 9
+
+    /**
      * Binary message type identifiers.
      */
     object BinaryType {
@@ -24,8 +29,16 @@ object SendSpinProtocol {
     object AudioFormat {
         const val SAMPLE_RATE = 48000
         const val CHANNELS = 2
+        const val CHANNELS_MONO = 1
         const val BIT_DEPTH = 16
         const val DEFAULT_CODEC = "pcm"
+    }
+
+    /**
+     * Artwork request constants for client/hello handshake.
+     */
+    object Artwork {
+        const val REQUEST_SIZE = 500  // Requested artwork width/height in pixels
     }
 
     /**

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/BinaryMessageParser.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/BinaryMessageParser.kt
@@ -5,7 +5,7 @@ import com.sendspindroid.shared.log.Log
 
 object BinaryMessageParser {
     private const val TAG = "BinaryMessageParser"
-    private const val HEADER_SIZE = 9 // 1 byte type + 8 bytes timestamp
+    private const val HEADER_SIZE = SendSpinProtocol.BINARY_HEADER_SIZE_BYTES
 
     sealed class BinaryMessage {
         data class Audio(

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -61,8 +61,8 @@ object MessageBuilder {
                         add(buildJsonObject {
                             put("source", "album")
                             put("format", "jpeg")
-                            put("media_width", 500)
-                            put("media_height", 500)
+                            put("media_width", SendSpinProtocol.Artwork.REQUEST_SIZE)
+                            put("media_height", SendSpinProtocol.Artwork.REQUEST_SIZE)
                         })
                     })
                 })
@@ -177,7 +177,7 @@ object MessageBuilder {
                     add(FormatEntry(
                         codec = codec,
                         sampleRate = SendSpinProtocol.AudioFormat.SAMPLE_RATE,
-                        channels = 1,
+                        channels = SendSpinProtocol.AudioFormat.CHANNELS_MONO,
                         bitDepth = bitDepth
                     ))
                 }


### PR DESCRIPTION
## Summary
- Replace hardcoded numeric literals in audio and protocol code with named constants from `SendSpinProtocol`
- Add `BINARY_HEADER_SIZE_BYTES`, `CHANNELS_MONO`, and `Artwork.REQUEST_SIZE` to the protocol constants object
- Add `OPUS_HEAD_SIZE` constant to `OpusDecoder` for the RFC 7845 OpusHead struct size
- Update `SyncAudioPlayer`, `AudioDecoderFactory`, `BinaryMessageParser`, `BinaryMessageParserExt`, and `MessageBuilder` to reference these constants

## Test plan
- [x] Build compiles successfully (`assembleDebug`)
- [x] Existing unit tests pass (3 pre-existing failures unrelated to this change)
- [ ] Verify audio playback still works on device (no behavioral changes expected -- pure refactor)