### PR TITLE
Replace inline fully-qualified names with imports

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/MainActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/MainActivity.kt
@@ -15,19 +15,25 @@ import android.content.pm.PackageManager
 import android.content.res.ColorStateList
 import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.util.Log
 import com.sendspindroid.debug.DebugLogger
 import com.sendspindroid.debug.FileLogger
 import android.app.UiModeManager
+import android.annotation.TargetApi
+import android.graphics.RenderEffect
+import android.graphics.Shader
 import android.view.HapticFeedbackConstants
 import android.view.KeyEvent
 import android.view.LayoutInflater
@@ -39,6 +45,7 @@ import android.view.WindowManager
 import android.view.accessibility.AccessibilityManager
 import android.view.animation.AnimationUtils
 import android.widget.EditText
+import android.widget.FrameLayout
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
@@ -97,14 +104,19 @@ import com.sendspindroid.ui.main.PlaybackState
 import com.sendspindroid.ui.main.ArtworkSource
 import com.sendspindroid.ui.main.ServerListScreen
 import com.sendspindroid.ui.main.components.ServerItemStatus
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.sendspindroid.ui.AppShell
 import com.sendspindroid.ui.adaptive.FormFactor
 import com.sendspindroid.ui.adaptive.LocalFormFactor
+import com.sendspindroid.ui.adaptive.determineFormFactor
 import com.sendspindroid.ui.adaptive.isTvDevice
 import com.sendspindroid.ui.theme.SendSpinTheme
 import com.sendspindroid.ui.main.NavTab
@@ -790,7 +802,7 @@ class MainActivity : AppCompatActivity() {
      * media controller) continue to work and update the ViewModel, which
      * the Compose UI observes.
      */
-    @OptIn(androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi::class)
+    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     private fun setupComposeShell() {
         val overlay = ComposeView(this).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -804,7 +816,7 @@ class MainActivity : AppCompatActivity() {
         contentParent?.removeView(binding.coordinatorLayout)
 
         // Create a FrameLayout wrapper for Compose + detail fragments
-        val rootFrame = android.widget.FrameLayout(this).apply {
+        val rootFrame = FrameLayout(this).apply {
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT
@@ -830,25 +842,25 @@ class MainActivity : AppCompatActivity() {
         composeOverlay = overlay
 
         overlay.setContent {
-            val windowSizeClass = androidx.compose.material3.windowsizeclass.calculateWindowSizeClass(this)
-            val detectedFormFactor = com.sendspindroid.ui.adaptive.determineFormFactor(
+            val windowSizeClass = calculateWindowSizeClass(this)
+            val detectedFormFactor = determineFormFactor(
                 windowSizeClass = windowSizeClass,
                 isTv = isTvDevice
             )
             // Observe layout mode reactively so changes in Settings take effect immediately
-            val layoutModeState = androidx.compose.runtime.remember {
-                androidx.compose.runtime.mutableStateOf(UserSettings.layoutMode)
+            val layoutModeState = remember {
+                mutableStateOf(UserSettings.layoutMode)
             }
-            androidx.compose.runtime.DisposableEffect(Unit) {
+            DisposableEffect(Unit) {
                 val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
                     if (key == UserSettings.KEY_LAYOUT_MODE) {
                         layoutModeState.value = UserSettings.layoutMode
                     }
                 }
-                androidx.preference.PreferenceManager.getDefaultSharedPreferences(this@MainActivity)
+                PreferenceManager.getDefaultSharedPreferences(this@MainActivity)
                     .registerOnSharedPreferenceChangeListener(listener)
                 onDispose {
-                    androidx.preference.PreferenceManager.getDefaultSharedPreferences(this@MainActivity)
+                    PreferenceManager.getDefaultSharedPreferences(this@MainActivity)
                         .unregisterOnSharedPreferenceChangeListener(listener)
                 }
             }
@@ -1860,7 +1872,7 @@ class MainActivity : AppCompatActivity() {
         if (durationMs >= 0 || positionMs >= 0) {
             val positionUpdatedAt = extras.getLong(
                 PlaybackService.EXTRA_POSITION_UPDATED_AT,
-                android.os.SystemClock.elapsedRealtime()
+                SystemClock.elapsedRealtime()
             )
             viewModel.updateTrackProgress(
                 positionMs = if (positionMs >= 0) positionMs else 0,
@@ -3173,11 +3185,11 @@ class MainActivity : AppCompatActivity() {
      * @param factor How much to darken (0.0 = black, 1.0 = original color)
      */
     private fun darkenColor(color: Int, factor: Float): Int {
-        val a = android.graphics.Color.alpha(color)
-        val r = (android.graphics.Color.red(color) * factor).toInt()
-        val g = (android.graphics.Color.green(color) * factor).toInt()
-        val b = (android.graphics.Color.blue(color) * factor).toInt()
-        return android.graphics.Color.argb(a, r, g, b)
+        val a = Color.alpha(color)
+        val r = (Color.red(color) * factor).toInt()
+        val g = (Color.green(color) * factor).toInt()
+        val b = (Color.blue(color) * factor).toInt()
+        return Color.argb(a, r, g, b)
     }
 
     /**
@@ -3209,7 +3221,7 @@ class MainActivity : AppCompatActivity() {
         if (UserSettings.lowMemoryMode) return
 
         // RenderEffect blur requires API 31+ (Android 12)
-        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S) return
+        if (Build.VERSION.SDK_INT < VERSION_CODES.S) return
 
         // De-duplicate: skip if this is the same artwork (use generationId as cheap identity check)
         val artworkId = "${bitmap.generationId}_${bitmap.width}x${bitmap.height}"
@@ -3238,12 +3250,12 @@ class MainActivity : AppCompatActivity() {
      * Applies Gaussian blur effect to the background using RenderEffect.
      * Blur radius can be adjusted (higher = more blur).
      */
-    @android.annotation.TargetApi(android.os.Build.VERSION_CODES.S)
+    @TargetApi(VERSION_CODES.S)
     private fun applyBlurEffect() {
         val blurRadius = 80f  // Adjust blur intensity here (1-150+)
-        val blurEffect = android.graphics.RenderEffect.createBlurEffect(
+        val blurEffect = RenderEffect.createBlurEffect(
             blurRadius, blurRadius,
-            android.graphics.Shader.TileMode.CLAMP
+            Shader.TileMode.CLAMP
         )
         binding.backgroundArtView.setRenderEffect(blurEffect)
     }
@@ -3253,7 +3265,7 @@ class MainActivity : AppCompatActivity() {
      */
     private fun clearBlurredBackground() {
         // Skip if feature not available
-        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S) return
+        if (Build.VERSION.SDK_INT < VERSION_CODES.S) return
 
         // Clear tracking so next artwork will update
         lastArtworkSource = null
@@ -3298,7 +3310,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Fade in the blurred background art
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+        if (Build.VERSION.SDK_INT >= VERSION_CODES.S) {
             binding.backgroundArtView.animate()
                 .alpha(0.5f)
                 .setDuration(300)

--- a/android/app/src/main/java/com/sendspindroid/debug/FileLogger.kt
+++ b/android/app/src/main/java/com/sendspindroid/debug/FileLogger.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid.debug
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import java.io.File
 import java.io.PrintWriter
@@ -61,8 +62,8 @@ object FileLogger {
         // Clear old log on init
         logFile?.writeText("=== SendSpinDroid Debug Log ===\n")
         logFile?.appendText("Initialized at ${Date()}\n")
-        logFile?.appendText("Device: ${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL}\n")
-        logFile?.appendText("Android: ${android.os.Build.VERSION.RELEASE} (API ${android.os.Build.VERSION.SDK_INT})\n")
+        logFile?.appendText("Device: ${Build.MANUFACTURER} ${Build.MODEL}\n")
+        logFile?.appendText("Android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})\n")
         logFile?.appendText("${"=".repeat(50)}\n\n")
     }
 

--- a/android/app/src/main/java/com/sendspindroid/discovery/NsdDiscoveryManager.kt
+++ b/android/app/src/main/java/com/sendspindroid/discovery/NsdDiscoveryManager.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.net.wifi.WifiManager
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 
 /**
@@ -120,7 +122,7 @@ class NsdDiscoveryManager(
                     Log.d(TAG, "Pending restart detected, restarting discovery")
                     pendingRestart = false
                     // Post to handler to avoid potential recursion issues
-                    android.os.Handler(android.os.Looper.getMainLooper()).post {
+                    Handler(Looper.getMainLooper()).post {
                         startDiscovery()
                     }
                 }

--- a/android/app/src/main/java/com/sendspindroid/musicassistant/transport/MaDataChannelTransport.kt
+++ b/android/app/src/main/java/com/sendspindroid/musicassistant/transport/MaDataChannelTransport.kt
@@ -12,6 +12,7 @@ import org.json.JSONObject
 import org.webrtc.DataChannel
 import java.io.IOException
 import java.nio.ByteBuffer
+import java.util.UUID
 
 /**
  * WebRTC DataChannel transport for the Music Assistant API.
@@ -114,7 +115,7 @@ class MaDataChannelTransport(
         // send auth immediately. Otherwise wait for it.
         if (serverInfoReceived) {
             Log.d(TAG, "ServerInfo already received, sending auth immediately")
-            val msgId = java.util.UUID.randomUUID().toString()
+            val msgId = UUID.randomUUID().toString()
             authMessageId = msgId
             _state.value = MaApiTransport.State.Authenticating
             sendAuthCommand(msgId)
@@ -157,7 +158,7 @@ class MaDataChannelTransport(
         // send login immediately. Otherwise wait for it.
         if (serverInfoReceived) {
             Log.d(TAG, "ServerInfo already received, sending login immediately")
-            val msgId = java.util.UUID.randomUUID().toString()
+            val msgId = UUID.randomUUID().toString()
             authMessageId = msgId
             _state.value = MaApiTransport.State.Authenticating
             sendAuthCommand(msgId)
@@ -361,7 +362,7 @@ class MaDataChannelTransport(
                 // ServerInfo — connect() will detect it and send auth immediately.
                 if (authDeferred != null) {
                     _state.value = MaApiTransport.State.Authenticating
-                    val msgId = java.util.UUID.randomUUID().toString()
+                    val msgId = UUID.randomUUID().toString()
                     authMessageId = msgId
                     sendAuthCommand(msgId)
                 } else {
@@ -404,7 +405,7 @@ class MaDataChannelTransport(
                         // flipping isLoginMode, which was not thread-safe (H-19).
                         pendingAuthToken = token
                         loginResponse = json  // Save for later completion
-                        val newMsgId = java.util.UUID.randomUUID().toString()
+                        val newMsgId = UUID.randomUUID().toString()
                         authMessageId = newMsgId
                         sendAuthCommand(newMsgId, forceTokenMode = true)
                     }

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -31,6 +31,7 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaLibraryService.LibraryParams
 import androidx.media3.session.MediaLibraryService
@@ -76,6 +77,8 @@ import com.sendspindroid.network.ConnectionSelector
 import com.sendspindroid.network.NetworkEvaluator
 import com.sendspindroid.network.NetworkState
 import com.sendspindroid.network.TransportType
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.DefaultMediaNotificationProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -114,7 +117,7 @@ import kotlinx.coroutines.withContext
  * 3. AAudio/Oboe playback with sync correction
  * 4. Remove ExoPlayer dependency
  */
-@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+@OptIn(UnstableApi::class)
 class PlaybackService : MediaLibraryService() {
 
     private var mediaSession: MediaLibrarySession? = null
@@ -508,7 +511,7 @@ class PlaybackService : MediaLibraryService() {
         data class Error(val message: String) : ConnectionState()
     }
 
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @OptIn(UnstableApi::class)
     override fun onCreate() {
         super.onCreate()
         Log.i(TAG, "PlaybackService.onCreate() started")
@@ -681,7 +684,7 @@ class PlaybackService : MediaLibraryService() {
     /**
      * Initializes the native Kotlin SendSpin client.
      */
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @OptIn(UnstableApi::class)
     private fun initializeSendSpinClient() {
         try {
             // Use user-configured player name, falls back to device model
@@ -704,7 +707,7 @@ class PlaybackService : MediaLibraryService() {
      * Updates SendSpinPlayer when playback state changes so MediaSession notifies controllers.
      */
     private inner class SyncAudioPlayerStateCallback : SyncAudioPlayerCallback {
-        @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+        @OptIn(UnstableApi::class)
         override fun onPlaybackStateChanged(state: SyncPlaybackState) {
             mainHandler.post {
                 Log.d(TAG, "SyncAudioPlayer state changed: $state")
@@ -721,7 +724,7 @@ class PlaybackService : MediaLibraryService() {
             }
         }
 
-        @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+        @OptIn(UnstableApi::class)
         override fun onBufferExhausted() {
             Log.e(TAG, "Buffer exhausted during reconnection - stopping playback")
             mainHandler.post {
@@ -754,7 +757,7 @@ class PlaybackService : MediaLibraryService() {
             Log.d(TAG, "Server discovered (ignored in service): $name at $address")
         }
 
-        @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+        @OptIn(UnstableApi::class)
         override fun onConnected(serverName: String) {
             mainHandler.post {
                 Log.d(TAG, "Connected to: $serverName")
@@ -798,7 +801,7 @@ class PlaybackService : MediaLibraryService() {
             }
         }
 
-        @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+        @OptIn(UnstableApi::class)
         override fun onDisconnected(wasUserInitiated: Boolean, wasReconnectExhausted: Boolean) {
             mainHandler.post {
                 Log.d(TAG, "Disconnected from server (userInitiated=$wasUserInitiated, reconnectExhausted=$wasReconnectExhausted)")
@@ -902,7 +905,7 @@ class PlaybackService : MediaLibraryService() {
             }
         }
 
-        @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+        @OptIn(UnstableApi::class)
         override fun onGroupUpdate(groupId: String, groupName: String, playbackState: String) {
             mainHandler.post {
                 Log.d(TAG, "Group update: id=$groupId name=$groupName state=$playbackState")
@@ -978,7 +981,7 @@ class PlaybackService : MediaLibraryService() {
             }
         }
 
-        @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+        @OptIn(UnstableApi::class)
         override fun onMetadataUpdate(
             title: String,
             artist: String,
@@ -1373,7 +1376,7 @@ class PlaybackService : MediaLibraryService() {
         return Bitmap.createScaledBitmap(bitmap, newWidth, newHeight, true)
     }
 
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @OptIn(UnstableApi::class)
     private fun updateMediaSessionArtwork(bitmap: Bitmap) {
         val state = _playbackState.value
 
@@ -1382,7 +1385,7 @@ class PlaybackService : MediaLibraryService() {
             artist = state.artist,
             album = state.album,
             artwork = bitmap,
-            artworkUri = state.artworkUrl?.let { android.net.Uri.parse(it) }
+            artworkUri = state.artworkUrl?.let { Uri.parse(it) }
         )
 
         broadcastMetadataToControllers(
@@ -1395,7 +1398,7 @@ class PlaybackService : MediaLibraryService() {
         )
     }
 
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @OptIn(UnstableApi::class)
     private fun updateMediaMetadata(title: String, artist: String, album: String) {
         val state = _playbackState.value
 
@@ -1404,7 +1407,7 @@ class PlaybackService : MediaLibraryService() {
             artist = state.artist,
             album = state.album,
             artwork = currentArtwork,
-            artworkUri = state.artworkUrl?.let { android.net.Uri.parse(it) }
+            artworkUri = state.artworkUrl?.let { Uri.parse(it) }
         )
 
         broadcastMetadataToControllers(
@@ -2090,7 +2093,7 @@ class PlaybackService : MediaLibraryService() {
         }
     }
 
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @OptIn(UnstableApi::class)
     private fun initializeMediaSession() {
         val player = sendSpinPlayer ?: run {
             Log.e(TAG, "Cannot create MediaSession: sendSpinPlayer is null")
@@ -2419,8 +2422,8 @@ class PlaybackService : MediaLibraryService() {
             // Player commands must include SET_MEDIA_ITEM so the legacy compat bridge
             // can translate playFromMediaId -> onAddMediaItems for Android Auto.
             val playerCommands = MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS.buildUpon()
-                .add(androidx.media3.common.Player.COMMAND_SET_MEDIA_ITEM)
-                .add(androidx.media3.common.Player.COMMAND_PREPARE)
+                .add(Player.COMMAND_SET_MEDIA_ITEM)
+                .add(Player.COMMAND_PREPARE)
                 .build()
 
             return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
@@ -3119,7 +3122,7 @@ class PlaybackService : MediaLibraryService() {
      * Fetches the MA queue in the background and populates the player's timeline.
      * This makes the native queue button in Android Auto show all queue items.
      */
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @OptIn(UnstableApi::class)
     private fun populatePlayerQueue() {
         if (!MusicAssistantManager.connectionState.value.isAvailable) return
 
@@ -3367,7 +3370,7 @@ class PlaybackService : MediaLibraryService() {
         return null
     }
 
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @OptIn(UnstableApi::class)
     private fun initializePlayer() {
         sendSpinPlayer = SendSpinPlayer()
         sendSpinPlayer?.onQueueItemSelected = { mediaId ->
@@ -3437,7 +3440,7 @@ class PlaybackService : MediaLibraryService() {
         super.onTaskRemoved(rootIntent)
     }
 
-    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    @OptIn(UnstableApi::class)
     override fun onDestroy() {
         Log.d(TAG, "PlaybackService destroyed")
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid.sendspin
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import com.sendspindroid.UserSettings
 import com.sendspindroid.remote.WebRTCTransport
@@ -24,6 +25,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import com.sendspindroid.sendspin.decoder.AudioDecoderFactory
 import com.sendspindroid.sendspin.protocol.message.MessageBuilder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -204,7 +208,7 @@ class SendSpinClient(
 
     override fun getDeviceName(): String = deviceName
 
-    override fun getManufacturer(): String = android.os.Build.MANUFACTURER ?: "Unknown"
+    override fun getManufacturer(): String = Build.MANUFACTURER ?: "Unknown"
 
     override fun getSupportedFormats(): List<MessageBuilder.FormatEntry> =
         MessageBuilder.buildSupportedFormats(
@@ -845,10 +849,10 @@ class SendSpinClient(
                 // WebSocket message.
                 Log.d(TAG, "Sending proxy auth message (token ${authToken!!.length} chars)")
                 awaitingAuthResponse = true
-                val authMsg = kotlinx.serialization.json.buildJsonObject {
-                    put("type", kotlinx.serialization.json.JsonPrimitive("auth"))
-                    put("token", kotlinx.serialization.json.JsonPrimitive(authToken))
-                    put("client_id", kotlinx.serialization.json.JsonPrimitive(clientId))
+                val authMsg = buildJsonObject {
+                    put("type", JsonPrimitive("auth"))
+                    put("token", JsonPrimitive(authToken))
+                    put("client_id", JsonPrimitive(clientId))
                 }
                 val sent = transport?.send(authMsg.toString())
                 Log.d(TAG, "Auth message send result: $sent")
@@ -867,7 +871,7 @@ class SendSpinClient(
             // Check for auth failure (server may send error if token is invalid)
             if (connectionMode == ConnectionMode.PROXY && !handshakeComplete) {
                 try {
-                    val json = kotlinx.serialization.json.Json.parseToJsonElement(text).jsonObject
+                    val json = Json.parseToJsonElement(text).jsonObject
                     val msgType = json["type"]?.jsonPrimitive?.contentOrNull ?: ""
                     if (msgType == "auth_failed" || msgType == "error") {
                         val msg = json["message"]?.jsonPrimitive?.contentOrNull ?: "Authentication failed"

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -2,6 +2,7 @@ package com.sendspindroid.sendspin
 
 import android.media.AudioAttributes
 import android.media.AudioFormat
+import android.os.Build
 import android.media.AudioTimestamp
 import android.media.AudioTrack
 import android.util.Log
@@ -469,16 +470,16 @@ class SyncAudioPlayer(
 
         val encoding = when (bitDepth) {
             16 -> AudioFormat.ENCODING_PCM_16BIT
-            24 -> if (android.os.Build.VERSION.SDK_INT >= 31) {
+            24 -> if (Build.VERSION.SDK_INT >= 31) {
                 AudioFormat.ENCODING_PCM_24BIT_PACKED
             } else {
-                Log.e(TAG, "24-bit PCM requires API 31+, device is API ${android.os.Build.VERSION.SDK_INT}")
+                Log.e(TAG, "24-bit PCM requires API 31+, device is API ${Build.VERSION.SDK_INT}")
                 return
             }
-            32 -> if (android.os.Build.VERSION.SDK_INT >= 31) {
+            32 -> if (Build.VERSION.SDK_INT >= 31) {
                 AudioFormat.ENCODING_PCM_32BIT
             } else {
-                Log.e(TAG, "32-bit PCM requires API 31+, device is API ${android.os.Build.VERSION.SDK_INT}")
+                Log.e(TAG, "32-bit PCM requires API 31+, device is API ${Build.VERSION.SDK_INT}")
                 return
             }
             else -> {

--- a/android/app/src/main/java/com/sendspindroid/sendspin/decoder/AudioDecoderFactory.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/decoder/AudioDecoderFactory.kt
@@ -2,6 +2,7 @@ package com.sendspindroid.sendspin.decoder
 
 import android.media.AudioFormat
 import android.media.AudioTrack
+import android.os.Build
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.util.Log
@@ -85,7 +86,7 @@ object AudioDecoderFactory {
         val depths = mutableListOf(16)
 
         // 32-bit integer PCM (ENCODING_PCM_32BIT) - API 31+
-        if (android.os.Build.VERSION.SDK_INT >= 31) {
+        if (Build.VERSION.SDK_INT >= 31) {
             try {
                 val minBuf = AudioTrack.getMinBufferSize(
                     SendSpinProtocol.AudioFormat.SAMPLE_RATE, AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_32BIT
@@ -97,7 +98,7 @@ object AudioDecoderFactory {
         }
 
         // 24-bit packed (ENCODING_PCM_24BIT_PACKED) - API 31+
-        if (android.os.Build.VERSION.SDK_INT >= 31) {
+        if (Build.VERSION.SDK_INT >= 31) {
             try {
                 val minBuf = AudioTrack.getMinBufferSize(
                     SendSpinProtocol.AudioFormat.SAMPLE_RATE, AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_24BIT_PACKED

--- a/android/app/src/main/java/com/sendspindroid/ui/detail/PodcastDetailScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/detail/PodcastDetailScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -193,7 +194,7 @@ private fun PodcastDetailContent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(32.dp),
-                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                    textAlign = TextAlign.Center
                 )
             }
         }

--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -175,7 +176,7 @@ fun NowPlayingHeadUnit(
         // Up Next queue peek (when MA connected and queue available)
         if (isMaConnected && queueViewModel != null) {
             // Load queue on first composition and refresh when track changes
-            androidx.compose.runtime.LaunchedEffect(metadata.title) {
+            LaunchedEffect(metadata.title) {
                 queueViewModel.loadQueue(showLoading = false)
             }
             Spacer(modifier = Modifier.height(12.dp))

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseListScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseListScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
@@ -220,7 +221,7 @@ private fun getSortLabel(sort: LibraryViewModel.SortOption): String {
 @Composable
 private fun ItemsList(
     items: List<MaLibraryItem>,
-    listState: androidx.compose.foundation.lazy.LazyListState,
+    listState: LazyListState,
     isLoadingMore: Boolean,
     onItemClick: (MaLibraryItem) -> Unit,
     onAddToPlaylist: (MaLibraryItem) -> Unit,

--- a/android/app/src/main/java/com/sendspindroid/ui/remote/ProxyConnectDialog.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/remote/ProxyConnectDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
 import com.sendspindroid.R
 import com.sendspindroid.UserSettings
@@ -54,7 +55,7 @@ class ProxyConnectDialog : DialogFragment() {
         private const val TAG = "ProxyConnectDialog"
 
         fun show(
-            fragmentManager: androidx.fragment.app.FragmentManager,
+            fragmentManager: FragmentManager,
             onConnect: (url: String, authToken: String, nickname: String?) -> Unit
         ): ProxyConnectDialog {
             val dialog = ProxyConnectDialog()

--- a/android/app/src/main/java/com/sendspindroid/ui/remote/QrScannerDialog.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/remote/QrScannerDialog.kt
@@ -14,6 +14,7 @@ import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
 import com.sendspindroid.R
 import com.sendspindroid.databinding.DialogQrScannerBinding
 import com.sendspindroid.remote.RemoteConnection
@@ -39,7 +40,7 @@ class QrScannerDialog : DialogFragment() {
         private const val TAG = "QrScannerDialog"
 
         fun show(
-            fragmentManager: androidx.fragment.app.FragmentManager,
+            fragmentManager: FragmentManager,
             onRemoteIdScanned: (String) -> Unit
         ): QrScannerDialog {
             val dialog = QrScannerDialog()

--- a/android/app/src/main/java/com/sendspindroid/ui/remote/RemoteConnectDialog.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/remote/RemoteConnectDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
 import com.sendspindroid.R
 import com.sendspindroid.UserSettings
 import com.sendspindroid.remote.RemoteConnection
@@ -39,7 +40,7 @@ class RemoteConnectDialog : DialogFragment() {
         private const val TAG = "RemoteConnectDialog"
 
         fun show(
-            fragmentManager: androidx.fragment.app.FragmentManager,
+            fragmentManager: FragmentManager,
             onConnect: (remoteId: String, nickname: String?) -> Unit
         ): RemoteConnectDialog {
             val dialog = RemoteConnectDialog()

--- a/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
@@ -12,6 +12,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.fragment.app.FragmentActivity
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.lifecycleScope
@@ -42,6 +43,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
 
 /**
  * Full-screen wizard Activity for adding or editing unified servers.
@@ -119,7 +127,7 @@ class AddServerWizardActivity : FragmentActivity() {
                 val state by viewModel.wizardState.collectAsStateWithLifecycle()
 
                 // Auto-start discovery when entering a FindServer step
-                androidx.compose.runtime.LaunchedEffect(state.currentStep) {
+                LaunchedEffect(state.currentStep) {
                     if ((state.currentStep == WizardStep.SS_FindServer ||
                          state.currentStep == WizardStep.MA_FindServer) && !state.isSearching) {
                         startDiscovery()
@@ -351,22 +359,22 @@ class AddServerWizardActivity : FragmentActivity() {
 
                 Log.d(TAG, "Testing WebSocket connection to: $wsUrl")
 
-                val client = okhttp3.OkHttpClient.Builder()
-                    .connectTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
-                    .readTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+                val client = OkHttpClient.Builder()
+                    .connectTimeout(5, TimeUnit.SECONDS)
+                    .readTimeout(5, TimeUnit.SECONDS)
                     .build()
 
-                val request = okhttp3.Request.Builder()
+                val request = Request.Builder()
                     .url(wsUrl)
                     .build()
 
                 var resultCode = 0
                 var connectionSuccess = false
                 var errorMessage: String? = null
-                val latch = java.util.concurrent.CountDownLatch(1)
+                val latch = CountDownLatch(1)
 
-                val listener = object : okhttp3.WebSocketListener() {
-                    override fun onOpen(webSocket: okhttp3.WebSocket, response: okhttp3.Response) {
+                val listener = object : WebSocketListener() {
+                    override fun onOpen(webSocket: WebSocket, response: Response) {
                         Log.d(TAG, "WebSocket connection opened, code: ${response.code}")
                         resultCode = response.code
                         connectionSuccess = true
@@ -374,7 +382,7 @@ class AddServerWizardActivity : FragmentActivity() {
                         latch.countDown()
                     }
 
-                    override fun onFailure(webSocket: okhttp3.WebSocket, t: Throwable, response: okhttp3.Response?) {
+                    override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                         Log.d(TAG, "WebSocket connection failed: ${t.message}, response code: ${response?.code}")
                         resultCode = response?.code ?: 0
                         errorMessage = t.message
@@ -384,7 +392,7 @@ class AddServerWizardActivity : FragmentActivity() {
                 }
 
                 client.newWebSocket(request, listener)
-                latch.await(6, java.util.concurrent.TimeUnit.SECONDS)
+                latch.await(6, TimeUnit.SECONDS)
                 client.dispatcher.executorService.shutdown()
 
                 if (connectionSuccess) {
@@ -518,13 +526,13 @@ class AddServerWizardActivity : FragmentActivity() {
 
                 Log.d(TAG, "Testing WebSocket proxy connection to: $wsUrl")
 
-                val clientBuilder = okhttp3.OkHttpClient.Builder()
-                    .connectTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
-                    .readTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
+                val clientBuilder = OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(10, TimeUnit.SECONDS)
 
                 val client = clientBuilder.build()
 
-                val requestBuilder = okhttp3.Request.Builder()
+                val requestBuilder = Request.Builder()
                     .url(wsUrl)
 
                 if (viewModel.proxyToken.isNotBlank()) {
@@ -533,17 +541,17 @@ class AddServerWizardActivity : FragmentActivity() {
 
                 var connectionSuccess = false
                 var errorMessage: String? = null
-                val latch = java.util.concurrent.CountDownLatch(1)
+                val latch = CountDownLatch(1)
 
-                val listener = object : okhttp3.WebSocketListener() {
-                    override fun onOpen(webSocket: okhttp3.WebSocket, response: okhttp3.Response) {
+                val listener = object : WebSocketListener() {
+                    override fun onOpen(webSocket: WebSocket, response: Response) {
                         Log.d(TAG, "Proxy WebSocket connection opened, code: ${response.code}")
                         connectionSuccess = true
                         webSocket.close(1000, "Test complete")
                         latch.countDown()
                     }
 
-                    override fun onFailure(webSocket: okhttp3.WebSocket, t: Throwable, response: okhttp3.Response?) {
+                    override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                         Log.d(TAG, "Proxy WebSocket connection failed: ${t.message}, response code: ${response?.code}")
                         errorMessage = t.message
                         connectionSuccess = response != null
@@ -552,7 +560,7 @@ class AddServerWizardActivity : FragmentActivity() {
                 }
 
                 client.newWebSocket(requestBuilder.build(), listener)
-                latch.await(11, java.util.concurrent.TimeUnit.SECONDS)
+                latch.await(11, TimeUnit.SECONDS)
                 client.dispatcher.executorService.shutdown()
 
                 if (connectionSuccess) {

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -2,6 +2,7 @@ package com.sendspindroid.ui.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -26,6 +27,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -475,7 +477,7 @@ private fun SyncOffsetPreference(
             onClick = onDecrease,
             modifier = Modifier.size(44.dp),
             shape = RoundedCornerShape(8.dp),
-            contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp)
+            contentPadding = PaddingValues(0.dp)
         ) {
             Text("-", style = MaterialTheme.typography.titleMedium)
         }
@@ -486,7 +488,7 @@ private fun SyncOffsetPreference(
         FilledTonalButton(
             onClick = onValueClick,
             shape = RoundedCornerShape(8.dp),
-            contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 12.dp, vertical = 8.dp)
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp)
         ) {
             Text(
                 text = if (offset >= 0) "+${offset}ms" else "${offset}ms",
@@ -501,7 +503,7 @@ private fun SyncOffsetPreference(
             onClick = onIncrease,
             modifier = Modifier.size(44.dp),
             shape = RoundedCornerShape(8.dp),
-            contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp)
+            contentPadding = PaddingValues(0.dp)
         ) {
             Text("+", style = MaterialTheme.typography.titleMedium)
         }
@@ -672,7 +674,7 @@ private fun CodecSelectionDialog(
                             .padding(vertical = 12.dp, horizontal = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        androidx.compose.material3.RadioButton(
+                        RadioButton(
                             selected = currentCodec == value,
                             onClick = { onSelect(value) }
                         )


### PR DESCRIPTION
## Summary
- Replaced ~60 inline fully-qualified class references with proper import statements across 16 Kotlin files
- Covers `android.os.Build`, `android.graphics.Color/RenderEffect/Shader`, `androidx.compose.runtime.*`, `androidx.annotation.OptIn`, `androidx.media3.common.util.UnstableApi`, `okhttp3.*`, `java.util.concurrent.*`, `kotlinx.serialization.json.*`, `androidx.fragment.app.FragmentManager`, and more
- One intentional exception: `ArtworkSource.Uri` in `MainUiState.kt` keeps `android.net.Uri` fully qualified to avoid a name conflict with the enclosing data class

## Test plan
- [x] Verified the project compiles with `./gradlew assembleDebug`
- [x] Smoke test the app on a device to confirm no runtime regressions