### PR TITLE
fix: remove redundant null check in auth message handling

### DIFF
--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/transport/MaWebSocketTransport.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/transport/MaWebSocketTransport.kt
@@ -376,7 +376,7 @@ class MaWebSocketTransport(
 
                                 // Phase 2: Auth response
                                 val msgId = json.optString("message_id")
-                                if (msgId == authMessageId && authMessageId != null) {
+                                if (msgId == authMessageId) {
                                     authMessageId = null
 
                                     if (json.has("error_code")) {


### PR DESCRIPTION
## Summary
- Remove redundant `&& authMessageId != null` condition in `MaWebSocketTransport.kt` line 379
- `msgId` is always a non-null `String` (from `optString`), so the equality check `msgId == authMessageId` already implies `authMessageId` is non-null when true
- Eliminates the "Condition is always true" compiler warning

## Test plan
- [ ] Verify the project compiles without the warning at MaWebSocketTransport.kt:379
- [ ] Confirm authentication flow still works correctly (auth message ID matching is unchanged)