### PR TITLE
fix: remove redundant elvis operator in PlaylistDetailScreen

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/detail/PlaylistDetailScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/detail/PlaylistDetailScreen.kt
@@ -177,7 +177,7 @@ private fun PlaylistDetailContent(
                     showArtist = true,
                     onClick = { onTrackClick(track) },
                     onRemoveFromPlaylist = {
-                        onRemoveTrack(index, track.name ?: "Track")
+                        onRemoveTrack(index, track.name)
                     }
                 )
             }


### PR DESCRIPTION
## Summary
- Removed unnecessary elvis operator (`?:`) on `track.name` in `PlaylistDetailScreen.kt` line 180
- `MaTrack.name` is a non-nullable `String`, so the `?: "Track"` fallback was dead code producing a compiler warning

## Test plan
- [ ] Verify the project compiles without the elvis operator warning
- [ ] Verify playlist detail screen still displays track names correctly