### PR TITLE
fix: resolve slow metadata updates and volume showing zero on song ch…

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -267,6 +267,10 @@ class PlaybackService : MediaLibraryService() {
     private val _playbackState = MutableStateFlow(PlaybackState())
     val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
 
+    // Sync offset state (included in broadcastSessionExtras to avoid bare-bundle overwrites)
+    private var lastSyncOffsetMs: Double = 0.0
+    private var lastSyncOffsetSource: String = ""
+
     // Artwork state
     private var lastArtworkUrl: String? = null
     private var currentArtwork: Bitmap? = null
@@ -1234,13 +1238,10 @@ class PlaybackService : MediaLibraryService() {
 
         override fun onSyncOffsetApplied(offsetMs: Double, source: String) {
             android.util.Log.i(TAG, "Sync offset applied: ${offsetMs}ms from $source")
-            // Optionally broadcast to UI for display
             mainHandler.post {
-                val extras = Bundle().apply {
-                    putDouble("sync_offset_ms", offsetMs)
-                    putString("sync_offset_source", source)
-                }
-                mediaSession?.setSessionExtras(extras)
+                lastSyncOffsetMs = offsetMs
+                lastSyncOffsetSource = source
+                broadcastSessionExtras()
             }
         }
 
@@ -1487,6 +1488,13 @@ class PlaybackService : MediaLibraryService() {
 
             // Volume
             putInt(EXTRA_VOLUME, playbackState.volume)
+
+            // Sync offset (included here to avoid bare-bundle overwrites that
+            // would clobber volume, metadata, and connection state)
+            if (lastSyncOffsetMs != 0.0) {
+                putDouble("sync_offset_ms", lastSyncOffsetMs)
+                putString("sync_offset_source", lastSyncOffsetSource)
+            }
         }
 
         mediaSession?.setSessionExtras(extras)

--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -106,6 +107,24 @@ fun NowPlayingScreen(
     val positionMs by viewModel.positionMs.collectAsStateWithLifecycle()
     val durationMs by viewModel.durationMs.collectAsStateWithLifecycle()
     val positionUpdatedAt by viewModel.positionUpdatedAt.collectAsStateWithLifecycle()
+    // Optimistic metadata update: when a queue item is tapped, update the UI
+    // immediately with the item's metadata instead of waiting for the server round-trip.
+    LaunchedEffect(queueViewModel) {
+        queueViewModel?.playedItem?.collect { item ->
+            viewModel.updateMetadata(item.name, item.artist ?: "", item.album ?: "")
+            item.imageUri?.takeIf { it.isNotEmpty() }?.let { url ->
+                viewModel.updateArtwork(ArtworkSource.Url(url))
+            }
+            item.duration?.let { durationSec ->
+                viewModel.updateTrackProgress(
+                    positionMs = 0,
+                    durationMs = durationSec * 1000,
+                    positionUpdatedAt = 0
+                )
+            }
+        }
+    }
+
     // Don't show buffering spinner when paused -- SendSpin's audio stream stops on
     // pause, so Media3 reports STATE_BUFFERING even though the user intentionally paused.
     val isBuffering = playbackState == PlaybackState.BUFFERING && !metadata.isEmpty && isPlaying

--- a/android/app/src/main/java/com/sendspindroid/ui/queue/QueueViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/queue/QueueViewModel.kt
@@ -5,8 +5,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sendspindroid.musicassistant.MaQueueItem
 import com.sendspindroid.musicassistant.MusicAssistantManager
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
@@ -53,6 +56,11 @@ class QueueViewModel : ViewModel() {
     /** Tracks whether an action is in progress (for disabling UI) */
     private val _isActionInProgress = MutableStateFlow(false)
     val isActionInProgress: StateFlow<Boolean> = _isActionInProgress.asStateFlow()
+
+    /** Emits the metadata of a queue item when the user taps to play it,
+     *  enabling optimistic UI updates before the server confirms. */
+    private val _playedItem = MutableSharedFlow<MaQueueItem>(extraBufferCapacity = 1)
+    val playedItem: SharedFlow<MaQueueItem> = _playedItem.asSharedFlow()
 
     companion object {
         private const val TAG = "QueueViewModel"
@@ -121,6 +129,14 @@ class QueueViewModel : ViewModel() {
      * Jump to and play a specific item in the queue.
      */
     fun playItem(queueItemId: String) {
+        // Emit the tapped item for optimistic UI update before the server round-trip
+        val state = _uiState.value as? QueueUiState.Success
+        val item = state?.upNextItems?.find { it.queueItemId == queueItemId }
+            ?: state?.currentItem?.takeIf { it.queueItemId == queueItemId }
+        if (item != null) {
+            _playedItem.tryEmit(item)
+        }
+
         viewModelScope.launch {
             _isActionInProgress.value = true
             Log.d(TAG, "Playing queue item: $queueItemId")


### PR DESCRIPTION
- Fix volume display resetting to zero: onSyncOffsetApplied was calling setSessionExtras with a bare 2-key bundle, overwriting the full session state (volume, metadata, connection). Now stores sync offset values and includes them in the unified broadcastSessionExtras call.

- Fix slow metadata updates (1.5-2.5s) when tapping queue items: add optimistic UI update that immediately displays the tapped item's metadata (title, artist, album, artwork, duration) before the server round-trip through Music Assistant completes.