### PR TITLE
fix: restrict Remote ID validation to ASCII characters

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/remote/RemoteConnection.kt
+++ b/android/app/src/main/java/com/sendspindroid/remote/RemoteConnection.kt
@@ -40,7 +40,7 @@ class RemoteConnection(private val context: Context) {
          */
         fun isValidRemoteId(remoteId: String): Boolean {
             // Must be 26 chars, all alphanumeric, no lowercase letters
-            return remoteId.length == 26 && remoteId.all { it.isDigit() || (it.isLetter() && it.isUpperCase()) }
+            return remoteId.length == 26 && remoteId.all { it in '0'..'9' || it in 'A'..'Z' }
         }
 
         /**


### PR DESCRIPTION
## Summary

- `RemoteConnection.isValidRemoteId()` used `Char.isLetter()` and `Char.isUpperCase()` which operate on Unicode, accepting accented uppercase letters like `É` (U+00C9)
- Remote IDs from Music Assistant are strictly ASCII alphanumeric (A-Z, 0-9), so the validation now uses explicit range checks
- Bug was caught by the unicode test in `RemoteConnectionValidationTest` (PR #76)

## Test plan

- [ ] `RemoteConnectionValidationTest` passes (all 12 tests including unicode rejection)
- [ ] `RemoteConnectionParseTest` passes (existing tests unaffected)