### PR TITLE
Constrain server list width on tablets and TV

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/adaptive/AdaptiveDefaults.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/adaptive/AdaptiveDefaults.kt
@@ -207,4 +207,19 @@ object AdaptiveDefaults {
         FormFactor.PHONE -> 0.dp  // Not shown
         FormFactor.HEADUNIT -> 0.dp  // Not shown
     }
+
+    // -- Server List --
+
+    /**
+     * Maximum width for the server list on wider form factors.
+     * Returns null for PHONE where no constraint is needed (list fills available width).
+     * On tablets and TV, constrains the list to avoid overly wide cards.
+     */
+    fun serverListMaxWidth(formFactor: FormFactor): Dp? = when (formFactor) {
+        FormFactor.PHONE -> null
+        FormFactor.HEADUNIT -> null
+        FormFactor.TABLET_7 -> 600.dp
+        FormFactor.TABLET_10 -> 600.dp
+        FormFactor.TV -> 600.dp
+    }
 }

--- a/android/app/src/main/java/com/sendspindroid/ui/main/ServerListScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/ServerListScreen.kt
@@ -3,7 +3,9 @@ package com.sendspindroid.ui.main
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.FloatingActionButton
@@ -19,6 +21,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sendspindroid.R
+import com.sendspindroid.ui.adaptive.AdaptiveDefaults
+import com.sendspindroid.ui.adaptive.LocalFormFactor
 import com.sendspindroid.model.LocalConnection
 import com.sendspindroid.model.RemoteConnection
 import com.sendspindroid.model.UnifiedServer
@@ -121,20 +125,34 @@ private fun ServerListScreenContent(
     modifier: Modifier = Modifier
 ) {
     val hasSavedServers = savedServers.isNotEmpty()
+    val formFactor = LocalFormFactor.current
+    val maxWidth = AdaptiveDefaults.serverListMaxWidth(formFactor)
 
-    Box(modifier = modifier.fillMaxSize()) {
+    // On wider form factors, constrain list width and center it
+    val contentModifier = if (maxWidth != null) {
+        Modifier.widthIn(max = maxWidth).fillMaxWidth()
+    } else {
+        Modifier.fillMaxSize()
+    }
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = if (maxWidth != null) Alignment.TopCenter else Alignment.TopStart
+    ) {
         if (!hasSavedServers) {
             // Welcome / empty state — hero card with discovered servers inline
-            ServerListEmptyState(
-                isScanning = isScanning,
-                discoveredServers = discoveredServers,
-                onAddServerClick = onAddServerClick,
-                onQuickConnectClick = onQuickConnectClick
-            )
+            Box(modifier = contentModifier) {
+                ServerListEmptyState(
+                    isScanning = isScanning,
+                    discoveredServers = discoveredServers,
+                    onAddServerClick = onAddServerClick,
+                    onQuickConnectClick = onQuickConnectClick
+                )
+            }
         } else {
             // Normal server list with saved + discovered sections
             LazyColumn(
-                modifier = Modifier.fillMaxSize(),
+                modifier = contentModifier,
                 contentPadding = PaddingValues(bottom = 88.dp) // Space for FAB
             ) {
                 // Saved Servers Section


### PR DESCRIPTION
## Summary

- On wider form factors (TABLET_7, TABLET_10, TV), the server list is now constrained to a max-width of 600dp and centered horizontally, preventing cards from stretching across the full screen width
- Adds `AdaptiveDefaults.serverListMaxWidth()` following the existing pattern for form-factor-aware layout constants
- Phone and head unit layouts are unchanged -- the list continues to fill the available width

## Details

The `ServerListScreenContent` composable now reads `LocalFormFactor` and applies `widthIn(max = 600.dp)` with `Alignment.TopCenter` on the outer Box for non-phone form factors. Both the `LazyColumn` (saved servers present) and the `ServerListEmptyState` wrapper (no saved servers) receive the same width constraint. The FAB remains anchored to the bottom-end of the full-size outer Box.

## Test plan

- [ ] Verify phone portrait/landscape layout is unchanged
- [ ] Verify tablet 7" shows server list centered with max 600dp width
- [ ] Verify tablet 10" shows server list centered with max 600dp width
- [ ] Verify empty state (no saved servers) is also width-constrained on tablets
- [ ] Verify FAB position is correct on all form factors
- [ ] Run Android Studio previews with `@AllDevicePreviews`