### PR TITLE
feat: connection status indicator in top bar

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
@@ -14,6 +14,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.PaddingValues
@@ -49,12 +50,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.sendspindroid.R
 import com.sendspindroid.UserSettings
@@ -81,6 +84,7 @@ import com.sendspindroid.ui.main.DetailDestination
 import com.sendspindroid.ui.main.MainActivityViewModel
 import com.sendspindroid.ui.main.NavTab
 import com.sendspindroid.ui.main.NowPlayingScreen
+import com.sendspindroid.ui.main.components.ConnectionStatusDot
 import com.sendspindroid.ui.main.components.MiniPlayer
 import com.sendspindroid.ui.main.components.MiniPlayerSide
 import com.sendspindroid.ui.navigation.home.HomeScreen
@@ -313,6 +317,12 @@ private fun ConnectedShell(
         else -> null
     }
 
+    // Subtitle text: show "Reconnecting..." instead of plain server name when reconnecting
+    val subtitleText = when (connectionState) {
+        is AppConnectionState.Reconnecting -> stringResource(R.string.reconnecting_toolbar_subtitle)
+        else -> serverName
+    }
+
     // Title for the top bar -- detail title takes priority
     val topBarTitle = if (currentDetail != null) {
         currentDetail!!.title
@@ -347,12 +357,20 @@ private fun ConnectedShell(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
-                    if (currentDetail == null && serverName != null) {
-                        Text(
-                            text = serverName,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                    if (currentDetail == null && subtitleText != null) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            ConnectionStatusDot(
+                                connectionState = connectionState
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = subtitleText,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
             },

--- a/android/app/src/main/java/com/sendspindroid/ui/main/components/ConnectionStatusDot.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/components/ConnectionStatusDot.kt
@@ -1,0 +1,110 @@
+package com.sendspindroid.ui.main.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sendspindroid.model.AppConnectionState
+import com.sendspindroid.ui.theme.SendSpinTheme
+
+/**
+ * Dot color indicating connection health.
+ */
+private val ConnectedGreen = Color(0xFF4CAF50)
+private val ReconnectingAmber = Color(0xFFFFA726)
+private val ConnectingAmber = Color(0xFFFFA726)
+private val ErrorRed = Color(0xFFEF5350)
+
+/**
+ * Small status dot that reflects the current connection state.
+ *
+ * - Connected: solid green dot
+ * - Connecting: pulsing amber dot
+ * - Reconnecting: pulsing amber dot
+ * - Error: solid red dot
+ */
+@Composable
+fun ConnectionStatusDot(
+    connectionState: AppConnectionState,
+    modifier: Modifier = Modifier
+) {
+    val (color, shouldPulse, description) = when (connectionState) {
+        is AppConnectionState.Connected -> Triple(ConnectedGreen, false, "Connected")
+        is AppConnectionState.Connecting -> Triple(ConnectingAmber, true, "Connecting")
+        is AppConnectionState.Reconnecting -> Triple(ReconnectingAmber, true, "Reconnecting")
+        is AppConnectionState.Error -> Triple(ErrorRed, false, "Connection error")
+        is AppConnectionState.ServerList -> Triple(Color.Transparent, false, "")
+    }
+
+    if (connectionState is AppConnectionState.ServerList) return
+
+    val alpha = if (shouldPulse) {
+        val transition = rememberInfiniteTransition(label = "pulse")
+        val animatedAlpha by transition.animateFloat(
+            initialValue = 1f,
+            targetValue = 0.3f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 800),
+                repeatMode = RepeatMode.Reverse
+            ),
+            label = "dotAlpha"
+        )
+        animatedAlpha
+    } else {
+        1f
+    }
+
+    Canvas(
+        modifier = modifier
+            .size(8.dp)
+            .semantics { contentDescription = description }
+    ) {
+        drawCircle(
+            color = color,
+            alpha = alpha
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ConnectionStatusDotConnectedPreview() {
+    SendSpinTheme {
+        ConnectionStatusDot(
+            connectionState = AppConnectionState.Connected("Living Room", "192.168.1.100")
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ConnectionStatusDotReconnectingPreview() {
+    SendSpinTheme {
+        ConnectionStatusDot(
+            connectionState = AppConnectionState.Reconnecting(
+                "Living Room", "192.168.1.100", attempt = 2, nextRetrySeconds = 5
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ConnectionStatusDotErrorPreview() {
+    SendSpinTheme {
+        ConnectionStatusDot(
+            connectionState = AppConnectionState.Error("Connection refused")
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Added a `ConnectionStatusDot` composable that shows a color-coded dot reflecting connection health: green (connected), pulsing amber (connecting/reconnecting), red (error)
- Integrated the dot into the top bar subtitle in `AppShell.kt`, next to the server name, so it is visible on all screens (Home, Search, Library, Playlists, Now Playing)
- During reconnection, the subtitle text changes from the server name to "Reconnecting..." for clearer state visibility

## Context
The `ReconnectingBanner` was only visible on the Now Playing screen. Users browsing other tabs had no indication of connection issues. The top bar subtitle previously showed the server name identically regardless of connection state.

## Test plan
- [ ] Connect to a server and verify the green dot appears next to the server name in the top bar
- [ ] Disconnect the network and verify the dot turns amber and pulses, subtitle shows "Reconnecting..."
- [ ] Navigate to browse tabs (Home, Search, Library) during reconnection and verify the indicator remains visible
- [ ] Trigger an error state and verify the dot turns red
- [ ] Verify the dot does not appear on the server list screen (ServerList state)