### PR TITLE
fix: enforce 48dp minimum touch targets

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/detail/components/AlbumGridItem.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/detail/components/AlbumGridItem.kt
@@ -104,7 +104,7 @@ fun AlbumGridItem(
                 ) {
                     IconButton(
                         onClick = { showMenu = true },
-                        modifier = Modifier.size(32.dp)
+                        modifier = Modifier.size(48.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Filled.MoreVert,

--- a/android/app/src/main/java/com/sendspindroid/ui/detail/components/TrackListItem.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/detail/components/TrackListItem.kt
@@ -139,7 +139,7 @@ fun TrackListItem(
             Box {
                 IconButton(
                     onClick = { showMenu = true },
-                    modifier = Modifier.size(40.dp)
+                    modifier = Modifier.size(48.dp)
                 ) {
                     Icon(
                         imageVector = Icons.Filled.MoreVert,

--- a/android/app/src/main/java/com/sendspindroid/ui/dialogs/ProxyConnectDialogContent.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/dialogs/ProxyConnectDialogContent.kt
@@ -349,7 +349,7 @@ private fun SavedProxyServerItem(
             // Delete button
             IconButton(
                 onClick = onDelete,
-                modifier = Modifier.size(32.dp),
+                modifier = Modifier.size(48.dp),
                 enabled = enabled
             ) {
                 Icon(

--- a/android/app/src/main/java/com/sendspindroid/ui/dialogs/RemoteConnectDialogContent.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/dialogs/RemoteConnectDialogContent.kt
@@ -211,7 +211,7 @@ private fun SavedRemoteServerItem(
             // Delete button
             IconButton(
                 onClick = onDelete,
-                modifier = Modifier.size(32.dp)
+                modifier = Modifier.size(48.dp)
             ) {
                 Icon(
                     painter = painterResource(R.drawable.ic_close),

--- a/android/app/src/main/java/com/sendspindroid/ui/main/components/MiniPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/components/MiniPlayer.kt
@@ -227,7 +227,7 @@ fun MiniPlayer(
                 ) {
                     IconButton(
                         onClick = onPreviousClick,
-                        modifier = Modifier.size(40.dp)
+                        modifier = Modifier.size(48.dp)
                     ) {
                         Icon(
                             painter = painterResource(R.drawable.ic_skip_previous),
@@ -239,7 +239,7 @@ fun MiniPlayer(
 
                     FilledIconButton(
                         onClick = onPlayPauseClick,
-                        modifier = Modifier.size(40.dp),
+                        modifier = Modifier.size(48.dp),
                         colors = IconButtonDefaults.filledIconButtonColors(
                             containerColor = MaterialTheme.colorScheme.primary,
                             contentColor = MaterialTheme.colorScheme.onPrimary
@@ -259,7 +259,7 @@ fun MiniPlayer(
 
                     IconButton(
                         onClick = onNextClick,
-                        modifier = Modifier.size(40.dp)
+                        modifier = Modifier.size(48.dp)
                     ) {
                         Icon(
                             painter = painterResource(R.drawable.ic_skip_next),
@@ -440,7 +440,7 @@ fun MiniPlayerSide(
                 ) {
                     FilledIconButton(
                         onClick = onPlayPauseClick,
-                        modifier = Modifier.size(44.dp),
+                        modifier = Modifier.size(48.dp),
                         colors = IconButtonDefaults.filledIconButtonColors(
                             containerColor = MaterialTheme.colorScheme.primary,
                             contentColor = MaterialTheme.colorScheme.onPrimary

--- a/android/app/src/main/java/com/sendspindroid/ui/main/components/PlaybackControls.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/components/PlaybackControls.kt
@@ -71,7 +71,7 @@ fun PlaybackControls(
                     onClick = onSwitchGroupClick,
                     enabled = isSwitchGroupEnabled,
                     modifier = Modifier
-                        .size(44.dp)
+                        .size(48.dp)
                         .tvFocusable()
                 ) {
                     Icon(
@@ -147,7 +147,7 @@ fun PlaybackControls(
                 FilledTonalIconButton(
                     onClick = onFavoriteClick,
                     modifier = Modifier
-                        .size(44.dp)
+                        .size(48.dp)
                         .tvFocusable()
                 ) {
                     Icon(
@@ -171,7 +171,7 @@ fun PlaybackControls(
                 FilledTonalIconButton(
                     onClick = onPlayerClick,
                     modifier = Modifier
-                        .size(44.dp)
+                        .size(48.dp)
                         .tvFocusable()
                 ) {
                     Icon(

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseContentScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseContentScreen.kt
@@ -230,7 +230,7 @@ private fun BrowseFolderItem(
         Box {
             IconButton(
                 onClick = { showMenu = true },
-                modifier = Modifier.size(40.dp)
+                modifier = Modifier.size(48.dp)
             ) {
                 Icon(
                     imageVector = Icons.Filled.MoreVert,

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/search/components/SearchResultItem.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/search/components/SearchResultItem.kt
@@ -132,7 +132,7 @@ fun SearchResultItem(
             Box {
                 IconButton(
                     onClick = { showMenu = true },
-                    modifier = Modifier.size(40.dp)
+                    modifier = Modifier.size(48.dp)
                 ) {
                     Icon(
                         imageVector = Icons.Filled.MoreVert,

--- a/android/app/src/main/java/com/sendspindroid/ui/player/MiniPlayerView.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/player/MiniPlayerView.kt
@@ -157,7 +157,7 @@ fun MiniPlayerView(
                     // Stop button
                     IconButton(
                         onClick = onStopClick,
-                        modifier = Modifier.size(40.dp)
+                        modifier = Modifier.size(48.dp)
                     ) {
                         Icon(
                             painter = painterResource(R.drawable.ic_stop),
@@ -170,7 +170,7 @@ fun MiniPlayerView(
                     // Play/Pause button
                     FilledIconButton(
                         onClick = onPlayPauseClick,
-                        modifier = Modifier.size(44.dp)
+                        modifier = Modifier.size(48.dp)
                     ) {
                         Icon(
                             painter = painterResource(

--- a/android/app/src/main/java/com/sendspindroid/ui/queue/QueueSheetContent.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/queue/QueueSheetContent.kt
@@ -595,7 +595,7 @@ private fun QueueListItem(
         Box {
             IconButton(
                 onClick = { showMenu = true },
-                modifier = Modifier.size(36.dp)
+                modifier = Modifier.size(48.dp)
             ) {
                 Icon(
                     imageVector = Icons.Filled.MoreVert,

--- a/android/app/src/main/java/com/sendspindroid/ui/queue/SaveQueueAsPlaylistDialog.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/queue/SaveQueueAsPlaylistDialog.kt
@@ -342,7 +342,7 @@ private fun PlaylistActionRow(
         // Add button (tonal)
         FilledTonalIconButton(
             onClick = onAppend,
-            modifier = Modifier.size(36.dp)
+            modifier = Modifier.size(48.dp)
         ) {
             Icon(
                 imageVector = Icons.Filled.Add,
@@ -356,7 +356,7 @@ private fun PlaylistActionRow(
         // Replace button (error-tinted)
         IconButton(
             onClick = onReplace,
-            modifier = Modifier.size(36.dp),
+            modifier = Modifier.size(48.dp),
             colors = IconButtonDefaults.iconButtonColors(
                 contentColor = MaterialTheme.colorScheme.error
             )

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -475,7 +475,7 @@ private fun SyncOffsetPreference(
         // -10ms button
         OutlinedButton(
             onClick = onDecrease,
-            modifier = Modifier.size(44.dp),
+            modifier = Modifier.size(48.dp),
             shape = RoundedCornerShape(8.dp),
             contentPadding = PaddingValues(0.dp)
         ) {
@@ -501,7 +501,7 @@ private fun SyncOffsetPreference(
         // +10ms button
         OutlinedButton(
             onClick = onIncrease,
-            modifier = Modifier.size(44.dp),
+            modifier = Modifier.size(48.dp),
             shape = RoundedCornerShape(8.dp),
             contentPadding = PaddingValues(0.dp)
         ) {


### PR DESCRIPTION
## Summary
- Increased all interactive button touch targets to meet the 48dp minimum required by Material 3 and Android accessibility guidelines
- Fixed 20 undersized buttons across 12 composable files: compact PlaybackControls inline buttons (44dp), MiniPlayer prev/play/next (40dp), MiniPlayerSide play (44dp), MiniPlayerView stop/play (40/44dp), queue/track/album/browse overflow menus (32-40dp), settings offset +/- buttons (44dp), save-playlist add/replace buttons (36dp), and proxy/remote delete buttons (32dp)
- Non-interactive elements (decorative icons, thumbnails, indicators) were left unchanged

## Test plan
- [ ] Verify PlaybackControls compact layout buttons are tappable without difficulty
- [ ] Verify MiniPlayer prev/play/next buttons remain functional and properly spaced
- [ ] Verify MiniPlayerSide play button in landscape mode
- [ ] Verify queue item overflow menus open reliably
- [ ] Verify track list and album grid overflow menus
- [ ] Verify settings sync offset +/- buttons
- [ ] Verify save-playlist dialog add/replace buttons
- [ ] Verify proxy and remote connection delete buttons
- [ ] Run accessibility scanner to confirm no touch target warnings remain