### PR TITLE
fix: remove unnecessary opacity from Now Playing labels

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingHeadUnit.kt
@@ -124,7 +124,7 @@ fun NowPlayingHeadUnit(
             Text(
                 text = metadataText,
                 style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.9f),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -139,7 +139,7 @@ fun NowPlayingHeadUnit(
             Text(
                 text = stringResource(R.string.group_label, groupName),
                 style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                color = MaterialTheme.colorScheme.primary,
                 textAlign = TextAlign.Center,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis

--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
@@ -399,7 +399,7 @@ private fun NowPlayingPortrait(
             Text(
                 text = metadataText,
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.9f),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
@@ -415,7 +415,7 @@ private fun NowPlayingPortrait(
             Text(
                 text = stringResource(R.string.group_label, groupName),
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                color = MaterialTheme.colorScheme.primary,
                 textAlign = TextAlign.Center,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
@@ -556,7 +556,7 @@ private fun NowPlayingLandscape(
                 Text(
                     text = metadataText,
                     style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.9f),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -570,7 +570,7 @@ private fun NowPlayingLandscape(
                 Text(
                     text = stringResource(R.string.group_label, groupName),
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                    color = MaterialTheme.colorScheme.primary,
                     textAlign = TextAlign.Center,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
@@ -862,7 +862,7 @@ private fun NowPlayingTv(
                     Text(
                         text = metadataText,
                         fontSize = AdaptiveDefaults.bodyTextSize(formFactor),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.9f),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.Center,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -876,7 +876,7 @@ private fun NowPlayingTv(
                     Text(
                         text = stringResource(R.string.group_label, groupName),
                         fontSize = AdaptiveDefaults.captionTextSize(formFactor),
-                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                        color = MaterialTheme.colorScheme.primary,
                         textAlign = TextAlign.Center,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis


### PR DESCRIPTION
## Summary
- Removed `copy(alpha = 0.9f)` from group label text (primary color) and metadata text (onSurfaceVariant) across all Now Playing layouts (portrait, landscape, TV, head unit)
- The Material 3 theme colors already provide sufficient visual hierarchy; the 0.9 alpha unnecessarily reduced contrast
- PlaybackControls secondary row icons (switch group, favorite, speaker) already use full-opacity Material 3 defaults -- no changes needed there

## Test plan
- [ ] Verify group label ("Group: Whole House") renders at full primary color in portrait, landscape, TV, and head unit layouts
- [ ] Verify artist/album metadata text renders at full onSurfaceVariant color
- [ ] Confirm visual hierarchy still looks correct without the subtle alpha reduction