### PR TITLE
fix: show secondary actions in landscape Now Playing

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
@@ -505,7 +505,7 @@ private fun NowPlayingLandscape(
     onVolumeChange: (Float) -> Unit,
     onQueueClick: () -> Unit,
     showQueueButton: Boolean = true,
-    showSecondaryRow: Boolean = false,
+    showSecondaryRow: Boolean = true,
     showPlayerButton: Boolean = false,
     onPlayerClick: () -> Unit = {},
     modifier: Modifier = Modifier


### PR DESCRIPTION
## Summary
- The `NowPlayingLandscape` composable defaulted `showSecondaryRow` to `false`, which hid switch-group, favorite, and player buttons in phone landscape and tablet 7-inch landscape (non-MA connected) layouts.
- Changed the default to `true` so the secondary row renders below the main playback controls, matching the portrait layout behavior.
- No portrait layouts are affected by this change.

## Test plan
- [ ] Verify phone landscape Now Playing shows switch-group and favorite buttons below the main controls
- [ ] Verify tablet 7-inch landscape (without MA) shows secondary actions
- [ ] Verify phone portrait layout is unchanged
- [ ] Verify tablet with MA queue panel still works correctly in both orientations