### PR TITLE
fix: improve carousel scroll affordance

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/home/components/MediaCarousel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/home/components/MediaCarousel.kt
@@ -94,7 +94,7 @@ private fun CarouselContent(
 ) {
     LazyRow(
         modifier = modifier.fillMaxWidth(),
-        contentPadding = PaddingValues(horizontal = 16.dp),
+        contentPadding = PaddingValues(start = 16.dp, end = 48.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         items(


### PR DESCRIPTION
## Summary
- Increased carousel end padding from 16dp to 48dp (asymmetric) so the last visible card does not sit flush with the screen edge, hinting that more content is available to scroll
- Card titles already use `maxLines = 2` with ellipsis -- no change needed
- Card subtitles already use 12sp (bodySmall) meeting accessibility minimum -- no change needed

## Test plan
- [ ] Verify carousels on Home/Browse screen show partial card peek at the right edge
- [ ] Verify scrolling to the end of a carousel shows trailing padding
- [ ] Verify card titles still wrap to 2 lines for long names
- [ ] Verify subtitle text remains readable at 12sp