### PR TITLE
Fix play button size inconsistency across tablet orientations

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/adaptive/AdaptiveDefaults.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/adaptive/AdaptiveDefaults.kt
@@ -89,7 +89,7 @@ object AdaptiveDefaults {
     /** Large playback button size (play/pause) */
     fun playButtonSize(formFactor: FormFactor): Dp = when (formFactor) {
         FormFactor.PHONE -> 72.dp
-        FormFactor.TABLET_7 -> 80.dp
+        FormFactor.TABLET_7 -> 88.dp
         FormFactor.TABLET_10 -> 88.dp
         FormFactor.TV -> 96.dp
         FormFactor.HEADUNIT -> 96.dp
@@ -98,7 +98,7 @@ object AdaptiveDefaults {
     /** Small playback button size (prev/next/group) */
     fun controlButtonSize(formFactor: FormFactor): Dp = when (formFactor) {
         FormFactor.PHONE -> 56.dp
-        FormFactor.TABLET_7 -> 64.dp
+        FormFactor.TABLET_7 -> 72.dp
         FormFactor.TABLET_10 -> 72.dp
         FormFactor.TV -> 80.dp
         FormFactor.HEADUNIT -> 80.dp

--- a/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/NowPlayingScreen.kt
@@ -442,6 +442,7 @@ private fun NowPlayingPortrait(
         Spacer(modifier = Modifier.height(16.dp))
 
         // Playback Controls
+        val formFactor = LocalFormFactor.current
         PlaybackControls(
             isPlaying = isPlaying,
             isEnabled = controlsEnabled,
@@ -456,7 +457,9 @@ private fun NowPlayingPortrait(
             isFavorite = false, // TODO: Track favorite state
             onFavoriteClick = onFavoriteClick,
             showPlayerButton = showPlayerButton,
-            onPlayerClick = onPlayerClick
+            onPlayerClick = onPlayerClick,
+            playButtonSize = AdaptiveDefaults.playButtonSize(formFactor),
+            controlButtonSize = AdaptiveDefaults.controlButtonSize(formFactor)
         )
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -597,6 +600,7 @@ private fun NowPlayingLandscape(
             Spacer(modifier = Modifier.height(12.dp))
 
             // Playback Controls (horizontal layout in landscape)
+            val formFactor = LocalFormFactor.current
             PlaybackControls(
                 isPlaying = isPlaying,
                 isEnabled = controlsEnabled,
@@ -610,7 +614,9 @@ private fun NowPlayingLandscape(
                 isFavorite = false,
                 onFavoriteClick = onFavoriteClick,
                 showPlayerButton = showPlayerButton,
-                onPlayerClick = onPlayerClick
+                onPlayerClick = onPlayerClick,
+                playButtonSize = AdaptiveDefaults.playButtonSize(formFactor),
+                controlButtonSize = AdaptiveDefaults.controlButtonSize(formFactor)
             )
 
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
## Summary
- Pass `AdaptiveDefaults.playButtonSize()` and `controlButtonSize()` to `PlaybackControls` in both `NowPlayingPortrait` and `NowPlayingLandscape` -- previously these used hardcoded defaults (72dp/56dp), ignoring the adaptive values entirely
- Unify TABLET_7 and TABLET_10 play button sizes to 88dp (was 80dp for TABLET_7) and control button sizes to 72dp (was 64dp for TABLET_7), so rotating a 10" tablet no longer causes the button to change size due to form factor reclassification

## Test plan
- [ ] Verify play button is 88dp on 7" and 10" tablets in both portrait and landscape
- [ ] Verify prev/next buttons are 72dp on tablets in both orientations
- [ ] Verify phone button sizes remain unchanged (72dp play, 56dp control)
- [ ] Verify TV and head unit button sizes remain unchanged (96dp play, 80dp control)
- [ ] Rotate a 10" tablet between portrait and landscape and confirm no visible button size change