### PR TITLE
fix: add Device Volume label to volume slider

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/main/components/VolumeSlider.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/components/VolumeSlider.kt
@@ -1,5 +1,6 @@
 package com.sendspindroid.ui.main.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,6 +11,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -22,6 +24,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.sendspindroid.R
 import com.sendspindroid.ui.theme.SendSpinTheme
 
@@ -40,45 +43,58 @@ fun VolumeSlider(
     val activeTrackColor = accentColor ?: MaterialTheme.colorScheme.primary
     val thumbColor = accentColor ?: MaterialTheme.colorScheme.primary
 
-    Row(
+    Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .padding(horizontal = 8.dp)
     ) {
-        // Volume Down Icon
-        Icon(
-            painter = painterResource(R.drawable.ic_volume_down),
-            contentDescription = null,
-            modifier = Modifier.size(20.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+        // Label
+        Text(
+            text = stringResource(R.string.device_volume),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            fontSize = 11.sp,
+            modifier = Modifier.padding(start = 32.dp, bottom = 2.dp)
         )
 
-        Spacer(modifier = Modifier.width(12.dp))
-
-        // Volume Slider
-        Slider(
-            value = volume,
-            onValueChange = onVolumeChange,
-            enabled = enabled,
-            modifier = Modifier.weight(1f),
-            valueRange = 0f..1f,
-            colors = SliderDefaults.colors(
-                thumbColor = thumbColor,
-                activeTrackColor = activeTrackColor,
-                inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Volume Down Icon
+            Icon(
+                painter = painterResource(R.drawable.ic_volume_down),
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
             )
-        )
 
-        Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(12.dp))
 
-        // Volume Up Icon
-        Icon(
-            painter = painterResource(R.drawable.ic_volume_up),
-            contentDescription = null,
-            modifier = Modifier.size(20.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-        )
+            // Volume Slider
+            Slider(
+                value = volume,
+                onValueChange = onVolumeChange,
+                enabled = enabled,
+                modifier = Modifier.weight(1f),
+                valueRange = 0f..1f,
+                colors = SliderDefaults.colors(
+                    thumbColor = thumbColor,
+                    activeTrackColor = activeTrackColor,
+                    inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            // Volume Up Icon
+            Icon(
+                painter = painterResource(R.drawable.ic_volume_up),
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
+        }
     }
 }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="next">Next</string>
     <string name="switch_group">Switch Group</string>
     <string name="volume">Volume</string>
+    <string name="device_volume">Device Volume</string>
     <string name="group_label">Group: %s</string>
     <string name="not_connected">Not Connected</string>
     <string name="connected">Connected</string>


### PR DESCRIPTION
## Summary
- The volume slider on the Now Playing screen controls the Android device's STREAM_MUSIC volume and also reports it to the SendSpin server for multi-client coordination
- Without a label, users could not tell whether the slider affected their local device or a server-wide volume -- an important distinction in a multi-room audio app
- Added a subtle "Device Volume" label (11sp, 70% opacity) above the slider row to clarify this

## Test plan
- [ ] Verify the "Device Volume" label appears above the volume slider in portrait and landscape
- [ ] Confirm the label uses the theme's `onSurfaceVariant` color at reduced opacity and does not visually dominate
- [ ] Check that the slider still functions correctly (drags, volume changes apply to device)