### PR TITLE
fix: move status indicator colors to theme semantic tokens

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/main/components/ServerListItem.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/components/ServerListItem.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -41,6 +40,8 @@ import com.sendspindroid.model.RemoteConnection
 import com.sendspindroid.model.UnifiedServer
 import com.sendspindroid.ui.adaptive.tvFocusable
 import com.sendspindroid.ui.theme.SendSpinTheme
+import com.sendspindroid.ui.theme.statusOnline
+import com.sendspindroid.ui.theme.statusWarning
 
 /**
  * Server status for UI display.
@@ -181,10 +182,10 @@ private fun StatusIndicator(
 ) {
     val color = when (status) {
         ServerItemStatus.DISCONNECTED -> MaterialTheme.colorScheme.outline
-        ServerItemStatus.ONLINE -> Color(0xFF4CAF50) // Green
+        ServerItemStatus.ONLINE -> MaterialTheme.colorScheme.statusOnline
         ServerItemStatus.CONNECTING -> MaterialTheme.colorScheme.tertiary
-        ServerItemStatus.CONNECTED -> Color(0xFF4CAF50) // Green
-        ServerItemStatus.RECONNECTING -> Color(0xFFFF9800) // Orange
+        ServerItemStatus.CONNECTED -> MaterialTheme.colorScheme.statusOnline
+        ServerItemStatus.RECONNECTING -> MaterialTheme.colorScheme.statusWarning
         ServerItemStatus.ERROR -> MaterialTheme.colorScheme.error
     }
 

--- a/android/app/src/main/java/com/sendspindroid/ui/theme/Color.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/theme/Color.kt
@@ -80,3 +80,9 @@ val md_theme_dark_inversePrimary = Color(0xFF6750A4)
 
 val md_theme_dark_surfaceTint = Color(0xFFD0BCFF)
 val md_theme_dark_scrim = Color(0xFF000000)
+
+// Semantic status colors -- used for server status indicators
+val StatusGreenLight = Color(0xFF4CAF50)
+val StatusGreenDark = Color(0xFF81C784)
+val StatusOrangeLight = Color(0xFFE65100)
+val StatusOrangeDark = Color(0xFFFFB74D)

--- a/android/app/src/main/java/com/sendspindroid/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/theme/Theme.kt
@@ -8,11 +8,21 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+
+/**
+ * CompositionLocal tracking whether the current theme is dark.
+ * Used by semantic color extension properties that need to vary by theme.
+ */
+val LocalIsDarkTheme = staticCompositionLocalOf { false }
 
 private val LightColorScheme = lightColorScheme(
     primary = md_theme_light_primary,
@@ -114,9 +124,26 @@ fun SendSpinTheme(
         }
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+    CompositionLocalProvider(LocalIsDarkTheme provides darkTheme) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography,
+            content = content
+        )
+    }
 }
+
+// -- Semantic color extensions --------------------------------------------------
+
+/**
+ * Green used for "online" / "connected" status indicators.
+ * Requires [LocalIsDarkTheme] to be provided (automatically set by [SendSpinTheme]).
+ */
+val ColorScheme.statusOnline: Color
+    @Composable get() = if (LocalIsDarkTheme.current) StatusGreenDark else StatusGreenLight
+
+/**
+ * Orange/amber used for "reconnecting" / "warning" status indicators.
+ */
+val ColorScheme.statusWarning: Color
+    @Composable get() = if (LocalIsDarkTheme.current) StatusOrangeDark else StatusOrangeLight


### PR DESCRIPTION
## Summary
- Defined `statusOnline` (green) and `statusWarning` (orange) as `ColorScheme` extension properties with light/dark variants
- Added `LocalIsDarkTheme` CompositionLocal to `SendSpinTheme` so semantic extensions can resolve the correct variant
- Replaced hardcoded `Color(0xFF4CAF50)` and `Color(0xFFFF9800)` in `StatusIndicator` with the new theme tokens

## Items reviewed but already correct
- **Server icon semantics**: Server list items use a status dot + connection-type icons (wifi/cloud/vpn), not a play triangle. No change needed.
- **FAB overlap on scroll**: `LazyColumn` already has `contentPadding = PaddingValues(bottom = 88.dp)` in both `ServerListScreen` implementations. No change needed.

## Test plan
- [ ] Verify status dot colors in light and dark themes
- [ ] Confirm online/connected shows green, reconnecting shows orange/amber
- [ ] Check that dynamic color (Material You) devices still render status dots correctly