### PR TITLE
Add skip-next button to landscape side mini player

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
@@ -595,6 +595,7 @@ private fun ConnectedShell(
                         SideMiniPlayerBar(
                             viewModel = viewModel,
                             onPlayPauseClick = onPlayPauseClick,
+                            onNextClick = onNextClick,
                             onReturnToNowPlaying = miniPlayerReturnToNowPlaying
                         )
                     }
@@ -1361,6 +1362,7 @@ private fun MiniPlayerBar(
 private fun SideMiniPlayerBar(
     viewModel: MainActivityViewModel,
     onPlayPauseClick: () -> Unit,
+    onNextClick: () -> Unit,
     onReturnToNowPlaying: () -> Unit
 ) {
     val metadata by viewModel.metadata.collectAsStateWithLifecycle()
@@ -1386,6 +1388,7 @@ private fun SideMiniPlayerBar(
                     onReturnToNowPlaying()
                 },
                 onPlayPauseClick = onPlayPauseClick,
+                onNextClick = onNextClick,
                 positionMs = positionMs,
                 durationMs = durationMs,
                 positionUpdatedAt = positionUpdatedAt,

--- a/android/app/src/main/java/com/sendspindroid/ui/main/components/MiniPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/components/MiniPlayer.kt
@@ -300,6 +300,7 @@ fun MiniPlayerSide(
     isPlaying: Boolean,
     onCardClick: () -> Unit,
     onPlayPauseClick: () -> Unit,
+    onNextClick: () -> Unit,
     positionMs: Long = 0,
     durationMs: Long = 0,
     positionUpdatedAt: Long = SystemClock.elapsedRealtime(),
@@ -455,6 +456,18 @@ fun MiniPlayerSide(
                                 else R.string.accessibility_play_button
                             ),
                             modifier = Modifier.size(24.dp)
+                        )
+                    }
+
+                    IconButton(
+                        onClick = onNextClick,
+                        modifier = Modifier.size(48.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_skip_next),
+                            contentDescription = stringResource(R.string.accessibility_next_button),
+                            modifier = Modifier.size(24.dp),
+                            tint = MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
- Added a skip-next button to the landscape `MiniPlayerSide` composable, matching the button style used in the portrait mini player
- Threaded the `onNextClick` callback through `SideMiniPlayerBar` in `AppShell.kt`
- Artist text was verified to already be 12sp (`bodySmall`) -- no size change needed

## Test plan
- [ ] Launch app in landscape on a phone, verify the side mini player shows both play/pause and skip-next buttons
- [ ] Tap skip-next and confirm it advances to the next track
- [ ] Verify portrait mini player is unchanged (still shows previous, play/pause, next)
- [ ] Verify no layout overflow on narrow landscape screens