### PR TITLE
feat: TV top bar and progress bar scaling

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/AppShell.kt
@@ -198,9 +198,19 @@ private fun ServerListShell(
     serverListContent: @Composable () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val formFactor = LocalFormFactor.current
     Column(modifier = modifier.fillMaxSize()) {
         TopAppBar(
-            title = { Text(stringResource(R.string.app_name)) },
+            title = {
+                Text(
+                    text = stringResource(R.string.app_name),
+                    style = if (formFactor == FormFactor.TV)
+                        MaterialTheme.typography.headlineMedium
+                    else
+                        MaterialTheme.typography.titleLarge
+                )
+            },
+            expandedHeight = AdaptiveDefaults.topBarHeight(formFactor),
             colors = TopAppBarDefaults.topAppBarColors(
                 containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)
             )
@@ -349,11 +359,15 @@ private fun ConnectedShell(
                     }
                 }
             },
+            expandedHeight = AdaptiveDefaults.topBarHeight(formFactor),
             title = {
                 Column {
                     Text(
                         text = topBarTitle,
-                        style = MaterialTheme.typography.titleLarge,
+                        style = if (formFactor == FormFactor.TV)
+                            MaterialTheme.typography.headlineMedium
+                        else
+                            MaterialTheme.typography.titleLarge,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )

--- a/android/app/src/main/java/com/sendspindroid/ui/adaptive/AdaptiveDefaults.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/adaptive/AdaptiveDefaults.kt
@@ -208,6 +208,28 @@ object AdaptiveDefaults {
         FormFactor.HEADUNIT -> 0.dp  // Not shown
     }
 
+    // -- Top Bar --
+
+    /** Top bar height. TV uses a taller bar for 10-foot visibility. */
+    fun topBarHeight(formFactor: FormFactor): Dp = when (formFactor) {
+        FormFactor.TV -> 72.dp
+        else -> 64.dp  // Material3 default
+    }
+
+    // -- Progress Bar --
+
+    /** Track progress bar thickness. TV uses a thicker bar for 10-foot visibility. */
+    fun progressBarHeight(formFactor: FormFactor): Dp = when (formFactor) {
+        FormFactor.TV -> 12.dp
+        else -> 4.dp
+    }
+
+    /** Track progress bar corner radius, matching half of the bar height. */
+    fun progressBarCornerRadius(formFactor: FormFactor): Dp = when (formFactor) {
+        FormFactor.TV -> 6.dp
+        else -> 2.dp
+    }
+
     // -- Server List --
 
     /**

--- a/android/app/src/main/java/com/sendspindroid/ui/main/components/TrackProgressBar.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/main/components/TrackProgressBar.kt
@@ -25,6 +25,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.sendspindroid.ui.adaptive.AdaptiveDefaults
+import com.sendspindroid.ui.adaptive.FormFactor
+import com.sendspindroid.ui.adaptive.LocalFormFactor
 import com.sendspindroid.ui.theme.SendSpinTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -127,14 +130,17 @@ fun TvTrackProgressBar(
 
     val progress = (displayPositionMs.toFloat() / durationMs).coerceIn(0f, 1f)
     val trackColor = accentColor ?: MaterialTheme.colorScheme.primary
+    val formFactor = LocalFormFactor.current
+    val barHeight = AdaptiveDefaults.progressBarHeight(formFactor)
+    val barCornerRadius = AdaptiveDefaults.progressBarCornerRadius(formFactor)
 
     Column(modifier = modifier.fillMaxWidth()) {
         LinearProgressIndicator(
             progress = { progress },
             modifier = Modifier
                 .fillMaxWidth()
-                .height(4.dp)
-                .clip(RoundedCornerShape(2.dp)),
+                .height(barHeight)
+                .clip(RoundedCornerShape(barCornerRadius)),
             color = trackColor,
             trackColor = MaterialTheme.colorScheme.surfaceVariant
         )


### PR DESCRIPTION
## Summary
- Increase TV top bar height from 64dp to 72dp with `headlineMedium` title text for 10-foot viewing distance readability
- Increase TV progress bar from 4dp to 12dp (with 6dp corner radius) for at-a-glance track progress visibility
- Add `topBarHeight`, `progressBarHeight`, and `progressBarCornerRadius` functions to `AdaptiveDefaults`
- Non-TV form factors are unchanged (64dp top bar, 4dp progress bar)

## Test plan
- [ ] Verify TV top bar is visibly taller with larger title text
- [ ] Verify TV progress bar is thick enough to see from 2-3m viewing distance
- [ ] Verify phone/tablet top bar and progress bar are unchanged
- [ ] Build succeeds with no regressions