### PR TITLE
Omit artwork role in low memory mode

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -175,7 +175,8 @@ abstract class SendSpinProtocolHandler(
             deviceName = getDeviceName(),
             bufferCapacity = bufferCapacity,
             manufacturer = getManufacturer(),
-            supportedFormats = formats
+            supportedFormats = formats,
+            lowMemoryMode = isLowMemoryMode()
         )
         sendTextMessage(text)
         Log.d(tag, "Sent client/hello: ${text.take(500)}")

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -20,7 +20,8 @@ object MessageBuilder {
         deviceName: String,
         bufferCapacity: Int,
         manufacturer: String,
-        supportedFormats: List<FormatEntry>
+        supportedFormats: List<FormatEntry>,
+        lowMemoryMode: Boolean = false
     ): String {
         val message = buildJsonObject {
             put("type", SendSpinProtocol.MessageType.CLIENT_HELLO)
@@ -32,7 +33,9 @@ object MessageBuilder {
                     add(kotlinx.serialization.json.JsonPrimitive(SendSpinProtocol.Roles.PLAYER))
                     add(kotlinx.serialization.json.JsonPrimitive(SendSpinProtocol.Roles.CONTROLLER))
                     add(kotlinx.serialization.json.JsonPrimitive(SendSpinProtocol.Roles.METADATA))
-                    add(kotlinx.serialization.json.JsonPrimitive(SendSpinProtocol.Roles.ARTWORK))
+                    if (!lowMemoryMode) {
+                        add(kotlinx.serialization.json.JsonPrimitive(SendSpinProtocol.Roles.ARTWORK))
+                    }
                 })
                 put("device_info", buildJsonObject {
                     put("product_name", "SendSpinDroid")
@@ -56,16 +59,18 @@ object MessageBuilder {
                         add(kotlinx.serialization.json.JsonPrimitive("mute"))
                     })
                 })
-                put("artwork@v1_support", buildJsonObject {
-                    put("channels", buildJsonArray {
-                        add(buildJsonObject {
-                            put("source", "album")
-                            put("format", "jpeg")
-                            put("media_width", SendSpinProtocol.Artwork.REQUEST_SIZE)
-                            put("media_height", SendSpinProtocol.Artwork.REQUEST_SIZE)
+                if (!lowMemoryMode) {
+                    put("artwork@v1_support", buildJsonObject {
+                        put("channels", buildJsonArray {
+                            add(buildJsonObject {
+                                put("source", "album")
+                                put("format", "jpeg")
+                                put("media_width", SendSpinProtocol.Artwork.REQUEST_SIZE)
+                                put("media_height", SendSpinProtocol.Artwork.REQUEST_SIZE)
+                            })
                         })
                     })
-                })
+                }
             })
         }
         return message.toString()


### PR DESCRIPTION
## Summary
- Omit `artwork@v1` from `supported_roles` in `client/hello` when low memory mode is enabled
- Skip the `artwork@v1_support` block in the handshake
- Server no longer scales, compresses, or sends artwork that the client immediately drops

## Test plan
- [ ] Enable low memory mode, connect to server, verify no artwork binary messages received
- [ ] Disable low memory mode, connect to server, verify artwork still works normally
- [ ] Unit tests pass