### PR TITLE
Constrain audio to 16-bit PCM in low memory mode

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -210,12 +210,18 @@ class SendSpinClient(
 
     override fun getManufacturer(): String = Build.MANUFACTURER ?: "Unknown"
 
-    override fun getSupportedFormats(): List<MessageBuilder.FormatEntry> =
-        MessageBuilder.buildSupportedFormats(
+    override fun getSupportedFormats(): List<MessageBuilder.FormatEntry> {
+        val bitDepths = if (isLowMemoryMode()) {
+            listOf(16)
+        } else {
+            AudioDecoderFactory.getSupportedPcmBitDepths()
+        }
+        return MessageBuilder.buildSupportedFormats(
             preferredCodec = UserSettings.getPreferredCodec(),
             isCodecSupported = { AudioDecoderFactory.isCodecSupported(it) },
-            supportedBitDepths = AudioDecoderFactory.getSupportedPcmBitDepths()
+            supportedBitDepths = bitDepths
         )
+    }
 
     override fun onHandshakeComplete(serverName: String, serverId: String) {
         this.serverName = serverName


### PR DESCRIPTION
## Summary
- In low memory mode, only advertise 16-bit PCM in `client/hello`
- Server negotiates 16-bit instead of 32-bit, halving per-sample memory usage
- Normal mode unchanged -- still advertises all supported bit depths

## Test plan
- [ ] Enable low memory mode, connect, verify server negotiates 16-bit PCM
- [ ] Disable low memory mode, connect, verify 24/32-bit still available
- [ ] Unit tests pass