### PR TITLE
Cap audio chunk queue capacity in low memory mode

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -71,6 +71,7 @@ import com.sendspindroid.sendspin.SyncAudioPlayer
 import com.sendspindroid.sendspin.SyncAudioPlayerCallback
 import com.sendspindroid.sendspin.PlaybackState as SyncPlaybackState
 import com.sendspindroid.sendspin.decoder.AudioDecoder
+import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import com.sendspindroid.sendspin.decoder.AudioDecoderFactory
 import com.sendspindroid.network.ConnectionSelector
 import com.sendspindroid.network.NetworkEvaluator
@@ -1153,11 +1154,18 @@ class PlaybackService : MediaLibraryService() {
                 } else {
                     // Format changed or no existing player - create new one
                     existingPlayer?.release()
+                    // In low memory mode, cap the chunk queue to ~10 seconds of audio
+                    val maxSamples = if (com.sendspindroid.UserSettings.lowMemoryMode) {
+                        sampleRate.toLong() * SendSpinProtocol.Buffer.DURATION_LOW_MEM_SEC
+                    } else {
+                        0L  // Unlimited
+                    }
                     syncAudioPlayer = SyncAudioPlayer(
                         timeFilter = timeFilter,
                         sampleRate = sampleRate,
                         channels = channels,
-                        bitDepth = bitDepth
+                        bitDepth = bitDepth,
+                        maxQueueSamples = maxSamples
                     ).apply {
                         // Set callback to update SendSpinPlayer when playback state changes
                         setStateCallback(SyncAudioPlayerStateCallback())

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -193,7 +193,8 @@ class SyncAudioPlayer(
     private val timeFilter: SendspinTimeFilter,
     private val sampleRate: Int = SendSpinProtocol.AudioFormat.SAMPLE_RATE,
     private val channels: Int = SendSpinProtocol.AudioFormat.CHANNELS,
-    private val bitDepth: Int = SendSpinProtocol.AudioFormat.BIT_DEPTH
+    private val bitDepth: Int = SendSpinProtocol.AudioFormat.BIT_DEPTH,
+    private val maxQueueSamples: Long = 0  // 0 = unlimited; >0 caps queue to this many samples
 ) {
     companion object {
         private const val TAG = "SyncAudioPlayer"
@@ -331,6 +332,7 @@ class SyncAudioPlayer(
     // Chunk queue
     private val chunkQueue = ConcurrentLinkedQueue<AudioChunk>()
     private val totalQueuedSamples = AtomicLong(0)
+    private var queueCapDrops = 0  // Counter for capacity-based drops (diagnostics)
 
     // Sync tracking
     private var lastChunkServerTime = 0L
@@ -1050,6 +1052,23 @@ class SyncAudioPlayer(
     }
 
     /**
+     * Evict oldest chunks from the queue if adding [newSamples] would exceed the
+     * capacity limit. Only active when [maxQueueSamples] > 0.
+     */
+    private fun evictIfOverCapacity(newSamples: Long) {
+        if (maxQueueSamples <= 0) return
+        while (totalQueuedSamples.get() + newSamples > maxQueueSamples) {
+            val evicted = chunkQueue.poll() ?: break
+            totalQueuedSamples.addAndGet(-evicted.sampleCount.toLong())
+            queueCapDrops++
+            if (queueCapDrops % 100 == 1) {
+                Log.w(TAG, "Queue capacity limit reached ($maxQueueSamples samples), " +
+                    "dropping oldest chunks (total drops: $queueCapDrops)")
+            }
+        }
+    }
+
+    /**
      * Queue an audio chunk for playback.
      *
      * Handles gaps and overlaps in the audio stream following the Python reference:
@@ -1145,6 +1164,7 @@ class SyncAudioPlayer(
                         pcmData = silenceData,
                         sampleCount = gapFrames
                     )
+                    evictIfOverCapacity(gapFrames.toLong())
                     chunkQueue.add(silenceChunk)
                     totalQueuedSamples.addAndGet(gapFrames.toLong())
 
@@ -1212,6 +1232,7 @@ class SyncAudioPlayer(
             pcmData = workingPcmData,
             sampleCount = sampleCount
         )
+        evictIfOverCapacity(sampleCount.toLong())
         chunkQueue.add(chunk)
         totalQueuedSamples.addAndGet(sampleCount.toLong())
 


### PR DESCRIPTION
## Summary
- Add `maxQueueSamples` parameter to `SyncAudioPlayer` to bound the chunk queue size
- In low memory mode, cap the queue to ~10 seconds of audio (matching `DURATION_LOW_MEM_SEC`)
- Oldest chunks are evicted when the limit is reached (drops preferred over OOM)
- Normal mode unchanged -- unbounded queue as before

## Test plan
- [ ] Enable low memory mode, play audio, verify no dropouts under normal conditions
- [ ] Verify reconnect after network interruption still works in low memory mode
- [ ] Disable low memory mode, verify unbounded behavior unchanged
- [ ] Unit tests pass