### PR TITLE
Auto-detect low memory devices for default setting

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -1,5 +1,6 @@
 package com.sendspindroid
 
+import android.app.ActivityManager
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
@@ -81,6 +82,10 @@ object UserSettings {
     internal var isEncrypted: Boolean = false
         private set
 
+    /** Application context for system service lookups (e.g., ActivityManager). */
+    @Volatile
+    private var appContext: Context? = null
+
     // In-memory fallback for player ID generated before prefs is available.
     // Ensures getPlayerId() always returns the same value even if called
     // before initialize(), preventing silent UUID loss (C-16).
@@ -97,6 +102,7 @@ object UserSettings {
             synchronized(this) {
                 if (prefs == null) {
                     val appContext = context.applicationContext
+                    this.appContext = appContext
                     val p = PreferenceManager.getDefaultSharedPreferences(appContext)
                     // If a player ID was generated before prefs was available,
                     // persist it now so it survives app restarts.
@@ -250,7 +256,15 @@ object UserSettings {
      * Use when controlling playback from the server and UI isn't needed.
      */
     val lowMemoryMode: Boolean
-        get() = prefs?.getBoolean(KEY_LOW_MEMORY_MODE, false) ?: false
+        get() {
+            val p = prefs ?: return false
+            if (!p.contains(KEY_LOW_MEMORY_MODE)) {
+                // First launch: auto-detect from device capabilities
+                val am = appContext?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+                return am?.isLowRamDevice == true
+            }
+            return p.getBoolean(KEY_LOW_MEMORY_MODE, false)
+        }
 
     /**
      * Whether Full Screen Mode is enabled.
@@ -692,6 +706,7 @@ object UserSettings {
             sensitivePrefs = null
             isEncrypted = false
             cachedPlayerId = null
+            appContext = null
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -261,7 +261,12 @@ object UserSettings {
             if (!p.contains(KEY_LOW_MEMORY_MODE)) {
                 // First launch: auto-detect from device capabilities
                 val am = appContext?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
-                return am?.isLowRamDevice == true
+                    ?: return false
+                // OEM-flagged low RAM devices, or devices with 2GB or less total RAM
+                if (am.isLowRamDevice) return true
+                val memInfo = ActivityManager.MemoryInfo()
+                am.getMemoryInfo(memInfo)
+                return memInfo.totalMem <= 2L * 1024 * 1024 * 1024
             }
             return p.getBoolean(KEY_LOW_MEMORY_MODE, false)
         }


### PR DESCRIPTION
## Summary
- Use `ActivityManager.isLowRamDevice()` to set the default for low memory mode on first launch
- Only affects initial default -- user's explicit choice always takes precedence
- Users on Android Go / low RAM devices get optimized experience without manual configuration

## Test plan
- [ ] Fresh install on low RAM device/emulator, verify low memory mode defaults to ON
- [ ] Fresh install on normal device, verify low memory mode defaults to OFF
- [ ] Toggle setting manually, restart, verify manual choice persists
- [ ] Unit tests pass