### PR TITLE
Fix stream format guard to allow pipeline reconfiguration on format change

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -41,6 +41,7 @@ abstract class SendSpinProtocolHandler(
 
     // Stream active tracking (mirrors CLI _stream_active)
     private var _streamActive = false
+    private var _currentStreamConfig: StreamConfig? = null
 
     // Last received values for change detection (avoids unnecessary UI recomposition)
     private var lastMetadata: TrackMetadata? = null
@@ -345,6 +346,7 @@ abstract class SendSpinProtocolHandler(
 
         // Clear cached values so the first post-handshake messages always propagate
         _streamActive = false
+        _currentStreamConfig = null
         lastMetadata = null
         lastPlaybackState = null
         lastGroupInfo = null
@@ -413,12 +415,17 @@ abstract class SendSpinProtocolHandler(
         if (config == null) return
 
         if (_streamActive) {
-            Log.i(tag, "Stream format update: codec=${config.codec}, rate=${config.sampleRate}, ch=${config.channels}, bits=${config.bitDepth}, header=${config.codecHeader?.size ?: 0} bytes")
-            return
+            if (config == _currentStreamConfig) {
+                Log.d(tag, "Stream format unchanged, suppressing redundant stream/start")
+                return
+            }
+            Log.i(tag, "Stream format changed: codec=${config.codec}, rate=${config.sampleRate}, ch=${config.channels}, bits=${config.bitDepth} - reconfiguring pipeline")
+        } else {
+            Log.i(tag, "Stream started: codec=${config.codec}, rate=${config.sampleRate}, ch=${config.channels}, bits=${config.bitDepth}, header=${config.codecHeader?.size ?: 0} bytes")
         }
 
         _streamActive = true
-        Log.i(tag, "Stream started: codec=${config.codec}, rate=${config.sampleRate}, ch=${config.channels}, bits=${config.bitDepth}, header=${config.codecHeader?.size ?: 0} bytes")
+        _currentStreamConfig = config
         onStreamStart(config)
     }
 
@@ -438,6 +445,7 @@ abstract class SendSpinProtocolHandler(
 
         Log.i(tag, "Stream end - server terminated playback (roles=${roles ?: "all"})")
         _streamActive = false
+        _currentStreamConfig = null
         onStreamEnd()
     }
 


### PR DESCRIPTION
## Summary
- The `_streamActive` guard from Beta7 blindly suppressed all `stream/start` messages when a stream was already active
- This caused pitch shifting and distortion when consecutive tracks had different sample rates, bit depths, channels, or codecs
- Now stores the current `StreamConfig` and compares before suppressing — only identical formats are suppressed
- On format change, `onStreamStart()` fires to reconfigure the decoder and SyncAudioPlayer
- Stored config is cleared on disconnect and stream end

Reported in Beta7 testing: "Some strange pitching going on while the music is playing"

## Test plan
- [ ] Play tracks with different sample rates back-to-back (e.g., 44.1kHz then 48kHz) — no pitch shift
- [ ] Play tracks with same format — no unnecessary pipeline teardown (check logs for "suppressing redundant")
- [ ] Unit tests pass