### PR TITLE
fix: prevent audioDecoder TOCTOU race in onAudioChunk

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -1199,17 +1199,27 @@ class PlaybackService : MediaLibraryService() {
             // Guard: don't try to decode if the decoder is being replaced (race with onStreamStart)
             if (!decoderReady) return
 
-            // Capture local reference to avoid TOCTOU race: the main thread can null
-            // and release syncAudioPlayer between a null-check and method call.
+            // Capture local references to avoid TOCTOU race: the main thread can null
+            // and release these between a null-check and method call.
             val player = syncAudioPlayer ?: return
+            val decoder = audioDecoder
 
-            // Decode compressed data to PCM (pass-through for PCM codec)
+            // Decode compressed data to PCM, or pass through for PCM codec.
+            // If decoder is null mid-reconfiguration, only PCM raw data is safe
+            // to forward -- compressed bytes (Opus/FLAC) would be garbled.
             val pcmData = try {
-                audioDecoder?.decode(audioData) ?: audioData
+                if (decoder != null) {
+                    decoder.decode(audioData)
+                } else if (currentCodec == "pcm") {
+                    audioData
+                } else {
+                    return // compressed codec with no decoder -- drop chunk
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Decode error, dropping chunk", e)
                 return
             }
+            if (pcmData == null) return
             // Queue decoded PCM - SyncAudioPlayer handles threading internally
             player.queueChunk(serverTimeMicros, pcmData)
         }


### PR DESCRIPTION
## Summary
- Fixes a TOCTOU race in `onAudioChunk()` where `audioDecoder` can become null between the `decoderReady` check and the `decode()` call during stream reconfiguration
- The old `?: audioData` fallback passed raw compressed bytes (Opus/FLAC) directly to SyncAudioPlayer expecting PCM, causing silence or garbled audio after track skips
- Now captures `audioDecoder` in a local variable and only falls back to raw data for PCM codec; drops chunks for compressed codecs when decoder is momentarily null

## Test plan
- [x] Unit tests pass
- [x] Compile verified
- [ ] Manual test: skip tracks rapidly with Opus/FLAC codec streams and verify no garbled audio
- [ ] Manual test: pause/play during compressed stream and verify clean recovery