### PR TITLE
fix: always dispatch stream/start to clear stale audio on skip

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -414,12 +414,13 @@ abstract class SendSpinProtocolHandler(
         val config = MessageParser.parseStreamStart(payload)
         if (config == null) return
 
+        val formatChanged = _streamActive && config != _currentStreamConfig
         if (_streamActive) {
-            if (config == _currentStreamConfig) {
-                Log.d(tag, "Stream format unchanged, suppressing redundant stream/start")
-                return
+            if (formatChanged) {
+                Log.i(tag, "Stream format changed: codec=${config.codec}, rate=${config.sampleRate}, ch=${config.channels}, bits=${config.bitDepth} - reconfiguring pipeline")
+            } else {
+                Log.d(tag, "Stream restart (same format): codec=${config.codec}, rate=${config.sampleRate}")
             }
-            Log.i(tag, "Stream format changed: codec=${config.codec}, rate=${config.sampleRate}, ch=${config.channels}, bits=${config.bitDepth} - reconfiguring pipeline")
         } else {
             Log.i(tag, "Stream started: codec=${config.codec}, rate=${config.sampleRate}, ch=${config.channels}, bits=${config.bitDepth}, header=${config.codecHeader?.size ?: 0} bytes")
         }

--- a/android/app/src/test/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandlerTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandlerTest.kt
@@ -152,6 +152,35 @@ class SendSpinProtocolHandlerTest {
         )
     }
 
+    // ========== Stream Start Dispatch Tests ==========
+
+    @Test
+    fun `stream start with same format dispatches every time`() {
+        val streamStart = buildStreamStartJson(codec = "pcm", sampleRate = 48000, channels = 2, bitDepth = 16)
+
+        handler.handleTextMessageForTest(streamStart)
+        handler.handleTextMessageForTest(streamStart)
+
+        assertEquals(
+            "Every stream/start should dispatch to onStreamStart regardless of format match",
+            2,
+            handler.streamStarts.size
+        )
+    }
+
+    @Test
+    fun `stream start with different format dispatches`() {
+        val start1 = buildStreamStartJson(codec = "pcm", sampleRate = 48000, channels = 2, bitDepth = 16)
+        val start2 = buildStreamStartJson(codec = "pcm", sampleRate = 44100, channels = 2, bitDepth = 24)
+
+        handler.handleTextMessageForTest(start1)
+        handler.handleTextMessageForTest(start2)
+
+        assertEquals(2, handler.streamStarts.size)
+        assertEquals(48000, handler.streamStarts[0].sampleRate)
+        assertEquals(44100, handler.streamStarts[1].sampleRate)
+    }
+
     // ========== Helpers ==========
 
     private fun buildServerStateJson(
@@ -183,6 +212,27 @@ class SendSpinProtocolHandlerTest {
             }
         """.trimIndent()
     }
+
+    private fun buildStreamStartJson(
+        codec: String,
+        sampleRate: Int,
+        channels: Int,
+        bitDepth: Int
+    ): String {
+        return """
+            {
+                "type": "stream/start",
+                "payload": {
+                    "player": {
+                        "codec": "$codec",
+                        "sample_rate": $sampleRate,
+                        "channels": $channels,
+                        "bit_depth": $bitDepth
+                    }
+                }
+            }
+        """.trimIndent()
+    }
 }
 
 /**
@@ -197,6 +247,7 @@ class TestProtocolHandler : SendSpinProtocolHandler("TestHandler") {
     val metadataUpdates = mutableListOf<TrackMetadata>()
     val playbackStateChanges = mutableListOf<String>()
     val groupUpdates = mutableListOf<GroupInfo>()
+    val streamStarts = mutableListOf<StreamConfig>()
 
     fun setHandshakeCompleteForTest() {
         handshakeComplete = true
@@ -245,7 +296,9 @@ class TestProtocolHandler : SendSpinProtocolHandler("TestHandler") {
         groupUpdates.add(info)
     }
 
-    override fun onStreamStart(config: StreamConfig) {}
+    override fun onStreamStart(config: StreamConfig) {
+        streamStarts.add(config)
+    }
 
     override fun onStreamClear() {}
 


### PR DESCRIPTION
## Summary
- Removes the early return in `handleStreamStart()` that suppressed same-format `stream/start` messages
- The CLI reference implementation always calls `audio_player.clear()` on every `stream/start` — our suppression skipped this buffer clear, causing stale audio from the previous track to play after skipping
- Keeps `_streamActive` tracking for diagnostic logging (new stream vs restart vs format change) but always dispatches `onStreamStart()`
- Adds tests verifying `stream/start` dispatches for both same-format and different-format scenarios

## Test plan
- [x] Unit tests pass (including new stream start dispatch tests)
- [x] Compile verified
- [ ] Manual test: skip tracks rapidly and verify audio from new track plays immediately
- [ ] Manual test: pause/play and verify clean audio recovery without stale data