### PR TITLE
fix: run audio write loop at URGENT_AUDIO priority (#116)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -5,13 +5,17 @@ import android.media.AudioFormat
 import android.os.Build
 import android.media.AudioTimestamp
 import android.media.AudioTrack
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Process
 import android.util.Log
 import com.sendspindroid.debug.FileLogger
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -288,6 +292,30 @@ class SyncAudioPlayer(
         val pcmData: ByteArray,
         val sampleCount: Int
     )
+
+    // Dedicated audio thread for the playback write loop.
+    //
+    // The write loop owns every blocking AudioTrack.write() call, the
+    // System.nanoTime()-based sync error computation, and the sample
+    // insert/drop corrector. Running it on a shared pool (Dispatchers.Default)
+    // at normal priority leaves it vulnerable to background CPU throttling:
+    // display-pipeline suspend / big.LITTLE migration / thermal DVFS can delay
+    // the coroutine past AudioTrack's DAC deadline, causing underruns and
+    // phantom sync drift that the corrector then chases with ±4% rate
+    // adjustments (audible pitch warble).
+    //
+    // A HandlerThread constructed with THREAD_PRIORITY_URGENT_AUDIO stays on
+    // the audio-class cpuset across foreground/background transitions, which
+    // is exactly what AudioTrack MODE_STREAM push-model playback needs.
+    //
+    // Thread-level lifecycle: created once per SyncAudioPlayer instance, quit
+    // in release() after the final coroutine drains. Safe because only one
+    // coroutine is ever launched into the scope (the main playback loop), so
+    // serializing through a single Looper cannot starve siblings.
+    private val audioThread: HandlerThread =
+        HandlerThread("SendSpinAudio", Process.THREAD_PRIORITY_URGENT_AUDIO).apply { start() }
+    private val audioDispatcher: CoroutineDispatcher =
+        Handler(audioThread.looper).asCoroutineDispatcher("SendSpinAudioDispatcher")
 
     // Coroutine scope for playback - recreated for each playback session
     private var scope: CoroutineScope? = null
@@ -584,8 +612,11 @@ class SyncAudioPlayer(
             }
 
             // Create a new scope for this playback session
-            // Using SupervisorJob so child failures don't cancel the scope
-            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            // Using SupervisorJob so child failures don't cancel the scope.
+            // Dispatcher is backed by a dedicated HandlerThread running at
+            // THREAD_PRIORITY_URGENT_AUDIO so the write loop keeps its audio
+            // deadline even when the app is backgrounded.
+            scope = CoroutineScope(SupervisorJob() + audioDispatcher)
 
             isPlaying.set(true)
             isPaused.set(false)
@@ -924,6 +955,11 @@ class SyncAudioPlayer(
 
         // Phase 2: Outside lock - cancel scope and wait for coroutine to finish
         awaitPlaybackLoopCancellation(captured)
+
+        // Quit the audio HandlerThread only after the playback coroutine has
+        // drained off its Looper. Quitting earlier would orphan pending
+        // messages and risk IllegalStateException on subsequent post().
+        audioThread.quitSafely()
 
         // Phase 3: Re-acquire lock for final resource cleanup
         stateLock.withLock {
@@ -1717,6 +1753,16 @@ class SyncAudioPlayer(
         }
 
         playbackJob = currentScope.launch {
+            // Confirms per-device whether THREAD_PRIORITY_URGENT_AUDIO was
+            // actually honored. Some OEMs clamp audio priorities for non-system
+            // apps; logging the effective tid/priority makes field triage
+            // deterministic. On a healthy device we expect priority = -19.
+            val tid = Process.myTid()
+            Log.i(
+                TAG,
+                "Playback loop thread: name=${Thread.currentThread().name} " +
+                    "tid=$tid priority=${Process.getThreadPriority(tid)}"
+            )
             Log.d(TAG, "Playback loop started, initial state=$playbackState")
 
             while (isActive && isPlaying.get()) {


### PR DESCRIPTION
## Summary

Fixes #116 — "Android Auto - choppy playback unless device stays on."

The playback write loop in `SyncAudioPlayer.kt` owned every blocking
`AudioTrack.write()` call plus the `System.nanoTime()`-based sync error
computation, but ran on `Dispatchers.Default` (normal-priority shared
coroutine pool) with zero `Process.setThreadPriority` / `THREAD_PRIORITY_*`
elevation anywhere in the app. Backgrounded/Android-Auto playback moves
the app's non-audio-tagged threads into the `background` cgroup/cpuset,
which delayed the writer past AudioTrack's DAC deadline and produced
the reported symptom trio:

- **Choppiness** — buffer underruns from late writes.
- **Pitch changes** — `±4%` sample insert/drop corrector chasing a
  clock it thought was drifting, when really the writer itself was
  slipping.
- **Eventual stoppage** — accumulated error past `REANCHOR_THRESHOLD_US`
  (500 ms) bouncing the state machine through REANCHORING / INITIALIZING.

This change backs the playback scope with a dedicated `HandlerThread`
constructed at `Process.THREAD_PRIORITY_URGENT_AUDIO`, exposed as a
`CoroutineDispatcher` via `Handler.asCoroutineDispatcher()`. Only the
worker thread's priority and identity change — the coroutine control
flow, cancellation protocol (`SyncAudioPlayer.kt:877-902`), and
`stateLock` serialization are untouched.

Also logs effective thread name / tid / priority once per `start()` so
field logcat confirms whether the OEM honored URGENT_AUDIO (-19).

## Test plan

- [x] `./gradlew assembleDebug` on Windows succeeds; no new compiler
  warnings from the touched file.
- [x] Install debug APK on reporter's GrapheneOS device; verify
  playback stays smooth for 10+ minutes with screen off and under
  Android Auto (reporter).
- [ ] Confirm logcat shows `priority=-19` in the startup log entry on
  the reporter's device.

## Follow-up

The compressed-codec decode path (`SendSpinClient.kt:909` →
`decoder.decode()` → `queueChunk()`) still runs on an OkHttp worker,
which is also normal-priority and subject to background throttling.
PCM users should see a full fix from this PR; Opus/FLAC users may see
residual choppiness. Will open a follow-up issue for the decode thread
after confirming from the reporter which codec their server is using.