### PR TITLE
fix: resilient reconnection (zombie WiFi / server restart / idle connections)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/MainActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/MainActivity.kt
@@ -214,7 +214,12 @@ class MainActivity : AppCompatActivity() {
     // has no upstream (captive portal, walked out of range, DNS hijack). The
     // PlaybackService callback owns the actual reconnect-pause side effect; this
     // field is UI-only.
-    private var lastActivityValidatedState: Boolean = true
+    //
+    // @Volatile: written from a binder thread (NetworkCallback) and read from the
+    // main looper via runOnUiThread. Null means "no prior state" -- first callback,
+    // no transition to compare against yet.
+    @Volatile
+    private var lastActivityValidatedState: Boolean? = null
 
     // Volume control - uses device STREAM_MUSIC (Spotify-style)
     private val audioManager by lazy {
@@ -1249,7 +1254,7 @@ class MainActivity : AppCompatActivity() {
                 // reconnect-pause side effect in its own callback; here we just show
                 // the snackbar if the user is connected or actively connecting.
                 val isValidated = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-                if (lastActivityValidatedState && !isValidated) {
+                if (lastActivityValidatedState == true && !isValidated) {
                     Log.w(TAG, "Activity: network lost VALIDATED")
                     runOnUiThread {
                         if (connectionState is AppConnectionState.Connected ||

--- a/android/app/src/main/java/com/sendspindroid/MainActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/MainActivity.kt
@@ -209,6 +209,13 @@ class MainActivity : AppCompatActivity() {
     }
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
+    // Tracks NET_CAPABILITY_VALIDATED transitions on the Activity's network callback
+    // so we can surface a "no internet access" snackbar when WiFi is associated but
+    // has no upstream (captive portal, walked out of range, DNS hijack). The
+    // PlaybackService callback owns the actual reconnect-pause side effect; this
+    // field is UI-only.
+    private var lastActivityValidatedState: Boolean = true
+
     // Volume control - uses device STREAM_MUSIC (Spotify-style)
     private val audioManager by lazy {
         getSystemService(Context.AUDIO_SERVICE) as AudioManager
@@ -1230,10 +1237,31 @@ class MainActivity : AppCompatActivity() {
             }
 
             override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
-                // Network type may have changed (WiFi ↔ cellular) - notify pinger
+                // Network type may have changed (WiFi <-> cellular) - notify pinger
                 // This triggers re-evaluation of connection priority
                 networkEvaluator?.evaluateCurrentNetwork(network)
                 defaultServerPinger?.onNetworkChanged()
+
+                // Detect NET_CAPABILITY_VALIDATED dropping. Android can keep INTERNET
+                // set while removing VALIDATED (captive portal, out of WiFi range with
+                // association still up, etc.), in which case onLost() never fires and
+                // the user would see no UI feedback. PlaybackService handles the
+                // reconnect-pause side effect in its own callback; here we just show
+                // the snackbar if the user is connected or actively connecting.
+                val isValidated = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                if (lastActivityValidatedState && !isValidated) {
+                    Log.w(TAG, "Activity: network lost VALIDATED")
+                    runOnUiThread {
+                        if (connectionState is AppConnectionState.Connected ||
+                            connectionState is AppConnectionState.Connecting) {
+                            showErrorSnackbar(
+                                message = "Network has no internet access",
+                                errorType = ErrorType.NETWORK
+                            )
+                        }
+                    }
+                }
+                lastActivityValidatedState = isValidated
             }
 
             override fun onLost(network: Network) {

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -347,7 +347,12 @@ class PlaybackService : MediaLibraryService() {
     // captive portal, DNS hijack). onLost() does not fire in that case, so we watch
     // for a VALIDATED=true->false transition in onCapabilitiesChanged and debounce
     // briefly to ride through roaming probe flickers.
-    private var lastValidatedState: Boolean = true
+    //
+    // @Volatile: written from a binder thread (NetworkCallback) and read from the
+    // main looper (validationLossRunnable). Null means "no prior state" -- first
+    // callback, no transition to compare against yet.
+    @Volatile
+    private var lastValidatedState: Boolean? = null
 
     // AudioManager for device volume control (Spotify-style hybrid approach)
     private var audioManager: AudioManager? = null
@@ -363,7 +368,7 @@ class PlaybackService : MediaLibraryService() {
     // Posted from onCapabilitiesChanged and cancelled if VALIDATED returns true before
     // the debounce elapses (which is common during WiFi roaming / probe retries).
     private val validationLossRunnable = Runnable {
-        if (!lastValidatedState) {
+        if (lastValidatedState == false) {
             Log.w(TAG, "Validation loss confirmed after debounce - notifying client")
             sendSpinClient?.setNetworkAvailable(false)
         }
@@ -416,11 +421,13 @@ class PlaybackService : MediaLibraryService() {
             val wasValidated = lastValidatedState
             lastValidatedState = isValidated
 
-            if (wasValidated && !isValidated) {
+            // Skip transition logic on the first callback (wasValidated == null) - we have
+            // no "previous state" to compare against, so there is no transition yet.
+            if (wasValidated == true && !isValidated) {
                 Log.w(TAG, "Network lost VALIDATED - debouncing ${VALIDATION_LOSS_DEBOUNCE_MS}ms")
                 mainHandler.removeCallbacks(validationLossRunnable)
                 mainHandler.postDelayed(validationLossRunnable, VALIDATION_LOSS_DEBOUNCE_MS)
-            } else if (!wasValidated && isValidated) {
+            } else if (wasValidated == false && isValidated) {
                 Log.i(TAG, "Network regained VALIDATED")
                 mainHandler.removeCallbacks(validationLossRunnable)
                 // setNetworkAvailable(true) triggers immediate reconnect via

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -342,6 +342,13 @@ class PlaybackService : MediaLibraryService() {
     private var lastNetworkId: Int = -1
     private var networkEvaluator: NetworkEvaluator? = null
 
+    // VALIDATED capability tracking: Android may keep NET_CAPABILITY_INTERNET set
+    // while dropping NET_CAPABILITY_VALIDATED (e.g., WiFi associated but no upstream,
+    // captive portal, DNS hijack). onLost() does not fire in that case, so we watch
+    // for a VALIDATED=true->false transition in onCapabilitiesChanged and debounce
+    // briefly to ride through roaming probe flickers.
+    private var lastValidatedState: Boolean = true
+
     // AudioManager for device volume control (Spotify-style hybrid approach)
     private var audioManager: AudioManager? = null
     private var volumeObserver: ContentObserver? = null
@@ -351,6 +358,16 @@ class PlaybackService : MediaLibraryService() {
     // Audio focus management - required for Android Auto to hand over audio output
     private var audioFocusRequest: AudioFocusRequest? = null
     private var hasAudioFocus: Boolean = false
+
+    // Runnable fired after VALIDATION_LOSS_DEBOUNCE_MS if VALIDATED has stayed false.
+    // Posted from onCapabilitiesChanged and cancelled if VALIDATED returns true before
+    // the debounce elapses (which is common during WiFi roaming / probe retries).
+    private val validationLossRunnable = Runnable {
+        if (!lastValidatedState) {
+            Log.w(TAG, "Validation loss confirmed after debounce - notifying client")
+            sendSpinClient?.setNetworkAvailable(false)
+        }
+    }
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
@@ -378,6 +395,8 @@ class PlaybackService : MediaLibraryService() {
             // Don't reset lastNetworkId here - we want to detect when a new network comes up
             // Update network evaluator to reflect disconnected state
             networkEvaluator?.evaluateCurrentNetwork(null)
+            // Cancel any pending validation-loss debounce; onLost is authoritative.
+            mainHandler.removeCallbacks(validationLossRunnable)
             // Notify client so reconnection pauses instead of wasting attempts
             sendSpinClient?.setNetworkAvailable(false)
         }
@@ -386,6 +405,28 @@ class PlaybackService : MediaLibraryService() {
             // Re-evaluate network conditions when capabilities change (e.g., signal strength)
             Log.d(TAG, "Network capabilities changed: id=${network.hashCode()}")
             networkEvaluator?.evaluateCurrentNetwork(network)
+
+            // Track NET_CAPABILITY_VALIDATED. A true->false transition means the
+            // network is still associated but Android's validation probe failed --
+            // e.g., walked out of WiFi range (association persists briefly),
+            // captive portal, DNS hijack, or upstream outage. In that case onLost()
+            // will not fire, so without this check the WebSocket sits open until
+            // ping timeout (~30s) long after the audio buffer drained.
+            val isValidated = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            val wasValidated = lastValidatedState
+            lastValidatedState = isValidated
+
+            if (wasValidated && !isValidated) {
+                Log.w(TAG, "Network lost VALIDATED - debouncing ${VALIDATION_LOSS_DEBOUNCE_MS}ms")
+                mainHandler.removeCallbacks(validationLossRunnable)
+                mainHandler.postDelayed(validationLossRunnable, VALIDATION_LOSS_DEBOUNCE_MS)
+            } else if (!wasValidated && isValidated) {
+                Log.i(TAG, "Network regained VALIDATED")
+                mainHandler.removeCallbacks(validationLossRunnable)
+                // setNetworkAvailable(true) triggers immediate reconnect via
+                // onNetworkAvailable() per SendSpinClient.kt (no-op if already connected).
+                sendSpinClient?.setNetworkAvailable(true)
+            }
         }
     }
 
@@ -401,6 +442,12 @@ class PlaybackService : MediaLibraryService() {
 
         // Debug logging interval (1 sample per second)
         private const val DEBUG_LOG_INTERVAL_MS = 1000L
+
+        // Debounce before acting on NET_CAPABILITY_VALIDATED loss. Android's
+        // validation probe can flicker briefly during WiFi roaming or captive-portal
+        // probes; 3s rides through those while still firing well before the ~30s
+        // WebSocket ping timeout would otherwise notice a silent WiFi drop.
+        private const val VALIDATION_LOSS_DEBOUNCE_MS = 3_000L
 
         // Custom session commands
         const val COMMAND_CONNECT = "com.sendspindroid.CONNECT"
@@ -682,6 +729,9 @@ class PlaybackService : MediaLibraryService() {
      * Unregisters the network callback.
      */
     private fun unregisterNetworkCallback() {
+        // Cancel any pending validation-loss debounce so it cannot fire after
+        // the service has torn down its callback/client state.
+        mainHandler.removeCallbacks(validationLossRunnable)
         try {
             connectivityManager?.unregisterNetworkCallback(networkCallback)
             Log.d(TAG, "Network callback unregistered")

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -38,6 +38,7 @@ import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import javax.net.ssl.SSLHandshakeException
 
 /**
@@ -81,6 +82,12 @@ class SendSpinClient(
         private const val INITIAL_RECONNECT_DELAY_MS = 500L // 500ms (was 1s)
         private const val MAX_RECONNECT_DELAY_MS = 10000L // 10 seconds (was 30s)
         private const val HIGH_POWER_RECONNECT_DELAY_MS = 30_000L // 30s steady-state for high power mode
+
+        // Stall watchdog: while connected+handshake-complete, if no bytes arrive for
+        // this long, force-close the transport so the existing reconnect path kicks in.
+        // Shorter than Ktor's 30s ping-timeout to beat buffer drain.
+        private const val STALL_TIMEOUT_MS = 7_000L
+        private const val STALL_CHECK_INTERVAL_MS = 3_000L
 
     }
 
@@ -174,6 +181,11 @@ class SendSpinClient(
     // When network is unavailable, reconnect attempts are paused (not wasted)
     private val networkAvailable = AtomicBoolean(true)
     private val waitingForNetwork = AtomicBoolean(false)
+
+    // Stall watchdog state. lastByteReceivedAtMs is updated on EVERY text/binary
+    // message from the transport. stallWatchdogJob is the polling coroutine.
+    private val lastByteReceivedAtMs = AtomicLong(System.currentTimeMillis())
+    private var stallWatchdogJob: Job? = null
 
     val isConnected: Boolean
         get() = _connectionState.value is ConnectionState.Connected
@@ -525,6 +537,8 @@ class SendSpinClient(
         transport?.setListener(null)
         transport?.destroy()
         transport = null
+
+        startStallWatchdog()
     }
 
     /**
@@ -604,6 +618,7 @@ class SendSpinClient(
      * Disconnect from the current server.
      */
     fun disconnect() {
+        stopStallWatchdog()
         Log.d(TAG, "Disconnecting (user-initiated)")
         userInitiatedDisconnect.set(true)
 
@@ -635,6 +650,7 @@ class SendSpinClient(
      * Clean up resources.
      */
     fun destroy() {
+        stopStallWatchdog()
         stopTimeSync()
         userInitiatedDisconnect.set(true)
 
@@ -678,6 +694,52 @@ class SendSpinClient(
     }
 
     /**
+     * Start the stall watchdog. Called when the connection reaches a state where
+     * we expect data to be flowing. Cancels any previous instance.
+     */
+    private fun startStallWatchdog() {
+        stallWatchdogJob?.cancel()
+        // Reset so we don't false-trip using a stale pre-handshake timestamp
+        lastByteReceivedAtMs.set(System.currentTimeMillis())
+        stallWatchdogJob = scope.launch {
+            while (true) {
+                delay(STALL_CHECK_INTERVAL_MS)
+                checkStall()
+            }
+        }
+    }
+
+    /**
+     * Stop the stall watchdog. Called on disconnect or during reconnect attempts.
+     */
+    private fun stopStallWatchdog() {
+        stallWatchdogJob?.cancel()
+        stallWatchdogJob = null
+    }
+
+    /**
+     * Check whether the transport has gone silent for too long and force-close it
+     * if so. Only acts when the client is connected, handshake is complete, and we
+     * are not already in a reconnect cycle.
+     *
+     * Private for production; reached via reflection from SendSpinClientStallWatchdogTest.
+     */
+    private fun checkStall() {
+        if (userInitiatedDisconnect.get()) return
+        if (reconnecting.get()) return
+        if (!handshakeComplete) return
+        val t = transport ?: return
+        if (!t.isConnected) return
+
+        val sinceLastByte = System.currentTimeMillis() - lastByteReceivedAtMs.get()
+        if (sinceLastByte > STALL_TIMEOUT_MS) {
+            Log.w(TAG, "Stall watchdog: no data received in ${sinceLastByte}ms (threshold ${STALL_TIMEOUT_MS}ms) - forcing transport close")
+            // 1001 "Going Away" is non-1000 so onClosed path triggers reconnection
+            t.close(1001, "stall watchdog")
+        }
+    }
+
+    /**
      * Attempt reconnection with exponential backoff.
      *
      * Smart reconnection: if network is unavailable, pauses without consuming attempts.
@@ -710,6 +772,7 @@ class SendSpinClient(
             timeFilter.freeze()
             Log.i(TAG, "Time filter frozen for reconnection (had ${timeFilter.measurementCountValue} measurements)")
         }
+        stopStallWatchdog()  // watchdog restarts on next successful handshake via prepareForConnection
 
         // Check attempt limits - high power mode allows infinite retries
         val maxAttempts = if (UserSettings.highPowerMode) Int.MAX_VALUE else MAX_RECONNECT_ATTEMPTS
@@ -874,6 +937,7 @@ class SendSpinClient(
         }
 
         override fun onMessage(text: String) {
+            lastByteReceivedAtMs.set(System.currentTimeMillis())
             // Check for auth failure (server may send error if token is invalid)
             if (connectionMode == ConnectionMode.PROXY && !handshakeComplete) {
                 try {
@@ -907,6 +971,7 @@ class SendSpinClient(
         }
 
         override fun onMessage(bytes: ByteArray) {
+            lastByteReceivedAtMs.set(System.currentTimeMillis())
             handleBinaryMessage(bytes)
         }
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -797,8 +797,7 @@ class SendSpinClient(
                 .coerceAtMost(MAX_RECONNECT_DELAY_MS)
         }
 
-        val attemptsDisplay = "$attempts"
-        Log.i(TAG, "Attempting reconnection $attemptsDisplay in ${delayMs}ms")
+        Log.i(TAG, "Attempting reconnection $attempts in ${delayMs}ms")
         reconnecting.set(true)
         _connectionState.value = ConnectionState.Connecting
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -775,18 +775,6 @@ class SendSpinClient(
         }
         stopStallWatchdog()  // watchdog restarts on next successful handshake via prepareForConnection
 
-        // Check attempt limits - high power mode allows infinite retries
-        val maxAttempts = if (UserSettings.highPowerMode) Int.MAX_VALUE else MAX_RECONNECT_ATTEMPTS
-        if (attempts > maxAttempts) {
-            Log.w(TAG, "Max reconnection attempts ($MAX_RECONNECT_ATTEMPTS) reached, giving up")
-            reconnecting.set(false)
-            timeFilter.resetAndDiscard()
-            _connectionState.value = ConnectionState.Error("Connection lost. Please reconnect manually.")
-            callback.onError("Connection lost after $MAX_RECONNECT_ATTEMPTS reconnection attempts")
-            callback.onDisconnected(wasUserInitiated = false, wasReconnectExhausted = true)
-            return
-        }
-
         // If network is unavailable, pause without wasting an attempt
         // setNetworkAvailable(true) will resume via onNetworkAvailable()
         if (!networkAvailable.get()) {
@@ -799,15 +787,17 @@ class SendSpinClient(
             return
         }
 
-        // Exponential backoff for first 5 attempts, then steady 30s in high power mode
-        val delayMs = if (UserSettings.highPowerMode && attempts > MAX_RECONNECT_ATTEMPTS) {
+        // Exponential backoff for first 5 attempts, then 30s steady-state forever.
+        // Applies in both normal and high power mode - the user can always disconnect
+        // manually if they're done listening.
+        val delayMs = if (attempts > MAX_RECONNECT_ATTEMPTS) {
             HIGH_POWER_RECONNECT_DELAY_MS
         } else {
             (INITIAL_RECONNECT_DELAY_MS * (1 shl (attempts - 1)))
                 .coerceAtMost(MAX_RECONNECT_DELAY_MS)
         }
 
-        val attemptsDisplay = if (UserSettings.highPowerMode) "$attempts" else "$attempts/$MAX_RECONNECT_ATTEMPTS"
+        val attemptsDisplay = "$attempts"
         Log.i(TAG, "Attempting reconnection $attemptsDisplay in ${delayMs}ms")
         reconnecting.set(true)
         _connectionState.value = ConnectionState.Connecting

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -258,6 +258,7 @@ class SendSpinClient(
         }
 
         callback.onConnected(serverName)
+        startStallWatchdog()  // (re)start watchdog now that we have a live handshake-complete session
     }
 
     override fun onMetadataUpdate(metadata: TrackMetadata) {
@@ -538,8 +539,6 @@ class SendSpinClient(
         transport?.setListener(null)
         transport?.destroy()
         transport = null
-
-        startStallWatchdog()
     }
 
     /**
@@ -743,8 +742,9 @@ class SendSpinClient(
     /**
      * Attempt reconnection with exponential backoff.
      *
-     * Smart reconnection: if network is unavailable, pauses without consuming attempts.
-     * High Power Mode: infinite retry with 30s steady-state interval.
+     * Exponential backoff for the first 5 attempts (500ms -> 8s), then 30s
+     * steady-state retries forever. Applies in both normal and high-power mode.
+     * If network is unavailable, pauses without consuming an attempt.
      */
     private fun attemptReconnect() {
         val savedServerName = serverName ?: serverAddress ?: remoteId ?: "Unknown"
@@ -773,7 +773,7 @@ class SendSpinClient(
             timeFilter.freeze()
             Log.i(TAG, "Time filter frozen for reconnection (had ${timeFilter.measurementCountValue} measurements)")
         }
-        stopStallWatchdog()  // watchdog restarts on next successful handshake via prepareForConnection
+        stopStallWatchdog()  // watchdog restarts on next successful handshake via onHandshakeComplete
 
         // If network is unavailable, pause without wasting an attempt
         // setNetworkAvailable(true) will resume via onNetworkAvailable()

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -185,6 +185,7 @@ class SendSpinClient(
     // Stall watchdog state. lastByteReceivedAtMs is updated on EVERY text/binary
     // message from the transport. stallWatchdogJob is the polling coroutine.
     private val lastByteReceivedAtMs = AtomicLong(System.currentTimeMillis())
+    @Volatile
     private var stallWatchdogJob: Job? = null
 
     val isConnected: Boolean

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -188,6 +188,11 @@ class SendSpinClient(
     @Volatile
     private var stallWatchdogJob: Job? = null
 
+    // True while a server-announced audio stream is active. The stall watchdog
+    // only trips while streaming - during idle (no stream) the server may send
+    // nothing for long periods, which would cause false-positive stalls.
+    private val streamActive = AtomicBoolean(false)
+
     val isConnected: Boolean
         get() = _connectionState.value is ConnectionState.Connected
 
@@ -258,6 +263,7 @@ class SendSpinClient(
         }
 
         callback.onConnected(serverName)
+        streamActive.set(false)  // fresh handshake - wait for server to announce stream state
         startStallWatchdog()  // (re)start watchdog now that we have a live handshake-complete session
     }
 
@@ -290,6 +296,11 @@ class SendSpinClient(
     }
 
     override fun onStreamStart(config: StreamConfig) {
+        streamActive.set(true)
+        // Reset so we don't false-trip from any stale timestamp accumulated while
+        // the stream was inactive (we were not expecting data then).
+        lastByteReceivedAtMs.set(System.currentTimeMillis())
+
         val preferredCodec = UserSettings.getPreferredCodec()
         Log.i(TAG, "Stream started: server chose codec=${config.codec} (we preferred=$preferredCodec)")
         callback.onStreamStart(
@@ -302,10 +313,12 @@ class SendSpinClient(
     }
 
     override fun onStreamClear() {
+        streamActive.set(false)
         callback.onStreamClear()
     }
 
     override fun onStreamEnd() {
+        streamActive.set(false)
         callback.onStreamEnd()
     }
 
@@ -719,8 +732,10 @@ class SendSpinClient(
 
     /**
      * Check whether the transport has gone silent for too long and force-close it
-     * if so. Only acts when the client is connected, handshake is complete, and we
-     * are not already in a reconnect cycle.
+     * if so. Only acts when the client is connected, handshake is complete, a
+     * stream is active (server has announced stream/start and not stream/stop),
+     * and we are not already in a reconnect cycle. Keeps the watchdog from
+     * false-tripping during idle periods when the server has nothing to send.
      *
      * Private for production; reached via reflection from SendSpinClientStallWatchdogTest.
      */
@@ -730,6 +745,9 @@ class SendSpinClient(
         if (!handshakeComplete) return
         val t = transport ?: return
         if (!t.isConnected) return
+        // Don't trip during idle - server may send nothing between streams, and
+        // WebSocket pings (which keep the socket alive) don't update lastByteReceivedAtMs.
+        if (!streamActive.get()) return
 
         val sinceLastByte = System.currentTimeMillis() - lastByteReceivedAtMs.get()
         if (sinceLastByte > STALL_TIMEOUT_MS) {

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -34,6 +34,7 @@ abstract class SendSpinProtocolHandler(
     protected val tag: String
 ) {
     // Protocol state
+    @Volatile
     protected var handshakeComplete = false
     protected var currentVolume: Int = 100
     protected var currentMuted: Boolean = false

--- a/android/app/src/test/java/com/sendspindroid/e2e/NetworkLossDrainingReconnectTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/e2e/NetworkLossDrainingReconnectTest.kt
@@ -189,28 +189,33 @@ class NetworkLossDrainingReconnectTest : E2ETestBase() {
     }
 
     @Test
-    fun `max reconnect attempts reached triggers exhausted callback`() {
+    fun `reconnect beyond old 5-attempt cap keeps retrying in normal mode`() {
+        // The 5-attempt cap was removed: both normal and high power mode now
+        // retry forever with 30s steady-state after attempt 5. There is no
+        // exhausted-callback path any more -- the user has to disconnect
+        // manually (or the reconnect succeeds) to exit reconnection state.
         connectAndHandshake()
 
-        // Manually set attempt counter near max
+        // Start past the old cap
         setAtomicInteger(client, "reconnectAttempts", 5)
 
-        // Trigger one more reconnection - should exceed max (5)
+        // Trigger another reconnection - in the old code this would exhaust
         fakeTransport.simulateFailure(
             error = SocketException("Connection reset"),
             isRecoverable = true
         )
 
-        // Should report exhausted reconnection
-        verify {
+        // Must NOT report exhausted reconnection any more
+        verify(exactly = 0) {
             mockCallback.onDisconnected(wasUserInitiated = false, wasReconnectExhausted = true)
         }
 
-        // Connection state should be Error
+        // Should still be reconnecting, not in Error state
+        verify { mockCallback.onReconnecting(any(), any()) }
         val state = client.connectionState.value
         assertTrue(
-            "State should be Error after exhausting reconnection attempts",
-            state is SendSpinClient.ConnectionState.Error
+            "State should remain Connecting with no cap, was: $state",
+            state is SendSpinClient.ConnectionState.Connecting
         )
     }
 

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientReconnectBackoffTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientReconnectBackoffTest.kt
@@ -139,35 +139,62 @@ class SendSpinClientReconnectBackoffTest {
     }
 
     @Test
-    fun `max 5 reconnect attempts in normal mode`() {
+    fun `normal mode retries forever without triggering exhausted error`() {
         setupForReconnection()
         every { UserSettings.highPowerMode } returns false
 
         val attemptReconnect = SendSpinClient::class.java.getDeclaredMethod("attemptReconnect")
         attemptReconnect.isAccessible = true
 
-        // Perform 5 attempts (all should proceed)
-        for (i in 1..5) {
+        // Perform 10 attempts - all should succeed in normal mode now
+        for (i in 1..10) {
             attemptReconnect.invoke(client)
         }
 
-        // Verify 5 onReconnecting calls were made
-        verify(exactly = 5) {
-            mockCallback.onReconnecting(any(), any())
-        }
-
-        // 6th attempt should exceed max and trigger error
-        attemptReconnect.invoke(client)
-
-        verify(exactly = 1) {
+        // Should NOT have called onDisconnected with wasReconnectExhausted=true
+        verify(exactly = 0) {
             mockCallback.onDisconnected(wasUserInitiated = false, wasReconnectExhausted = true)
         }
 
-        // State should be Error
+        // All 10 should have been onReconnecting calls
+        verify(exactly = 10) {
+            mockCallback.onReconnecting(any(), any())
+        }
+
+        // State should remain Connecting (not Error)
         assertTrue(
-            "State should be Error after max attempts exceeded",
-            client.connectionState.value is SendSpinClient.ConnectionState.Error
+            "State should remain Connecting in normal mode with no cap, was: ${client.connectionState.value}",
+            client.connectionState.value is SendSpinClient.ConnectionState.Connecting
         )
+    }
+
+    @Test
+    fun `normal mode uses 30s steady-state delay after attempt 5`() {
+        // Verify the delay formula selects the steady-state path for attempts > 5
+        // regardless of highPowerMode setting. The formula we expect in SendSpinClient:
+        //   val delayMs = if (attempts > MAX_RECONNECT_ATTEMPTS) HIGH_POWER_RECONNECT_DELAY_MS
+        //                 else (INITIAL_RECONNECT_DELAY_MS * (1 shl (attempts - 1)))
+        //                         .coerceAtMost(MAX_RECONNECT_DELAY_MS)
+
+        val initialDelay = 500L
+        val maxDelay = 10_000L
+        val steadyStateDelay = 30_000L
+
+        for (attempt in 1..5) {
+            val computed = (initialDelay * (1 shl (attempt - 1))).coerceAtMost(maxDelay)
+            val expected = when (attempt) {
+                1 -> 500L; 2 -> 1000L; 3 -> 2000L; 4 -> 4000L; 5 -> 8000L
+                else -> fail("unreachable") as Long
+            }
+            assertEquals("Attempt $attempt should use exponential backoff", expected, computed)
+        }
+
+        // Attempt 6+ should use steady-state 30s
+        for (attempt in 6..10) {
+            val computed = if (attempt > 5) steadyStateDelay
+                           else (initialDelay * (1 shl (attempt - 1))).coerceAtMost(maxDelay)
+            assertEquals("Attempt $attempt should use 30s steady-state", steadyStateDelay, computed)
+        }
     }
 
     @Test

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientReconnectBackoffTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientReconnectBackoffTest.kt
@@ -26,10 +26,10 @@ import org.junit.Test
 
 /**
  * Tests that reconnection uses exponential backoff with the correct delays
- * and respects the max attempt limit (normal mode) and high power mode behavior.
+ * and that both normal and high-power modes retry indefinitely.
  *
- * Expected delay sequence: 500ms, 1s, 2s, 4s, 8s with max 5 attempts.
- * High power mode: infinite retries, 30s steady-state after 5th attempt.
+ * Expected delay sequence: 500ms, 1s, 2s, 4s, 8s.
+ * Both normal and high-power mode: infinite retries, 30s steady-state after the 5th attempt.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class SendSpinClientReconnectBackoffTest {

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientStallWatchdogTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientStallWatchdogTest.kt
@@ -1,0 +1,193 @@
+package com.sendspindroid.sendspin
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.preference.PreferenceManager
+import com.sendspindroid.UserSettings
+import com.sendspindroid.sendspin.decoder.AudioDecoderFactory
+import com.sendspindroid.sendspin.transport.SendSpinTransport
+import com.sendspindroid.sendspin.transport.TransportState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SendSpinClientStallWatchdogTest {
+
+    private lateinit var mockContext: Context
+    private lateinit var mockCallback: SendSpinClient.Callback
+    private lateinit var client: SendSpinClient
+    private lateinit var fakeTransport: FakeTransport
+
+    private class FakeTransport : SendSpinTransport {
+        var closeCalled = false
+        var closeCode: Int = -1
+        override val state = TransportState.Connected
+        override val isConnected = true
+        override fun connect() {}
+        override fun send(text: String) = true
+        override fun send(bytes: ByteArray) = true
+        override fun setListener(listener: SendSpinTransport.Listener?) {}
+        override fun close(code: Int, reason: String) {
+            closeCalled = true
+            closeCode = code
+        }
+        override fun destroy() {}
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+
+        mockkStatic(Log::class)
+        every { Log.v(any(), any()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.e(any(), any<String>()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+
+        mockkObject(UserSettings)
+        every { UserSettings.getPlayerId() } returns "test-player-id"
+        every { UserSettings.getPreferredCodec() } returns "opus"
+        every { UserSettings.lowMemoryMode } returns false
+        every { UserSettings.highPowerMode } returns false
+
+        mockkObject(AudioDecoderFactory)
+        every { AudioDecoderFactory.isCodecSupported(any()) } returns true
+
+        mockkStatic(PreferenceManager::class)
+        val mockPrefs = mockk<SharedPreferences>(relaxed = true)
+        every { PreferenceManager.getDefaultSharedPreferences(any()) } returns mockPrefs
+
+        mockContext = mockk(relaxed = true)
+        mockCallback = mockk(relaxed = true)
+
+        client = SendSpinClient(mockContext, "TestDevice", mockCallback)
+        fakeTransport = FakeTransport()
+
+        // Put client in a "connected + handshake complete" state
+        val addrField = SendSpinClient::class.java.getDeclaredField("serverAddress")
+        addrField.isAccessible = true
+        addrField.set(client, "127.0.0.1:8080")
+
+        val transportField = SendSpinClient::class.java.getDeclaredField("transport")
+        transportField.isAccessible = true
+        transportField.set(client, fakeTransport)
+
+        val handshakeField = SendSpinClient::class.java.superclass.getDeclaredField("handshakeComplete")
+        handshakeField.isAccessible = true
+        handshakeField.set(client, true)
+    }
+
+    @After
+    fun tearDown() {
+        client.destroy()
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `lastByteReceivedAtMs is updated on text message`() {
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as AtomicLong
+
+        val before = atomicLong.get()
+        Thread.sleep(10)
+
+        val listener = buildTransportListener()
+        listener.onMessage("{\"type\":\"ping\"}")
+
+        val after = atomicLong.get()
+        assertTrue("lastByteReceivedAtMs should advance on text message (before=$before after=$after)",
+            after > before)
+    }
+
+    @Test
+    fun `lastByteReceivedAtMs is updated on binary message`() {
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as AtomicLong
+
+        val before = atomicLong.get()
+        Thread.sleep(10)
+
+        val listener = buildTransportListener()
+        listener.onMessage(byteArrayOf(0, 1, 2, 3))
+
+        val after = atomicLong.get()
+        assertTrue("lastByteReceivedAtMs should advance on binary message (before=$before after=$after)",
+            after > before)
+    }
+
+    @Test
+    fun `checkStall forces transport close when stalled past timeout`() {
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as AtomicLong
+        atomicLong.set(System.currentTimeMillis() - 60_000L)  // 60s in the past
+
+        val checkStall = SendSpinClient::class.java.getDeclaredMethod("checkStall")
+        checkStall.isAccessible = true
+        checkStall.invoke(client)
+
+        assertTrue("Watchdog should have called transport.close()", fakeTransport.closeCalled)
+        assertNotEquals(1000, fakeTransport.closeCode)  // non-1000 triggers reconnect
+    }
+
+    @Test
+    fun `checkStall does not close when recently active`() {
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as AtomicLong
+        atomicLong.set(System.currentTimeMillis())  // just now
+
+        val checkStall = SendSpinClient::class.java.getDeclaredMethod("checkStall")
+        checkStall.isAccessible = true
+        checkStall.invoke(client)
+
+        assertFalse("Watchdog should NOT close when data was recently received", fakeTransport.closeCalled)
+    }
+
+    @Test
+    fun `checkStall does not close during active reconnection`() {
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as AtomicLong
+        atomicLong.set(System.currentTimeMillis() - 60_000L)
+
+        val reconnectingField = SendSpinClient::class.java.getDeclaredField("reconnecting")
+        reconnectingField.isAccessible = true
+        val reconnecting = reconnectingField.get(client) as AtomicBoolean
+        reconnecting.set(true)
+
+        val checkStall = SendSpinClient::class.java.getDeclaredMethod("checkStall")
+        checkStall.isAccessible = true
+        checkStall.invoke(client)
+
+        assertFalse("Watchdog should NOT close during reconnection", fakeTransport.closeCalled)
+    }
+
+    private fun buildTransportListener(): SendSpinTransport.Listener {
+        val innerClasses = SendSpinClient::class.java.declaredClasses
+        val listenerClass = innerClasses.find { it.simpleName == "TransportEventListener" }!!
+        val constructor = listenerClass.getDeclaredConstructor(SendSpinClient::class.java)
+        constructor.isAccessible = true
+        return constructor.newInstance(client) as SendSpinTransport.Listener
+    }
+}

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientStallWatchdogTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientStallWatchdogTest.kt
@@ -183,6 +183,42 @@ class SendSpinClientStallWatchdogTest {
         assertFalse("Watchdog should NOT close during reconnection", fakeTransport.closeCalled)
     }
 
+    @Test
+    fun `watchdog restarts after onHandshakeComplete so a second stall is detected`() {
+        // Simulate the post-reconnect state: stop the watchdog (as attemptReconnect does),
+        // then fire onHandshakeComplete and verify the watchdog job is active again.
+
+        // Force-start the watchdog (as if from a prior connect), then stop it (as if from
+        // attemptReconnect at line 776).
+        val startWatchdog = SendSpinClient::class.java.getDeclaredMethod("startStallWatchdog")
+        startWatchdog.isAccessible = true
+        startWatchdog.invoke(client)
+
+        val stopWatchdog = SendSpinClient::class.java.getDeclaredMethod("stopStallWatchdog")
+        stopWatchdog.isAccessible = true
+        stopWatchdog.invoke(client)
+
+        // Verify the job is null after stop
+        val jobField = SendSpinClient::class.java.getDeclaredField("stallWatchdogJob")
+        jobField.isAccessible = true
+        assertNull("stallWatchdogJob should be null after stop", jobField.get(client))
+
+        // Now simulate onHandshakeComplete firing - this is what happens after a
+        // reconnect succeeds. We call it through the superclass since the method is
+        // declared on SendSpinProtocolHandler and overridden in SendSpinClient.
+        val handshakeMethod = SendSpinClient::class.java.getDeclaredMethod(
+            "onHandshakeComplete", String::class.java, String::class.java
+        )
+        handshakeMethod.isAccessible = true
+        handshakeMethod.invoke(client, "TestServer", "test-server-id")
+
+        // Verify the watchdog job exists again and is active
+        val newJob = jobField.get(client) as? kotlinx.coroutines.Job
+        assertNotNull("stallWatchdogJob should be restarted by onHandshakeComplete", newJob)
+        assertTrue("stallWatchdogJob should be active after onHandshakeComplete",
+            newJob!!.isActive)
+    }
+
     private fun buildTransportListener(): SendSpinTransport.Listener {
         val innerClasses = SendSpinClient::class.java.declaredClasses
         val listenerClass = innerClasses.find { it.simpleName == "TransportEventListener" }!!

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientStallWatchdogTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientStallWatchdogTest.kt
@@ -141,6 +141,9 @@ class SendSpinClientStallWatchdogTest {
         lastByteField.isAccessible = true
         val atomicLong = lastByteField.get(client) as AtomicLong
         atomicLong.set(System.currentTimeMillis() - 60_000L)  // 60s in the past
+        val streamActiveField = SendSpinClient::class.java.getDeclaredField("streamActive")
+        streamActiveField.isAccessible = true
+        (streamActiveField.get(client) as AtomicBoolean).set(true)
 
         val checkStall = SendSpinClient::class.java.getDeclaredMethod("checkStall")
         checkStall.isAccessible = true
@@ -217,6 +220,51 @@ class SendSpinClientStallWatchdogTest {
         assertNotNull("stallWatchdogJob should be restarted by onHandshakeComplete", newJob)
         assertTrue("stallWatchdogJob should be active after onHandshakeComplete",
             newJob!!.isActive)
+    }
+
+    @Test
+    fun `checkStall does not close when no stream is active`() {
+        // Seed a stale timestamp that would normally trip the watchdog
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as AtomicLong
+        atomicLong.set(System.currentTimeMillis() - 60_000L)
+
+        // Ensure streamActive is false (it defaults to false, but be explicit)
+        val streamActiveField = SendSpinClient::class.java.getDeclaredField("streamActive")
+        streamActiveField.isAccessible = true
+        val streamActive = streamActiveField.get(client) as AtomicBoolean
+        streamActive.set(false)
+
+        val checkStall = SendSpinClient::class.java.getDeclaredMethod("checkStall")
+        checkStall.isAccessible = true
+        checkStall.invoke(client)
+
+        assertFalse("Watchdog should NOT close while no stream is active",
+            fakeTransport.closeCalled)
+    }
+
+    @Test
+    fun `checkStall closes when stream is active and stalled`() {
+        // Seed a stale timestamp
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as AtomicLong
+        atomicLong.set(System.currentTimeMillis() - 60_000L)
+
+        // Activate the stream
+        val streamActiveField = SendSpinClient::class.java.getDeclaredField("streamActive")
+        streamActiveField.isAccessible = true
+        val streamActive = streamActiveField.get(client) as AtomicBoolean
+        streamActive.set(true)
+
+        val checkStall = SendSpinClient::class.java.getDeclaredMethod("checkStall")
+        checkStall.isAccessible = true
+        checkStall.invoke(client)
+
+        assertTrue("Watchdog should close when stream is active and stalled",
+            fakeTransport.closeCalled)
+        assertNotEquals(1000, fakeTransport.closeCode)
     }
 
     private fun buildTransportListener(): SendSpinTransport.Listener {

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientTimeFilterFreezeTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientTimeFilterFreezeTest.kt
@@ -216,7 +216,12 @@ class SendSpinClientTimeFilterFreezeTest {
     }
 
     @Test
-    fun `time filter is reset and discarded when reconnect attempts exhausted`() {
+    fun `time filter stays frozen across many reconnect attempts in normal mode`() {
+        // After removing the 5-attempt cap, there is no exhaustion path in normal
+        // mode: the client retries forever and the time filter stays frozen so
+        // clock sync state is preserved across long outages. The filter only
+        // thaws on successful handshake (covered by the thaw tests above) or
+        // explicit disconnect.
         seedTimeFilter()
         setupForReconnection()
         every { UserSettings.highPowerMode } returns false
@@ -225,17 +230,13 @@ class SendSpinClientTimeFilterFreezeTest {
         val attemptReconnect = SendSpinClient::class.java.getDeclaredMethod("attemptReconnect")
         attemptReconnect.isAccessible = true
 
-        // Exhaust all 5 attempts
-        for (i in 1..5) {
+        // Perform many attempts, well past the old 5-attempt cap.
+        for (i in 1..10) {
             attemptReconnect.invoke(client)
         }
-        assertTrue("Should be frozen during reconnection", tf.isFrozen)
 
-        // 6th attempt should exhaust and call resetAndDiscard
-        attemptReconnect.invoke(client)
-
-        assertFalse(
-            "Time filter should not be frozen after exhaustion (resetAndDiscard clears frozen state)",
+        assertTrue(
+            "Time filter should remain frozen while still reconnecting (no exhaustion path)",
             tf.isFrozen
         )
     }


### PR DESCRIPTION
## Summary

Three-layered fix for the bug where the app shows "Connected" but audio cuts out with no recovery after a silent network loss -- the "walk outside and lose WiFi" scenario. Force-killing the app was the only way back. After this PR all three failure modes recover automatically.

**A. `NET_CAPABILITY_VALIDATED` loss detection** (`PlaybackService`, `MainActivity`)
Android keeps `NET_CAPABILITY_INTERNET` on a WiFi association that has lost real internet (out of range, captive portal, router dead, upstream hang). `onLost()` does not fire. We now watch `onCapabilitiesChanged` for a `VALIDATED: true -> false` edge, debounce 3s to absorb roaming flaps, then call `sendSpinClient.setNetworkAvailable(false)` which pauses reconnect attempts the same way `onLost()` already did. Fields are `@Volatile` + `Boolean?` null-initial so the first callback never spuriously trips.

**B. Application-level stall watchdog** (`SendSpinClient`)
TCP half-open can keep a socket looking alive for 30s+ until Ktor's ping timeout, long after the audio buffer drained. A 3s-poll coroutine tracks `lastByteReceivedAtMs` and force-closes the transport with code 1001 after 7s of silence -- routing through the existing `onClosed` reconnect path. Gated on `streamActive` so idle connections (no stream = no expected data) do not false-trip. Restarted on every successful handshake so it survives the full connect-reconnect-reconnect-... lifecycle.

**C. Unbounded reconnect** (`SendSpinClient`)
Normal mode previously gave up after 5 attempts (~15s) with a "Connection lost. Please reconnect manually." error -- but there is no manual-reconnect UI, so in practice users had to force-kill. Both normal and high-power mode now use the same policy: exponential backoff 500ms -> 8s for attempts 1-5, then 30s steady-state forever. Battery impact is negligible (2 req/min steady state).

## Issues Impacted

Fixes / significantly improves:
- **#23** ("Will not Auto reconnect to MA if you restart server") -- unbounded retry in C means the client reconnects automatically once MA comes back, no walking around to tap server tiles.
- **#14** ("No persistent server connecting") -- C covers the "app gives up after a timeout" case; B catches genuine connection death within 7s when a stream is active.
- **#114** ("Massive delays everywhere and constant breaking") -- the ~30s stale-state window matches the audio buffer. B should break the client out of the janky state faster when it is caused by a zombie connection. Not guaranteed to fix the underlying state-management issues.

## Test Plan

Automated: 562/562 unit tests pass, `assembleDebug` succeeds.

Manual verification on physical device:

- [ ] **Primary scenario:** Start playback, walk out of WiFi range. Within ~7s the "Reconnecting..." banner should appear (watchdog). Audio drains from buffer then stops. Walk back in range -- app reconnects within ~30s and playback resumes after re-sync. No force-kill needed.
- [ ] **MA server restart (#23):** Stop the Music Assistant service while client is connected, wait ~1 min, restart MA. Client should auto-reconnect with no user interaction.
- [ ] **Idle regression check:** Connect but do not start playback. Sit idle for 2+ minutes. Grep logcat for `Stall watchdog: no data received` -- should be absent. If present, the `streamActive` gate is not catching idle time.
- [ ] **Idle-to-play transition:** Sit idle 60s, then start playback. Audio should flow immediately without any watchdog trip at the transition.
- [ ] **Fast reconnect cycle:** Toggle WiFi off and on a few times while playing. Each cycle should recover cleanly (tests the watchdog-restarts-on-handshake fix, commit 42347fc).

## Follow-ups (deferred to future PRs)

D-G from the original plan at `docs/superpowers/plans/2026-04-20-connection-resilience-abc.md`:

- **D.** Manual "Reconnect now" button in UI (safety net for unforeseen failure modes)
- **E.** Auto-escalate LOCAL -> REMOTE/PROXY after N consecutive LOCAL failures (graceful degradation out of range)
- **F.** Loosen `isRecoverableError()` during post-network-transition DNS flaps
- **G.** Signal audio pipeline -> client on buffer underrun (more confident "stream is dead" signal)

## Commits

```
e501c4f fix: gate stall watchdog on active stream to avoid idle false-trips
42347fc fix: restart stall watchdog after each successful handshake
ffacb10 chore: clean up stale docstring and redundant log variable
d049c0a fix: retry reconnect forever in normal mode with 30s steady-state
16b9da4 fix: mark cross-thread watchdog state @Volatile
40defd9 feat: add application-level stall watchdog to SendSpinClient
55ab821 fix: address code review on VALIDATED loss detection
df2d15b fix: detect loss of NET_CAPABILITY_VALIDATED on active network
```