### PR TITLE
diag: instrument command path + close enterIdle streamGeneration gap (#114)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -1241,7 +1241,9 @@ class PlaybackService : MediaLibraryService() {
         }
 
         override fun onStreamClear() {
+            Log.i(TAG, "[cmd-trace] T2 onStreamClear ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name}")
             mainHandler.post {
+                Log.i(TAG, "[cmd-trace] T3 onStreamClear.post ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name}")
                 Log.d(TAG, "Stream clear - flushing audio and decoder buffers")
                 audioDecoder?.flush()
                 syncAudioPlayer?.clearBuffer()
@@ -1249,7 +1251,9 @@ class PlaybackService : MediaLibraryService() {
         }
 
         override fun onStreamEnd() {
+            Log.i(TAG, "[cmd-trace] T2 onStreamEnd ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name}")
             mainHandler.post {
+                Log.i(TAG, "[cmd-trace] T3 onStreamEnd.post ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name}")
                 Log.i(TAG, "Stream end - server terminated playback")
                 // Enter idle mode: keep AudioTrack alive and writing silence
                 // so DAC timestamps stay warm for the next stream start
@@ -1287,7 +1291,9 @@ class PlaybackService : MediaLibraryService() {
         }
 
         override fun onVolumeChanged(volume: Int) {
+            Log.i(TAG, "[cmd-trace] T2 onVolumeChanged ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name} vol=$volume")
             mainHandler.post {
+                Log.i(TAG, "[cmd-trace] T3 onVolumeChanged.post ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name} vol=$volume")
                 // Convert from 0-100 to 0.0-1.0 and apply to device volume
                 val volumeFloat = volume / 100f
                 setVolume(volumeFloat)  // Sets device STREAM_MUSIC volume
@@ -1789,6 +1795,7 @@ class PlaybackService : MediaLibraryService() {
 
         // Set device volume (no flags = silent, no UI popup)
         am.setStreamVolume(AudioManager.STREAM_MUSIC, newVolume, 0)
+        Log.i(TAG, "[cmd-trace] T4 setStreamVolume ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name} new=$newVolume max=$maxVolume")
     }
 
     /**

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -793,6 +793,15 @@ class SyncAudioPlayer(
      */
     fun enterIdle() {
         stateLock.withLock {
+            // Mirrors clearBuffer(): invalidate any queueChunk() invocations
+            // that are still in flight on the WebSocket IO thread. Without
+            // this, a chunk whose queueChunk() captured the pre-idle
+            // generation can re-populate the queue after the clears below
+            // run, leaving stale audio in the pipeline after stream/end.
+            streamGeneration++
+
+            Log.i(TAG, "[cmd-trace] T4 enterIdle ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name} gen=$streamGeneration")
+
             // Clear all audio buffers
             chunkQueue.clear()
             totalQueuedSamples.set(0)
@@ -1000,6 +1009,8 @@ class SyncAudioPlayer(
 
         stateLock.withLock {
             streamGeneration++
+
+            Log.i(TAG, "[cmd-trace] T4 clearBuffer ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name} gen=$streamGeneration")
 
             // Reset paused state - we're starting a fresh stream (e.g., after seek)
             // This ensures playback loop will process new chunks even if we were paused

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -381,6 +381,7 @@ abstract class SendSpinProtocolHandler(
     }
 
     protected fun handleServerCommand(payload: JsonObject?) {
+        Log.i(tag, "[cmd-trace] T1 handleServerCommand ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name}")
         when (val result = MessageParser.parseServerCommand(payload)) {
             is ServerCommandResult.Volume -> {
                 Log.d(tag, "Server command: set volume to ${result.volume}%")
@@ -431,11 +432,13 @@ abstract class SendSpinProtocolHandler(
     }
 
     protected fun handleStreamClear() {
+        Log.i(tag, "[cmd-trace] T1 handleStreamClear ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name}")
         Log.v(tag, "Stream clear - flushing audio buffers")
         onStreamClear()
     }
 
     protected fun handleStreamEnd(payload: JsonObject?) {
+        Log.i(tag, "[cmd-trace] T1 handleStreamEnd ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name}")
         val rolesArray = payload?.get("roles")?.jsonArray
         val roles = rolesArray?.map { it.jsonPrimitive.content }
 

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/BaseWebSocketTransport.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/BaseWebSocketTransport.kt
@@ -180,7 +180,11 @@ abstract class BaseWebSocketTransport(
                     try {
                         for (frame in incoming) {
                             when (frame) {
-                                is Frame.Text -> listener?.onMessage(frame.readText())
+                                is Frame.Text -> {
+                                    val txt = frame.readText()
+                                    Log.i(tag, "[cmd-trace] T0 wire-text len=${txt.length}")
+                                    listener?.onMessage(txt)
+                                }
                                 is Frame.Binary -> listener?.onMessage(frame.readBytes())
                                 is Frame.Close -> {
                                     val reason = closeReason.await()


### PR DESCRIPTION
## Summary

Diagnostic-first step at issue #114 ("Massive delays everywhere and
constant breaking"). The reporter sees ~30 s lag on every remote
command (volume, skip) against Music Assistant. Investigation ruled
out the easy hypotheses — the volume handler is correctly wired
(`PlaybackService.kt:1232` → `AudioManager.setStreamVolume`), aiosendspin
puts control messages on a priority queue that bypasses the
BufferTracker, and MA's `PushStream.stop()` does send `stream/end` on
cancel (`aiosendspin/server/push_stream.py:2043-2099` →
`roles/player/v1.py:359-367`). On paper the client should silence within
~10 ms of `stream/end` via `onStreamEnd` → `enterIdle()` →
`chunkQueue.clear()`. Yet the reporter observes 30 s of stale audio.

Rather than ship another guess, this PR is **instrumentation-first** so
one reproduction from the reporter pinpoints exactly where the 30 s is.
It also closes the one real asymmetry I found while investigating
(belt-and-braces, cheap).

### Part A — defensive fix

`clearBuffer()` bumps `streamGeneration++` to invalidate any
`queueChunk()` that was mid-processing on the WebSocket IO thread when
the clear fires. `enterIdle()` did not do this. In theory a chunk in
flight during the brief `onStreamEnd` → `mainHandler.post { enterIdle }`
window could re-populate `chunkQueue` after `enterIdle`'s
`chunkQueue.clear()` runs. Wire ordering (audio → stream/end → new
stream/start) makes that narrow in practice, but the asymmetry is real
and the fix is one line. Now `enterIdle()` and `clearBuffer()` share the
same generation-invalidation semantics.

### Part B — command-path instrumentation

Five `[cmd-trace]`-tagged `Log.i` points along the remote-command path:

| # | Point | File |
|---|-------|------|
| T0 | Text frame received on WebSocket | `BaseWebSocketTransport.kt` |
| T1 | Protocol-handler dispatch | `SendSpinProtocolHandler.kt` |
| T2 | PlaybackService callback entered | `PlaybackService.kt` |
| T3 | `mainHandler.post { }` body ran | `PlaybackService.kt` |
| T4 | Terminal action executed (setStreamVolume / enterIdle / clearBuffer) | PlaybackService.kt / SyncAudioPlayer.kt |

**No behavior change for successful-case playback** — pure observation.
Filter logcat on `[cmd-trace]` to extract a trace. Gaps between
consecutive T-numbers localize the delay:

- T0 is 30 s after the user's click → wire / server delay (open a
  follow-up against MA).
- T0 → T1 is 30 s → Ktor receive-loop starved.
- T2 → T3 is 30 s → main Looper backed up.
- T3 → T4 is 30 s → terminal call itself blocking.
- All timestamps tight yet stale audio continues → bug is downstream
  of `enterIdle`.

## Test plan

- [x] `./gradlew assembleDebug` clean compile on the modified worktree;
  no new compiler warnings on the four touched files (the three
  existing warnings are pre-existing and unrelated).
- [ ] Reporter (Jan Gutowski) installs the debug APK, reproduces the
  30 s lag with a remote volume change and a remote skip, and shares
  `adb logcat -s SendSpin:* PlaybackService:* SyncAudioPlayer:* BaseWebSocketTransport:* SendSpinProtocolHandler:* | grep cmd-trace`
  (or the unfiltered logcat covering the reproduction window).
- [ ] With the log in hand, open a focused follow-up fix targeting the
  specific inter-timestamp gap that contains the 30 s.

## Out of scope

- Any protocol change, buffer sizing, MediaSession data-source change.
- A fix for the "janky UI under rapid inputs" symptom — likely a
  second-order effect of whatever the primary delay turns out to be;
  will revisit after the diagnostic data lands.

Relates to #114.