### PR TITLE
fix: send WebSocket pings on OkHttp engine (#105)

### DIFF
--- a/android/shared/src/androidMain/kotlin/com/sendspindroid/sendspin/transport/HttpClientFactory.android.kt
+++ b/android/shared/src/androidMain/kotlin/com/sendspindroid/sendspin/transport/HttpClientFactory.android.kt
@@ -1,0 +1,39 @@
+package com.sendspindroid.sendspin.transport
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.websocket.WebSockets
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+/**
+ * Android `actual` for [createWebSocketHttpClient].
+ *
+ * Configures the ping interval on the underlying `OkHttpClient` rather than
+ * via Ktor's `install(WebSockets) { pingIntervalMillis = ... }` (which the
+ * OkHttp engine ignores per https://ktor.io/docs/client-websockets).
+ *
+ * OkHttp's `pingInterval` sends pings at the configured cadence AND
+ * auto-closes the socket if the peer fails to respond within the same
+ * interval. That close propagates up to Ktor's receive loop, which triggers
+ * the existing `TransportEventListener.onClosed` path and its
+ * infinite-backoff reconnect logic.
+ */
+internal actual fun createWebSocketHttpClient(
+    pingIntervalSeconds: Long,
+    connectTimeoutMs: Long,
+): HttpClient = HttpClient(OkHttp) {
+    engine {
+        preconfigured = OkHttpClient.Builder()
+            .pingInterval(pingIntervalSeconds, TimeUnit.SECONDS)
+            .build()
+    }
+    install(WebSockets)
+    install(HttpTimeout) {
+        connectTimeoutMillis = connectTimeoutMs
+        // No socket timeout for WebSocket (long-lived connection); ping/pong
+        // is the keepalive and dead-peer detector.
+        socketTimeoutMillis = Long.MAX_VALUE
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/transport/MaWebSocketTransport.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/transport/MaWebSocketTransport.kt
@@ -2,7 +2,6 @@ package com.sendspindroid.musicassistant.transport
 
 import com.sendspindroid.shared.log.Log
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
@@ -64,19 +63,17 @@ class MaWebSocketTransport(
 
         /**
          * Create a default Ktor HttpClient configured for MA WebSocket connections.
+         *
+         * Delegates to the platform-specific [createWebSocketHttpClient] — see that
+         * function's docs for why Ktor's `pingIntervalMillis` alone is insufficient.
          */
         fun createDefaultClient(
             pingIntervalSeconds: Long = 30,
             connectTimeoutMs: Long = 15000
-        ): HttpClient = HttpClient {
-            install(WebSockets) {
-                pingIntervalMillis = pingIntervalSeconds * 1000
-            }
-            install(io.ktor.client.plugins.HttpTimeout) {
-                connectTimeoutMillis = connectTimeoutMs
-                socketTimeoutMillis = Long.MAX_VALUE
-            }
-        }
+        ): HttpClient = com.sendspindroid.sendspin.transport.createWebSocketHttpClient(
+            pingIntervalSeconds,
+            connectTimeoutMs,
+        )
     }
 
     private val _state = MutableStateFlow<MaApiTransport.State>(MaApiTransport.State.Disconnected)

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/remote/SignalingClient.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/remote/SignalingClient.kt
@@ -2,7 +2,6 @@ package com.sendspindroid.remote
 
 import com.sendspindroid.shared.log.Log
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
@@ -91,15 +90,11 @@ class SignalingClient(
             IceServerConfig("stun:stun.home-assistant.io:3478")
         )
 
-        fun createDefaultClient(): HttpClient = HttpClient {
-            install(WebSockets) {
-                pingIntervalMillis = 30_000
-            }
-            install(io.ktor.client.plugins.HttpTimeout) {
-                connectTimeoutMillis = 10_000
-                socketTimeoutMillis = Long.MAX_VALUE
-            }
-        }
+        fun createDefaultClient(): HttpClient =
+            com.sendspindroid.sendspin.transport.createWebSocketHttpClient(
+                pingIntervalSeconds = 30,
+                connectTimeoutMs = 10_000,
+            )
     }
 
     /**

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/BaseWebSocketTransport.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/BaseWebSocketTransport.kt
@@ -2,7 +2,6 @@ package com.sendspindroid.sendspin.transport
 
 import com.sendspindroid.shared.log.Log
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.websocket.Frame
@@ -44,20 +43,16 @@ abstract class BaseWebSocketTransport(
     companion object {
         /**
          * Create a default Ktor HttpClient configured for WebSocket connections.
+         *
+         * Delegates to the platform-specific [createWebSocketHttpClient] so the
+         * ping interval is applied on the actual engine (OkHttp on Android),
+         * not via Ktor's `install(WebSockets) { pingIntervalMillis = ... }` —
+         * the OkHttp engine silently ignores the latter.
          */
         fun createDefaultClient(
             pingIntervalSeconds: Long = 30,
             connectTimeoutMs: Long = 5000
-        ): HttpClient = HttpClient {
-            install(WebSockets) {
-                pingIntervalMillis = pingIntervalSeconds * 1000
-            }
-            install(io.ktor.client.plugins.HttpTimeout) {
-                connectTimeoutMillis = connectTimeoutMs
-                // No socket timeout for WebSocket (long-lived connection)
-                socketTimeoutMillis = Long.MAX_VALUE
-            }
-        }
+        ): HttpClient = createWebSocketHttpClient(pingIntervalSeconds, connectTimeoutMs)
     }
 
     private val _state = AtomicReference(TransportState.Disconnected)

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/HttpClientFactory.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/HttpClientFactory.kt
@@ -1,0 +1,22 @@
+package com.sendspindroid.sendspin.transport
+
+import io.ktor.client.HttpClient
+
+/**
+ * Platform-specific factory for a Ktor [HttpClient] configured with WebSocket
+ * keepalive pings.
+ *
+ * Implementations must ensure pings actually reach the wire at the given
+ * interval AND that the socket is auto-closed if the peer fails to pong
+ * within that interval. Ktor's own `install(WebSockets) { pingIntervalMillis = ... }`
+ * is silently ignored by the OkHttp engine — the ping interval must be
+ * configured on the underlying `OkHttpClient.Builder`. Without keepalive
+ * pings, a server crash in idle state is never detected (TCP may never
+ * deliver a RST), and the client appears connected to a dead socket
+ * forever. See https://ktor.io/docs/client-websockets for the Ktor docs
+ * noting this engine caveat.
+ */
+internal expect fun createWebSocketHttpClient(
+    pingIntervalSeconds: Long,
+    connectTimeoutMs: Long,
+): HttpClient


### PR DESCRIPTION
## Summary

Fixes #105 (reopened scenario).

Issue #105 was originally closed by the auto-start-on-boot feature, but reopened because the reporter (`kaazvaag`, Echo Show 5 / LineageOS / Fully Kiosk dashboard) found that once SendSpinDroid connects to MA on boot, it **never reconnects if the MA server restarts** — even though PR #119 added stall-watchdog + infinite exponential-backoff reconnect.

### Root cause

All three WebSocket HTTP-client factories in the project configure keepalive pings via:

```kotlin
install(WebSockets) {
    pingIntervalMillis = pingIntervalSeconds * 1000
}
```

Per the official Ktor client docs ([ktor.io/docs/client-websockets](https://ktor.io/docs/client-websockets)):

> "`pingInterval` and `pingIntervalMillis` are not applicable for the OkHttp engine; for OkHttp, the ping interval must be configured via the engine configuration."

The project uses `ktor-client-okhttp:3.1.1`, so `pingIntervalMillis` silently no-ops. **No keepalive pings are ever sent.** When the server dies and TCP never delivers a clean RST (very common during a quick restart, especially on LineageOS/Amazon kernels that keep half-open sockets alive), the client's receive loop blocks forever — `onClosed`/`onFailure` never fire, and PR #119's otherwise-correct reconnect machinery never gets a chance to run.

### Fix

Introduced `expect`/`actual` `createWebSocketHttpClient` so the ping-interval setting lands on `OkHttpClient.Builder.pingInterval(...)` where the engine actually honors it. OkHttp's `pingInterval` both sends the pings AND auto-closes the socket on pong timeout within the same interval, so dead-socket detection drops from **indefinite** to **≤ one ping interval (~60s worst case)**.

All three existing `createDefaultClient` functions (SendSpin transport, MA transport, Signaling client) delegate to the new helper — the fix is uniform and future-proofed for any additional platform targets.

## Test plan

- [x] `./gradlew assembleDebug` clean on worktree — no new warnings on touched files.
- [x] `./gradlew :shared:testAndroidHostTest --tests "*transport*" --tests "*SignalingClient*"` — 48 of 49 pass. The single failure (`MaCommandMultiplexerTest`) is pre-existing on `origin/main` and unrelated to this change.
- [ ] **Reporter verification** (attach debug APK): boot device with auto-start, confirm connection → restart MA server while SendSpinDroid is idle → confirm reconnect within ~60 seconds.
- [x] Optional device-side sanity check: `adb shell ss -t` while connected, observe small packet activity every 30s on the WebSocket (indicates pings). Without this fix, counters are flat.

## Out of scope

- **Pre-handshake server crash** (Gap 1 from the investigation): if server dies during `client/hello`/`server/hello`, `onClosed`/`onFailure` bail out because `handshakeComplete == false`. Rare, will open a separate issue if it becomes a problem.
- **Reducing the 60s worst-case detection time.** Would require a shorter ping interval; battery/network trade-off not worth making unilaterally.
- **Enhanced stall watchdog during idle.** No longer needed — OkHttp's own pong timeout handles it.