### PR TITLE
fix: AAAA-only hostname / IPv6 connection support (#115)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/network/DefaultServerPinger.kt
+++ b/android/app/src/main/java/com/sendspindroid/network/DefaultServerPinger.kt
@@ -357,7 +357,7 @@ class DefaultServerPinger(
     private suspend fun pingLocal(address: String, path: String): Boolean {
         return withContext(Dispatchers.IO) {
             try {
-                val url = "ws://$address$path"
+                val url = WebSocketUrlBuilder.build(address, path)
                 Log.d(TAG, "Ping local: $url")
 
                 withTimeout(LOCAL_PING_TIMEOUT_MS) {

--- a/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
@@ -355,7 +355,7 @@ class AddServerWizardActivity : FragmentActivity() {
                 // Use the shared builder - it handles IPv4, hostnames, and IPv6 literals
                 // (bracket-wraps when needed per RFC 3986). If the user did not specify
                 // a port (no colon in non-IPv6 input), append the default.
-                val addressWithPort = ensureDefaultPort(address, defaultPort = 8927)
+                val addressWithPort = WebSocketUrlBuilder.ensureDefaultPort(address, defaultPort = 8927)
                 val wsUrl = WebSocketUrlBuilder.build(addressWithPort, "/sendspin")
 
                 Log.d(TAG, "Testing WebSocket connection to: $wsUrl")
@@ -405,27 +405,6 @@ class AddServerWizardActivity : FragmentActivity() {
                 Log.e(TAG, "Connection test exception", e)
                 Result.failure(e)
             }
-        }
-    }
-
-    /**
-     * Ensures the user-entered address has a port. Appends :8927 if none is present.
-     * Does not touch bracketed IPv6 literals that already include a port.
-     */
-    private fun ensureDefaultPort(address: String, defaultPort: Int): String {
-        val trimmed = address.trim()
-        // Already bracketed IPv6 - check for :port after the closing bracket
-        if (trimmed.startsWith("[")) {
-            val closeIdx = trimmed.indexOf(']')
-            val hasPort = closeIdx >= 0 && closeIdx < trimmed.length - 1 &&
-                          trimmed[closeIdx + 1] == ':'
-            return if (hasPort) trimmed else "$trimmed:$defaultPort"
-        }
-        val colonCount = trimmed.count { it == ':' }
-        return when {
-            colonCount == 0 -> "$trimmed:$defaultPort"       // hostname/IPv4 bare
-            colonCount == 1 -> trimmed                        // host:port already
-            else -> "[$trimmed]:$defaultPort"                 // bare IPv6 literal
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
@@ -26,6 +26,7 @@ import com.sendspindroid.model.UnifiedServer
 import com.sendspindroid.musicassistant.MaSettings
 import com.sendspindroid.network.NetworkEvaluator
 import com.sendspindroid.network.TransportType
+import com.sendspindroid.network.WebSocketUrlBuilder
 import com.sendspindroid.remote.RemoteConnection
 import com.sendspindroid.musicassistant.MaAuthHelper
 import com.sendspindroid.musicassistant.transport.MaApiTransport
@@ -351,11 +352,11 @@ class AddServerWizardActivity : FragmentActivity() {
     private suspend fun testLocalConnection(address: String): Result<Int> {
         return withContext(Dispatchers.IO) {
             try {
-                val wsUrl = if (address.contains(":")) {
-                    "ws://$address/sendspin"
-                } else {
-                    "ws://$address:8927/sendspin"
-                }
+                // Use the shared builder - it handles IPv4, hostnames, and IPv6 literals
+                // (bracket-wraps when needed per RFC 3986). If the user did not specify
+                // a port (no colon in non-IPv6 input), append the default.
+                val addressWithPort = ensureDefaultPort(address, defaultPort = 8927)
+                val wsUrl = WebSocketUrlBuilder.build(addressWithPort, "/sendspin")
 
                 Log.d(TAG, "Testing WebSocket connection to: $wsUrl")
 
@@ -404,6 +405,27 @@ class AddServerWizardActivity : FragmentActivity() {
                 Log.e(TAG, "Connection test exception", e)
                 Result.failure(e)
             }
+        }
+    }
+
+    /**
+     * Ensures the user-entered address has a port. Appends :8927 if none is present.
+     * Does not touch bracketed IPv6 literals that already include a port.
+     */
+    private fun ensureDefaultPort(address: String, defaultPort: Int): String {
+        val trimmed = address.trim()
+        // Already bracketed IPv6 - check for :port after the closing bracket
+        if (trimmed.startsWith("[")) {
+            val closeIdx = trimmed.indexOf(']')
+            val hasPort = closeIdx >= 0 && closeIdx < trimmed.length - 1 &&
+                          trimmed[closeIdx + 1] == ':'
+            return if (hasPort) trimmed else "$trimmed:$defaultPort"
+        }
+        val colonCount = trimmed.count { it == ':' }
+        return when {
+            colonCount == 0 -> "$trimmed:$defaultPort"       // hostname/IPv4 bare
+            colonCount == 1 -> trimmed                        // host:port already
+            else -> "[$trimmed]:$defaultPort"                 // bare IPv6 literal
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardViewModel.kt
@@ -6,6 +6,7 @@ import com.sendspindroid.model.UnifiedServer
 import com.sendspindroid.musicassistant.MaSettings
 import com.sendspindroid.musicassistant.MaAuthHelper
 import com.sendspindroid.musicassistant.transport.MaApiTransport
+import com.sendspindroid.network.WebSocketUrlBuilder
 import com.sendspindroid.ui.wizard.ClientMode
 import com.sendspindroid.ui.wizard.ConnectionTestState
 import com.sendspindroid.ui.wizard.DiscoveredServerUi
@@ -546,7 +547,7 @@ class AddServerWizardViewModel : ViewModel() {
     private fun deriveMaApiUrl(): String? {
         if (localAddress.isNotBlank()) {
             val host = localAddress.substringBefore(":")
-            return "ws://$host:$maPort/ws"
+            return WebSocketUrlBuilder.buildFromHostPort(host, maPort, "/ws")
         }
 
         if (proxyUrl.isNotBlank()) {

--- a/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardViewModel.kt
@@ -546,7 +546,7 @@ class AddServerWizardViewModel : ViewModel() {
 
     private fun deriveMaApiUrl(): String? {
         if (localAddress.isNotBlank()) {
-            val host = localAddress.substringBefore(":")
+            val host = WebSocketUrlBuilder.extractHost(localAddress)
             return WebSocketUrlBuilder.buildFromHostPort(host, maPort, "/ws")
         }
 

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/ConnectionSelectorTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/ConnectionSelectorTest.kt
@@ -65,10 +65,11 @@ class ConnectionSelectorTest {
     }
 
     @Test
-    fun getPriorityOrder_cellular_noLocal() {
-        val order = ConnectionSelector.getPriorityOrder(TransportType.CELLULAR)
-        assertEquals(listOf(ConnectionType.PROXY, ConnectionType.REMOTE), order)
-        assertFalse(order.contains(ConnectionType.LOCAL))
+    fun getPriorityOrder_cellular_proxy_remote_local() {
+        assertEquals(
+            listOf(ConnectionType.PROXY, ConnectionType.REMOTE, ConnectionType.LOCAL),
+            ConnectionSelector.getPriorityOrder(TransportType.CELLULAR)
+        )
     }
 
     @Test
@@ -172,8 +173,10 @@ class ConnectionSelectorTest {
     }
 
     @Test
-    fun shouldAttemptLocal_cellular_false() {
-        assertFalse(ConnectionSelector.shouldAttemptLocal(TransportType.CELLULAR))
+    fun shouldAttemptLocal_cellular_true() {
+        // LOCAL is no longer excluded on cellular - users may configure
+        // a publicly-routable hostname as their local connection target.
+        assertTrue(ConnectionSelector.shouldAttemptLocal(TransportType.CELLULAR))
     }
 
     @Test

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/ConnectionSelectorTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/ConnectionSelectorTest.kt
@@ -106,6 +106,21 @@ class ConnectionSelectorTest {
     }
 
     @Test
+    fun selectConnection_cellularOnlyLocal_selectsLocal() {
+        // Regression guard for #115: LOCAL must be attempted on cellular
+        // when it is the only configured connection (publicly-routable
+        // hostname case - e.g. user configured an AAAA-only DNS name).
+        val result = ConnectionSelector.selectConnection(
+            server(local = localConn),
+            networkState(TransportType.CELLULAR)
+        )
+        assertTrue(
+            "Expected Local selection but got $result",
+            result is ConnectionSelector.SelectedConnection.Local
+        )
+    }
+
+    @Test
     fun selectConnection_wifiNoLocal_selectsProxy() {
         val result = ConnectionSelector.selectConnection(
             server(remote = remoteConn, proxy = proxyConn),
@@ -130,7 +145,7 @@ class ConnectionSelectorTest {
         val result = ConnectionSelector.selectConnection(
             server(local = localConn, remote = remoteConn, proxy = proxyConn,
                 preference = ConnectionPreference.LOCAL_ONLY),
-            networkState(TransportType.CELLULAR) // Would normally skip local
+            networkState(TransportType.CELLULAR)
         )
         assertTrue(result is ConnectionSelector.SelectedConnection.Local)
     }
@@ -163,30 +178,6 @@ class ConnectionSelectorTest {
             networkState(TransportType.WIFI)
         )
         assertTrue(result is ConnectionSelector.SelectedConnection.Proxy)
-    }
-
-    // --- shouldAttemptLocal ---
-
-    @Test
-    fun shouldAttemptLocal_wifi_true() {
-        assertTrue(ConnectionSelector.shouldAttemptLocal(TransportType.WIFI))
-    }
-
-    @Test
-    fun shouldAttemptLocal_cellular_true() {
-        // LOCAL is no longer excluded on cellular - users may configure
-        // a publicly-routable hostname as their local connection target.
-        assertTrue(ConnectionSelector.shouldAttemptLocal(TransportType.CELLULAR))
-    }
-
-    @Test
-    fun shouldAttemptLocal_ethernet_true() {
-        assertTrue(ConnectionSelector.shouldAttemptLocal(TransportType.ETHERNET))
-    }
-
-    @Test
-    fun shouldAttemptLocal_vpn_true() {
-        assertTrue(ConnectionSelector.shouldAttemptLocal(TransportType.VPN))
     }
 
     // --- getConnectionDescription ---

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/WebSocketUrlBuilderTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/WebSocketUrlBuilderTest.kt
@@ -124,4 +124,19 @@ class WebSocketUrlBuilderTest {
             WebSocketUrlBuilder.buildFromHostPort("host.example.com", 8927, "/ws")
         )
     }
+
+    @Test
+    fun buildFromHostPort_wss_scheme() {
+        assertEquals(
+            "wss://host.example.com:8927/ws",
+            WebSocketUrlBuilder.buildFromHostPort("host.example.com", 8927, "/ws", scheme = "wss")
+        )
+    }
+
+    @Test
+    fun empty_address_produces_schemeless_authority() {
+        // Documents current behavior: no input validation. Callers must ensure
+        // the address is non-empty. The wizard validates this upstream.
+        assertEquals("ws:///path", WebSocketUrlBuilder.build("", "/path"))
+    }
 }

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/WebSocketUrlBuilderTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/WebSocketUrlBuilderTest.kt
@@ -139,4 +139,73 @@ class WebSocketUrlBuilderTest {
         // the address is non-empty. The wizard validates this upstream.
         assertEquals("ws:///path", WebSocketUrlBuilder.build("", "/path"))
     }
+
+    // --- ensureDefaultPort ---
+
+    @Test
+    fun ensureDefaultPort_bare_hostname_appends_default() {
+        assertEquals("host.example.com:8927", WebSocketUrlBuilder.ensureDefaultPort("host.example.com", 8927))
+    }
+
+    @Test
+    fun ensureDefaultPort_ipv4_appends_default() {
+        assertEquals("192.168.1.1:8927", WebSocketUrlBuilder.ensureDefaultPort("192.168.1.1", 8927))
+    }
+
+    @Test
+    fun ensureDefaultPort_hostname_with_port_unchanged() {
+        assertEquals("host.example.com:8080", WebSocketUrlBuilder.ensureDefaultPort("host.example.com:8080", 8927))
+    }
+
+    @Test
+    fun ensureDefaultPort_bare_ipv6_wraps_and_appends() {
+        assertEquals("[2001:db8::1]:8927", WebSocketUrlBuilder.ensureDefaultPort("2001:db8::1", 8927))
+    }
+
+    @Test
+    fun ensureDefaultPort_bracketed_ipv6_without_port_appends() {
+        assertEquals("[2001:db8::1]:8927", WebSocketUrlBuilder.ensureDefaultPort("[2001:db8::1]", 8927))
+    }
+
+    @Test
+    fun ensureDefaultPort_bracketed_ipv6_with_port_unchanged() {
+        assertEquals("[2001:db8::1]:8080", WebSocketUrlBuilder.ensureDefaultPort("[2001:db8::1]:8080", 8927))
+    }
+
+    // --- extractHost ---
+
+    @Test
+    fun extractHost_bare_hostname() {
+        assertEquals("host.example.com", WebSocketUrlBuilder.extractHost("host.example.com"))
+    }
+
+    @Test
+    fun extractHost_hostname_with_port() {
+        assertEquals("host.example.com", WebSocketUrlBuilder.extractHost("host.example.com:8080"))
+    }
+
+    @Test
+    fun extractHost_ipv4() {
+        assertEquals("192.168.1.1", WebSocketUrlBuilder.extractHost("192.168.1.1"))
+    }
+
+    @Test
+    fun extractHost_ipv4_with_port() {
+        assertEquals("192.168.1.1", WebSocketUrlBuilder.extractHost("192.168.1.1:8927"))
+    }
+
+    @Test
+    fun extractHost_bare_ipv6() {
+        assertEquals("2001:db8::1", WebSocketUrlBuilder.extractHost("2001:db8::1"))
+    }
+
+    @Test
+    fun extractHost_bracketed_ipv6() {
+        assertEquals("2001:db8::1", WebSocketUrlBuilder.extractHost("[2001:db8::1]"))
+    }
+
+    @Test
+    fun extractHost_bracketed_ipv6_with_port() {
+        assertEquals("2001:db8::1", WebSocketUrlBuilder.extractHost("[2001:db8::1]:8927"))
+    }
 }

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/WebSocketUrlBuilderTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/network/WebSocketUrlBuilderTest.kt
@@ -1,0 +1,127 @@
+package com.sendspindroid.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WebSocketUrlBuilderTest {
+
+    @Test
+    fun ipv4_with_port() {
+        assertEquals(
+            "ws://192.168.1.100:8927/sendspin",
+            WebSocketUrlBuilder.build("192.168.1.100:8927", "/sendspin")
+        )
+    }
+
+    @Test
+    fun ipv4_without_port() {
+        assertEquals(
+            "ws://192.168.1.100/sendspin",
+            WebSocketUrlBuilder.build("192.168.1.100", "/sendspin")
+        )
+    }
+
+    @Test
+    fun hostname_with_port() {
+        assertEquals(
+            "ws://host.example.com:8927/sendspin",
+            WebSocketUrlBuilder.build("host.example.com:8927", "/sendspin")
+        )
+    }
+
+    @Test
+    fun hostname_without_port() {
+        assertEquals(
+            "ws://host.example.com/sendspin",
+            WebSocketUrlBuilder.build("host.example.com", "/sendspin")
+        )
+    }
+
+    @Test
+    fun ipv6_literal_bare_is_wrapped() {
+        assertEquals(
+            "ws://[2001:db8::1]/sendspin",
+            WebSocketUrlBuilder.build("2001:db8::1", "/sendspin")
+        )
+    }
+
+    @Test
+    fun ipv6_literal_bracketed_with_port_is_preserved() {
+        assertEquals(
+            "ws://[2001:db8::1]:8927/sendspin",
+            WebSocketUrlBuilder.build("[2001:db8::1]:8927", "/sendspin")
+        )
+    }
+
+    @Test
+    fun ipv6_literal_bracketed_without_port() {
+        assertEquals(
+            "ws://[2001:db8::1]/sendspin",
+            WebSocketUrlBuilder.build("[2001:db8::1]", "/sendspin")
+        )
+    }
+
+    @Test
+    fun loopback_ipv6() {
+        assertEquals(
+            "ws://[::1]/sendspin",
+            WebSocketUrlBuilder.build("::1", "/sendspin")
+        )
+    }
+
+    @Test
+    fun path_without_leading_slash_is_normalized() {
+        assertEquals(
+            "ws://host/sendspin",
+            WebSocketUrlBuilder.build("host", "sendspin")
+        )
+    }
+
+    @Test
+    fun empty_path_produces_no_trailing_slash() {
+        assertEquals(
+            "ws://host",
+            WebSocketUrlBuilder.build("host", "")
+        )
+    }
+
+    @Test
+    fun wss_scheme_is_used_verbatim() {
+        assertEquals(
+            "wss://host.example.com/path",
+            WebSocketUrlBuilder.build("host.example.com", "/path", scheme = "wss")
+        )
+    }
+
+    @Test
+    fun buildFromHostPort_ipv4() {
+        assertEquals(
+            "ws://192.168.1.1:8927/ws",
+            WebSocketUrlBuilder.buildFromHostPort("192.168.1.1", 8927, "/ws")
+        )
+    }
+
+    @Test
+    fun buildFromHostPort_ipv6_wraps() {
+        assertEquals(
+            "ws://[2001:db8::1]:8927/ws",
+            WebSocketUrlBuilder.buildFromHostPort("2001:db8::1", 8927, "/ws")
+        )
+    }
+
+    @Test
+    fun buildFromHostPort_bracketed_ipv6_not_double_wrapped() {
+        assertEquals(
+            "ws://[2001:db8::1]:8927/ws",
+            WebSocketUrlBuilder.buildFromHostPort("[2001:db8::1]", 8927, "/ws")
+        )
+    }
+
+    @Test
+    fun buildFromHostPort_hostname() {
+        assertEquals(
+            "ws://host.example.com:8927/ws",
+            WebSocketUrlBuilder.buildFromHostPort("host.example.com", 8927, "/ws")
+        )
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/MaApiEndpoint.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/MaApiEndpoint.kt
@@ -70,7 +70,7 @@ object MaApiEndpoint {
      */
     fun deriveFromLocal(server: UnifiedServer, defaultPort: Int = 8095): String? {
         return server.local?.let { local ->
-            val host = local.address.substringBefore(":")
+            val host = WebSocketUrlBuilder.extractHost(local.address)
             WebSocketUrlBuilder.buildFromHostPort(host, defaultPort, "/ws")
         }
     }

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/MaApiEndpoint.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/MaApiEndpoint.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid.musicassistant
 
 import com.sendspindroid.model.UnifiedServer
+import com.sendspindroid.network.WebSocketUrlBuilder
 
 /**
  * Derives Music Assistant API WebSocket URL from server configuration.
@@ -70,7 +71,7 @@ object MaApiEndpoint {
     fun deriveFromLocal(server: UnifiedServer, defaultPort: Int = 8095): String? {
         return server.local?.let { local ->
             val host = local.address.substringBefore(":")
-            "ws://$host:$defaultPort/ws"
+            WebSocketUrlBuilder.buildFromHostPort(host, defaultPort, "/ws")
         }
     }
 

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/transport/MaWebSocketTransport.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/transport/MaWebSocketTransport.kt
@@ -1,5 +1,6 @@
 package com.sendspindroid.musicassistant.transport
 
+import com.sendspindroid.network.WebSocketUrlBuilder
 import com.sendspindroid.shared.log.Log
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.WebSockets
@@ -472,7 +473,7 @@ class MaWebSocketTransport(
             url.startsWith("ws://") || url.startsWith("wss://") -> url
             url.startsWith("https://") -> url.replaceFirst("https://", "wss://")
             url.startsWith("http://") -> url.replaceFirst("http://", "ws://")
-            else -> "ws://$url"
+            else -> WebSocketUrlBuilder.build(url, path = "")
         }
     }
 }

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/network/ConnectionSelector.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/network/ConnectionSelector.kt
@@ -11,7 +11,7 @@ import com.sendspindroid.shared.log.Log
  * | Network       | Priority Order            | Rationale                          |
  * |---------------|---------------------------|------------------------------------|
  * | WiFi/Ethernet | Local -> Proxy -> Remote    | Local has lowest latency           |
- * | Cellular      | Proxy -> Remote            | Skip local (not on LAN)            |
+ * | Cellular      | Proxy -> Remote -> Local    | Local last - supports publicly-routable hostnames |
  * | VPN           | Proxy -> Remote -> Local    | VPN may route home, proxy preferred|
  * | Unknown       | Proxy -> Remote -> Local    | Can't determine network, proxy safest|
  *
@@ -110,10 +110,15 @@ object ConnectionSelector {
                 ConnectionType.REMOTE
             )
 
-            // Cellular: Skip local (not on LAN), prefer proxy over WebRTC
+            // Cellular: Proxy first (direct, usually fastest on cellular), then Remote
+            // (WebRTC signaling), then Local last. Local is included because users may
+            // configure a publicly-routable hostname (AAAA, public IP, dyndns) as their
+            // "local" address - those work over cellular even though mDNS-discovered
+            // LAN servers don't. A doomed attempt to a LAN-only server times out fast.
             TransportType.CELLULAR -> listOf(
                 ConnectionType.PROXY,
-                ConnectionType.REMOTE
+                ConnectionType.REMOTE,
+                ConnectionType.LOCAL
             )
 
             // VPN: Proxy first (VPN might tunnel to home network)
@@ -133,11 +138,13 @@ object ConnectionSelector {
     }
 
     /**
-     * Checks if local connections should be attempted on the current network.
-     * Returns false for cellular networks where local connections won't work.
+     * Checks whether local connections should be attempted on the current network.
+     * Always true: the "local" slot may hold a publicly-routable hostname or IP,
+     * and we would rather make a quick doomed attempt than wrongly exclude a
+     * working configuration. Kept as a function to avoid breaking callers.
      */
-    fun shouldAttemptLocal(transportType: TransportType): Boolean {
-        return transportType != TransportType.CELLULAR
+    fun shouldAttemptLocal(@Suppress("UNUSED_PARAMETER") transportType: TransportType): Boolean {
+        return true
     }
 
     /**

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/network/ConnectionSelector.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/network/ConnectionSelector.kt
@@ -11,7 +11,7 @@ import com.sendspindroid.shared.log.Log
  * | Network       | Priority Order            | Rationale                          |
  * |---------------|---------------------------|------------------------------------|
  * | WiFi/Ethernet | Local -> Proxy -> Remote    | Local has lowest latency           |
- * | Cellular      | Proxy -> Remote -> Local    | Local last - supports publicly-routable hostnames |
+ * | Cellular      | Proxy -> Remote -> Local    | Local last as fallback for public hosts |
  * | VPN           | Proxy -> Remote -> Local    | VPN may route home, proxy preferred|
  * | Unknown       | Proxy -> Remote -> Local    | Can't determine network, proxy safest|
  *
@@ -135,16 +135,6 @@ object ConnectionSelector {
                 ConnectionType.LOCAL
             )
         }
-    }
-
-    /**
-     * Checks whether local connections should be attempted on the current network.
-     * Always true: the "local" slot may hold a publicly-routable hostname or IP,
-     * and we would rather make a quick doomed attempt than wrongly exclude a
-     * working configuration. Kept as a function to avoid breaking callers.
-     */
-    fun shouldAttemptLocal(@Suppress("UNUSED_PARAMETER") transportType: TransportType): Boolean {
-        return true
     }
 
     /**

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/network/WebSocketUrlBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/network/WebSocketUrlBuilder.kt
@@ -44,24 +44,28 @@ object WebSocketUrlBuilder {
      * (i.e. host or host:port, with IPv6 literals bracket-wrapped).
      */
     private fun formatAuthority(address: String): String {
-        val trimmed = address.trim()
+        // Callers are responsible for stripping whitespace at the input boundary
+        // (e.g. the wizard ViewModel). Don't silently swallow it here - that would
+        // mask copy-paste issues that don't survive in other contexts.
 
-        // Already bracketed? Keep as-is.
-        if (trimmed.startsWith("[")) {
-            return trimmed
+        // Already bracketed? Keep as-is. Note: this is a pass-through for any
+        // "[..." prefix; malformed bracketed input (no closing bracket) would
+        // produce a malformed URL. Acceptable given trusted wizard inputs.
+        if (address.startsWith("[")) {
+            return address
         }
 
-        val colonCount = trimmed.count { it == ':' }
+        val colonCount = address.count { it == ':' }
         return when {
             // No colons: bare hostname or IPv4, no port
-            colonCount == 0 -> trimmed
+            colonCount == 0 -> address
 
             // Exactly one colon: host:port (hostname or IPv4 with port)
-            colonCount == 1 -> trimmed
+            colonCount == 1 -> address
 
             // 2+ colons and no brackets: bare IPv6 literal, no port
             // Wrap the whole thing in brackets
-            else -> "[$trimmed]"
+            else -> "[$address]"
         }
     }
 

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/network/WebSocketUrlBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/network/WebSocketUrlBuilder.kt
@@ -40,6 +40,64 @@ object WebSocketUrlBuilder {
     }
 
     /**
+     * Ensure a user-entered address has a port. Appends `:defaultPort` if none is present.
+     * Handles IPv6 literals correctly, distinguishing bare-IPv6-2+-colons from host:port.
+     *
+     * Examples:
+     * - `host` -> `host:8927`
+     * - `host:8080` -> `host:8080` (unchanged)
+     * - `192.168.1.1` -> `192.168.1.1:8927`
+     * - `2001:db8::1` (bare IPv6) -> `[2001:db8::1]:8927`
+     * - `[2001:db8::1]` (bracketed, no port) -> `[2001:db8::1]:8927`
+     * - `[2001:db8::1]:8080` (bracketed with port) -> `[2001:db8::1]:8080` (unchanged)
+     */
+    fun ensureDefaultPort(address: String, defaultPort: Int): String {
+        if (address.startsWith("[")) {
+            val closeIdx = address.indexOf(']')
+            val hasPort = closeIdx >= 0 && closeIdx < address.length - 1 &&
+                          address[closeIdx + 1] == ':'
+            return if (hasPort) address else "$address:$defaultPort"
+        }
+        val colonCount = address.count { it == ':' }
+        return when {
+            colonCount == 0 -> "$address:$defaultPort"       // hostname/IPv4 bare
+            colonCount == 1 -> address                        // host:port already
+            else -> "[$address]:$defaultPort"                 // bare IPv6 literal
+        }
+    }
+
+    /**
+     * Extract just the host portion of an address string, discarding any port and
+     * unwrapping IPv6 brackets. The returned value is suitable for passing to
+     * [buildFromHostPort] (which will re-wrap IPv6 literals as needed).
+     *
+     * Examples:
+     * - `192.168.1.1` -> `192.168.1.1`
+     * - `192.168.1.1:8927` -> `192.168.1.1`
+     * - `host.example.com` -> `host.example.com`
+     * - `host.example.com:8080` -> `host.example.com`
+     * - `2001:db8::1` (bare IPv6) -> `2001:db8::1`
+     * - `[2001:db8::1]` -> `2001:db8::1`
+     * - `[2001:db8::1]:8927` -> `2001:db8::1`
+     */
+    fun extractHost(address: String): String {
+        if (address.startsWith("[")) {
+            val closeIdx = address.indexOf(']')
+            if (closeIdx >= 0) {
+                return address.substring(1, closeIdx)
+            }
+            // Malformed bracketed input - return as-is
+            return address
+        }
+        val colonCount = address.count { it == ':' }
+        return when {
+            colonCount == 0 -> address                        // bare host
+            colonCount == 1 -> address.substringBefore(':')   // host:port
+            else -> address                                   // bare IPv6 literal - no port possible
+        }
+    }
+
+    /**
      * Normalize an address string into an RFC 3986 authority component
      * (i.e. host or host:port, with IPv6 literals bracket-wrapped).
      */

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/network/WebSocketUrlBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/network/WebSocketUrlBuilder.kt
@@ -1,0 +1,87 @@
+package com.sendspindroid.network
+
+/**
+ * Builds syntactically valid WebSocket URLs from user-entered addresses.
+ * Handles IPv6 literal bracket-wrapping per RFC 3986.
+ *
+ * ## Address forms accepted by [build]
+ * - `host` or `host:port` where host is a hostname or IPv4 literal
+ * - `[ipv6]` or `[ipv6]:port` - bracketed IPv6 with optional port
+ * - bare IPv6 literal (2+ colons, no brackets) - treated as no port, wrapped
+ *
+ * ## Ambiguity convention
+ * A bare string with 2+ colons is treated as an IPv6 literal with no port.
+ * To combine an IPv6 literal with a port, the caller must bracket-wrap:
+ * `[2001:db8::1]:8927`. This matches RFC 3986 authority syntax.
+ */
+object WebSocketUrlBuilder {
+
+    /**
+     * Build a WebSocket URL from a user-facing address plus path.
+     *
+     * @param address host or host:port, with IPv6 literals optionally in brackets
+     * @param path request path (leading slash added if missing; empty path produces no trailing slash)
+     * @param scheme URL scheme (default "ws"; use "wss" for TLS)
+     */
+    fun build(address: String, path: String, scheme: String = "ws"): String {
+        val authority = formatAuthority(address)
+        val pathPart = normalizePath(path)
+        return "$scheme://$authority$pathPart"
+    }
+
+    /**
+     * Build a WebSocket URL when host and port are already separated.
+     * Wraps IPv6 literals in brackets; passes hostnames and IPv4 through unchanged.
+     */
+    fun buildFromHostPort(host: String, port: Int, path: String, scheme: String = "ws"): String {
+        val hostPart = wrapIfIpv6Literal(stripBrackets(host))
+        val pathPart = normalizePath(path)
+        return "$scheme://$hostPart:$port$pathPart"
+    }
+
+    /**
+     * Normalize an address string into an RFC 3986 authority component
+     * (i.e. host or host:port, with IPv6 literals bracket-wrapped).
+     */
+    private fun formatAuthority(address: String): String {
+        val trimmed = address.trim()
+
+        // Already bracketed? Keep as-is.
+        if (trimmed.startsWith("[")) {
+            return trimmed
+        }
+
+        val colonCount = trimmed.count { it == ':' }
+        return when {
+            // No colons: bare hostname or IPv4, no port
+            colonCount == 0 -> trimmed
+
+            // Exactly one colon: host:port (hostname or IPv4 with port)
+            colonCount == 1 -> trimmed
+
+            // 2+ colons and no brackets: bare IPv6 literal, no port
+            // Wrap the whole thing in brackets
+            else -> "[$trimmed]"
+        }
+    }
+
+    private fun wrapIfIpv6Literal(host: String): String {
+        return if (host.contains(':')) "[$host]" else host
+    }
+
+    private fun stripBrackets(host: String): String {
+        return if (host.startsWith("[") && host.endsWith("]")) {
+            host.substring(1, host.length - 1)
+        } else {
+            host
+        }
+    }
+
+    private fun normalizePath(path: String): String {
+        return when {
+            path.isEmpty() -> ""
+            path.startsWith("/") -> path
+            else -> "/$path"
+        }
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/WebSocketTransport.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/WebSocketTransport.kt
@@ -1,5 +1,6 @@
 package com.sendspindroid.sendspin.transport
 
+import com.sendspindroid.network.WebSocketUrlBuilder
 import io.ktor.client.HttpClient
 
 /**
@@ -36,5 +37,5 @@ class WebSocketTransport(
         private const val TAG = "WebSocketTransport"
     }
 
-    override fun buildWebSocketUrl(): String = "ws://$address$path"
+    override fun buildWebSocketUrl(): String = WebSocketUrlBuilder.build(address, path)
 }


### PR DESCRIPTION
## Summary

Fixes issue #115: user with an AAAA-only DNS hostname gets "No connection method available" when connecting over the internet from cellular. Works with `sendspin-cli` but not SendspinDroid.

Three layers of fix:

**1. ConnectionSelector: include LOCAL on cellular.**
The old cellular priority order `[PROXY, REMOTE]` assumed "local" always meant "LAN-only, mDNS-discovered". That assumption breaks for users who configure a publicly-routable hostname (AAAA, public IPv4, dyndns) as their local address. Cellular now uses `[PROXY, REMOTE, LOCAL]` -- LOCAL tried last as a fallback. A doomed attempt to a genuinely-LAN-only server times out quickly (5s Ktor connect timeout). `shouldAttemptLocal` deleted -- zero production callers.

**2. WebSocketUrlBuilder: IPv6-safe URL construction.**
New pure-function utility in the shared module. Handles RFC 3986 bracket-wrapping for literal IPv6 addresses. Public API:
- `build(address, path)` for user-facing host/host:port/IPv6 strings
- `buildFromHostPort(host, port, path)` for already-parsed pairs
- `ensureDefaultPort(address, defaultPort)` appends default port, IPv6-aware
- `extractHost(address)` strips port and brackets, replaces naive `substringBefore(\":\")`

30 unit tests cover every documented input shape.

**3. Migrate six ws:// construction sites.**
All six `\"ws://\$address\$path\"` interpolations replaced with the builder:
- `WebSocketTransport.buildWebSocketUrl` (runtime transport)
- `DefaultServerPinger.pingLocal`
- `AddServerWizardActivity.testLocalConnection`
- `AddServerWizardViewModel` MA URL derivation
- `MaApiEndpoint` MA ws URL
- `MaWebSocketTransport` bare-host fallback

Fixes two latent `substringBefore(\":\")` bugs that broke for bracketed IPv6 inputs: `MaApiEndpoint.deriveFromLocal` and the MA URL path in `AddServerWizardViewModel`.

Also fixes a latent wizard bug where `address.contains(\":\")` conflated \"user specified host:port\" with \"bare IPv6 literal\".

## Test Plan

Automated: full suite passes, including new regression test `selectConnection_cellularOnlyLocal_selectsLocal` and 30 `WebSocketUrlBuilder` cases. `assembleDebug` succeeds.

Manual verification:

- [ ] **Primary #115 repro:** Toggle device to cellular data. Add a server with a hostname that has only an AAAA record (or use a literal IPv6 address). Connection should now succeed. Previously produced \"No connection method available\".
- [ ] **Regression guard -- WiFi hostname:** On WiFi, connect to a hostname server. Should still work (no change to WiFi priority).
- [ ] **Regression guard -- cellular with all methods:** On cellular with LOCAL + REMOTE + PROXY configured, PROXY should still be selected first.
- [ ] **Literal IPv6:** Add a server with `[2001:db8::1]:8927` or a real bracketed IPv6 URL. Wizard test should pass and runtime connection should work.
- [ ] **Cellular LAN-only fallback:** Server configured with a LAN-only address, client on cellular with no REMOTE/PROXY. Should fail after ~5s with \"No connection method available\" (acceptable -- user's setup is genuinely unreachable).

## Deferred (follow-up issues worth filing)

The final cross-task review identified four related but out-of-scope issues:

- Three `wss://\$baseUrl` / `wss://\$url` interpolations in proxy-URL paths (`MaApiEndpoint.kt:96`, `ProxyWebSocketTransport.kt:78`, `AddServerWizardViewModel.kt:561`). Bare IPv6 literals in the proxy field would still produce malformed URLs. Realistic proxy inputs (AAAA hostname, fully-formed bracketed URL) already work.
- `extractServerNameFromUrl` at `AddServerWizardViewModel.kt:595` still uses `substringBefore(\":\")` on a bare hostname. Cosmetic display-name bug for IPv6-literal MA servers.

## Commits

```
4e25da3 refactor: consolidate IPv6-aware address helpers in WebSocketUrlBuilder
cb5c931 fix: use WebSocketUrlBuilder at all URL-construction sites
f5f7edf refactor: address code review on WebSocketUrlBuilder
02f2ac3 feat: add WebSocketUrlBuilder for IPv6-safe URL construction
d48f9e1 refactor: address code review on cellular priority fix
a2fb8bc fix: include local in cellular connection priority
```

Fixes #115.