### PR TITLE
fix: simplify codec preference to one user-chosen setting (#26)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -8,7 +8,6 @@ import android.util.Log
 import androidx.preference.PreferenceManager
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
-import com.sendspindroid.network.TransportType
 import java.util.UUID
 
 /**
@@ -48,10 +47,6 @@ object UserSettings {
     const val KEY_ALBUM_ARTISTS_ONLY = "album_artists_only"
     const val KEY_LAYOUT_MODE = "layout_mode"
     const val KEY_AUTO_START_ON_BOOT = "auto_start_on_boot"
-
-    // Network-specific codec preference keys
-    const val KEY_CODEC_WIFI = "codec_wifi"
-    const val KEY_CODEC_CELLULAR = "codec_cellular"
 
     // Remote access preference keys (stored in encrypted prefs)
     const val KEY_REMOTE_SERVERS = "remote_servers"
@@ -375,38 +370,6 @@ object UserSettings {
      */
     fun setPreferredCodec(codec: String) {
         prefs?.edit()?.putString(KEY_PREFERRED_CODEC, codec)?.apply()
-    }
-
-    /**
-     * Gets the preferred codec for a specific network type.
-     * Falls back to the global preferred codec if no network-specific preference is set.
-     *
-     * @param transportType The current network transport type
-     * @return The codec to use (pcm, flac, or opus)
-     */
-    fun getCodecForNetwork(transportType: TransportType): String {
-        val key = when (transportType) {
-            TransportType.WIFI -> KEY_CODEC_WIFI
-            TransportType.CELLULAR -> KEY_CODEC_CELLULAR
-            else -> KEY_PREFERRED_CODEC
-        }
-        // Fall back to global preferred codec if network-specific not set
-        return prefs?.getString(key, null) ?: getPreferredCodec()
-    }
-
-    /**
-     * Sets the preferred codec for a specific network type.
-     *
-     * @param transportType The network transport type
-     * @param codec The codec to use (pcm, flac, or opus)
-     */
-    fun setCodecForNetwork(transportType: TransportType, codec: String) {
-        val key = when (transportType) {
-            TransportType.WIFI -> KEY_CODEC_WIFI
-            TransportType.CELLULAR -> KEY_CODEC_CELLULAR
-            else -> KEY_PREFERRED_CODEC
-        }
-        prefs?.edit()?.putString(key, codec)?.apply()
     }
 
     // ========== Remote Access Settings ==========

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -664,13 +664,7 @@ private fun CodecSelectionDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .then(
-                                if (supported) {
-                                    Modifier.clickable { onSelect(value) }
-                                } else {
-                                    Modifier
-                                }
-                            )
+                            .clickable(enabled = supported) { onSelect(value) }
                             .padding(vertical = 12.dp, horizontal = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -718,6 +712,7 @@ private fun getCodecDisplayName(codec: String): String {
     return when (codec.lowercase()) {
         "opus" -> "Opus"
         "flac" -> "FLAC"
+        "pcm" -> "PCM"
         else -> codec
     }
 }

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -80,8 +80,7 @@ fun SettingsScreen(
     val layoutMode by viewModel.layoutMode.collectAsStateWithLifecycle()
     val syncOffset by viewModel.syncOffset.collectAsStateWithLifecycle()
     val preferredCodec by viewModel.preferredCodec.collectAsStateWithLifecycle()
-    val wifiCodec by viewModel.wifiCodec.collectAsStateWithLifecycle()
-    val cellularCodec by viewModel.cellularCodec.collectAsStateWithLifecycle()
+    val supportedCodecs by viewModel.supportedCodecs.collectAsStateWithLifecycle()
     val lowMemoryMode by viewModel.lowMemoryMode.collectAsStateWithLifecycle()
     val highPowerMode by viewModel.highPowerMode.collectAsStateWithLifecycle()
     val autoStartOnBoot by viewModel.autoStartOnBoot.collectAsStateWithLifecycle()
@@ -95,7 +94,7 @@ fun SettingsScreen(
     var showPlayerNameDialog by remember { mutableStateOf(false) }
     var showSyncOffsetDialog by remember { mutableStateOf(false) }
     var showRestartDialog by remember { mutableStateOf(false) }
-    var showCodecDialog by remember { mutableStateOf<CodecDialogType?>(null) }
+    var showCodecDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -175,20 +174,7 @@ fun SettingsScreen(
             CodecPreference(
                 title = stringResource(R.string.pref_codec_title),
                 summary = getCodecDisplayName(preferredCodec),
-                onClick = { showCodecDialog = CodecDialogType.PREFERRED }
-            )
-
-            // Network Codecs Category
-            PreferenceCategory(title = stringResource(R.string.pref_category_network_codecs))
-            CodecPreference(
-                title = stringResource(R.string.pref_codec_wifi_title),
-                summary = getCodecDisplayName(wifiCodec),
-                onClick = { showCodecDialog = CodecDialogType.WIFI }
-            )
-            CodecPreference(
-                title = stringResource(R.string.pref_codec_cellular_title),
-                summary = getCodecDisplayName(cellularCodec),
-                onClick = { showCodecDialog = CodecDialogType.CELLULAR }
+                onClick = { showCodecDialog = true }
             )
 
             // Performance Category
@@ -319,33 +305,18 @@ fun SettingsScreen(
     }
 
     // Codec Selection Dialog
-    showCodecDialog?.let { dialogType ->
+    if (showCodecDialog) {
         CodecSelectionDialog(
-            title = when (dialogType) {
-                CodecDialogType.PREFERRED -> stringResource(R.string.pref_codec_title)
-                CodecDialogType.WIFI -> stringResource(R.string.pref_codec_wifi_title)
-                CodecDialogType.CELLULAR -> stringResource(R.string.pref_codec_cellular_title)
-            },
-            currentCodec = when (dialogType) {
-                CodecDialogType.PREFERRED -> preferredCodec
-                CodecDialogType.WIFI -> wifiCodec
-                CodecDialogType.CELLULAR -> cellularCodec
-            },
+            title = stringResource(R.string.pref_codec_title),
+            currentCodec = preferredCodec,
+            supportedCodecs = supportedCodecs,
             onSelect = { codec ->
-                when (dialogType) {
-                    CodecDialogType.PREFERRED -> viewModel.setPreferredCodec(codec)
-                    CodecDialogType.WIFI -> viewModel.setWifiCodec(codec)
-                    CodecDialogType.CELLULAR -> viewModel.setCellularCodec(codec)
-                }
-                showCodecDialog = null
+                viewModel.setPreferredCodec(codec)
+                showCodecDialog = false
             },
-            onDismiss = { showCodecDialog = null }
+            onDismiss = { showCodecDialog = false }
         )
     }
-}
-
-private enum class CodecDialogType {
-    PREFERRED, WIFI, CELLULAR
 }
 
 // ============================================================================
@@ -672,13 +643,16 @@ private fun RestartAppDialog(
 private fun CodecSelectionDialog(
     title: String,
     currentCodec: String,
+    supportedCodecs: Set<String>,
     onSelect: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
     val codecs = listOf(
         "opus" to "Opus",
-        "flac" to "FLAC"
+        "flac" to "FLAC",
+        "pcm" to "PCM"
     )
+    val unavailableHint = stringResource(R.string.pref_codec_unavailable_hint)
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -686,19 +660,43 @@ private fun CodecSelectionDialog(
         text = {
             Column {
                 codecs.forEach { (value, label) ->
+                    val supported = value in supportedCodecs
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onSelect(value) }
+                            .then(
+                                if (supported) {
+                                    Modifier.clickable { onSelect(value) }
+                                } else {
+                                    Modifier
+                                }
+                            )
                             .padding(vertical = 12.dp, horizontal = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         RadioButton(
                             selected = currentCodec == value,
-                            onClick = { onSelect(value) }
+                            onClick = if (supported) { { onSelect(value) } } else null,
+                            enabled = supported
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(label)
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = label,
+                                color = if (supported) {
+                                    MaterialTheme.colorScheme.onSurface
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                }
+                            )
+                            if (!supported) {
+                                Text(
+                                    text = unavailableHint,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import com.sendspindroid.SyncOffsetPreference
 import com.sendspindroid.UnifiedServerRepository
 import com.sendspindroid.UserSettings
 import com.sendspindroid.debug.DebugLogger
+import com.sendspindroid.sendspin.decoder.AudioDecoderFactory
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -65,6 +66,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val _preferredCodec = MutableStateFlow(UserSettings.getPreferredCodec())
     val preferredCodec: StateFlow<String> = _preferredCodec.asStateFlow()
+
+    private val _supportedCodecs = MutableStateFlow(computeSupportedCodecs())
+    val supportedCodecs: StateFlow<Set<String>> = _supportedCodecs.asStateFlow()
 
     // Performance settings
     private val _lowMemoryMode = MutableStateFlow(UserSettings.lowMemoryMode)
@@ -233,5 +237,11 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             putExtra(EXTRA_DEBUG_LOGGING_ENABLED, enabled)
         }
         LocalBroadcastManager.getInstance(getApplication()).sendBroadcast(intent)
+    }
+
+    private fun computeSupportedCodecs(): Set<String> {
+        return listOf("opus", "flac", "pcm")
+            .filter { AudioDecoderFactory.isCodecSupported(it) }
+            .toSet()
     }
 }

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsViewModel.kt
@@ -13,7 +13,6 @@ import com.sendspindroid.SyncOffsetPreference
 import com.sendspindroid.UnifiedServerRepository
 import com.sendspindroid.UserSettings
 import com.sendspindroid.debug.DebugLogger
-import com.sendspindroid.network.TransportType
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -66,13 +65,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val _preferredCodec = MutableStateFlow(UserSettings.getPreferredCodec())
     val preferredCodec: StateFlow<String> = _preferredCodec.asStateFlow()
-
-    // Network-specific codec settings
-    private val _wifiCodec = MutableStateFlow(UserSettings.getCodecForNetwork(TransportType.WIFI))
-    val wifiCodec: StateFlow<String> = _wifiCodec.asStateFlow()
-
-    private val _cellularCodec = MutableStateFlow(UserSettings.getCodecForNetwork(TransportType.CELLULAR))
-    val cellularCodec: StateFlow<String> = _cellularCodec.asStateFlow()
 
     // Performance settings
     private val _lowMemoryMode = MutableStateFlow(UserSettings.lowMemoryMode)
@@ -180,16 +172,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun setPreferredCodec(codec: String) {
         UserSettings.setPreferredCodec(codec)
         _preferredCodec.value = codec
-    }
-
-    fun setWifiCodec(codec: String) {
-        UserSettings.setCodecForNetwork(TransportType.WIFI, codec)
-        _wifiCodec.value = codec
-    }
-
-    fun setCellularCodec(codec: String) {
-        UserSettings.setCodecForNetwork(TransportType.CELLULAR, codec)
-        _cellularCodec.value = codec
     }
 
     // Performance settings

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -173,17 +173,6 @@
     <string name="sync_offset_decrease">Decrease sync offset by 10ms</string>
     <string name="sync_offset_increase">Increase sync offset by 10ms</string>
     <string name="pref_codec_title">Preferred Audio Codec</string>
-    <string name="pref_codec_summary">Preferred format (falls back to PCM if unsupported)</string>
-    <string-array name="codec_entries">
-        <item>OPUS (Compressed)</item>
-        <item>FLAC (Lossless)</item>
-    </string-array>
-    <string-array name="codec_values">
-        <item>opus</item>
-        <item>flac</item>
-    </string-array>
-    <string name="pref_codec_reconnect_title">Reconnect Required</string>
-    <string name="pref_codec_reconnect_message">The new codec preference will be used the next time you connect to a server.</string>
     <string name="pref_codec_unavailable_hint">Not available on this device</string>
 
     <!-- Switch Server dialog (was Disconnect dialog) -->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -184,13 +184,7 @@
     </string-array>
     <string name="pref_codec_reconnect_title">Reconnect Required</string>
     <string name="pref_codec_reconnect_message">The new codec preference will be used the next time you connect to a server.</string>
-
-    <!-- Network-specific codec preferences -->
-    <string name="pref_category_network_codecs">Network Codec Preferences</string>
-    <string name="pref_codec_wifi_title">Codec on WiFi</string>
-    <string name="pref_codec_wifi_summary">Audio codec when connected via WiFi (leave unset to use default)</string>
-    <string name="pref_codec_cellular_title">Codec on Cellular</string>
-    <string name="pref_codec_cellular_summary">Audio codec when connected via cellular data (leave unset to use default)</string>
+    <string name="pref_codec_unavailable_hint">Not available on this device</string>
 
     <!-- Switch Server dialog (was Disconnect dialog) -->
     <string name="disconnect_dialog_title">Switch Server?</string>

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilderTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilderTest.kt
@@ -103,63 +103,62 @@ class MessageBuilderTest {
     // --- buildSupportedFormats ---
 
     @Test
-    fun buildSupportedFormats_preferredCodecFirst() {
+    fun buildSupportedFormats_preferredCodecFirst_pcmLast() {
         val formats = MessageBuilder.buildSupportedFormats(
             preferredCodec = "opus",
-            isCodecSupported = { it in listOf("flac", "opus", "pcm") }
+            isCodecSupported = { it in listOf("opus", "pcm") }
         )
         assertTrue(formats.isNotEmpty())
-        assertEquals("opus", formats[0].codec)
+        assertEquals("opus", formats.first().codec)
+        assertEquals("pcm", formats.last().codec)
     }
 
     @Test
-    fun buildSupportedFormats_pcmAlwaysLast() {
+    fun buildSupportedFormats_onlyPreferredAndPcm_noSecondaryCodec() {
+        // Regression guard for issue #26: previously a hardcoded [flac, opus] secondary
+        // list was appended after the preferred codec. Now only the preferred codec
+        // and PCM are advertised.
         val formats = MessageBuilder.buildSupportedFormats(
-            preferredCodec = "flac",
-            isCodecSupported = { it in listOf("flac", "opus", "pcm") }
+            preferredCodec = "opus",
+            isCodecSupported = { it in listOf("opus", "flac", "pcm") }
         )
-        val lastCodec = formats.last().codec
-        assertEquals("pcm", lastCodec)
+        val codecsAdvertised = formats.map { it.codec }.toSet()
+        assertEquals(setOf("opus", "pcm"), codecsAdvertised)
+    }
+
+    @Test
+    fun buildSupportedFormats_preferredPcmProducesPcmOnly() {
+        val formats = MessageBuilder.buildSupportedFormats(
+            preferredCodec = "pcm",
+            isCodecSupported = { it == "pcm" }
+        )
+        assertTrue(formats.all { it.codec == "pcm" })
+    }
+
+    @Test
+    fun buildSupportedFormats_preferredUnsupportedFallsBackToPcm() {
+        // On a device where the preferred codec is not decodable, we still advertise
+        // PCM so the session is not silently broken.
+        val formats = MessageBuilder.buildSupportedFormats(
+            preferredCodec = "opus",
+            isCodecSupported = { it == "pcm" }
+        )
+        val codecsAdvertised = formats.map { it.codec }.toSet()
+        assertEquals(setOf("pcm"), codecsAdvertised)
     }
 
     @Test
     fun buildSupportedFormats_stereoAndMonoForEachCodec() {
         val formats = MessageBuilder.buildSupportedFormats(
             preferredCodec = "flac",
-            isCodecSupported = { it == "flac" }
+            isCodecSupported = { it in listOf("flac", "pcm") }
         )
-        // flac: stereo + mono = 2 entries
-        assertEquals(2, formats.size)
-        assertEquals(2, formats[0].channels)
-        assertEquals(1, formats[1].channels)
-    }
-
-    @Test
-    fun buildSupportedFormats_includesMultipleBitDepths() {
-        val formats = MessageBuilder.buildSupportedFormats(
-            preferredCodec = "pcm",
-            isCodecSupported = { it == "pcm" },
-            supportedBitDepths = listOf(16, 24, 32)
-        )
-        // pcm at 32-bit stereo/mono, 24-bit stereo/mono, 16-bit stereo/mono = 6
-        // Higher bit depths should come first (server picks first match)
-        assertEquals(6, formats.size)
-        assertEquals(32, formats[0].bitDepth)
-        assertEquals(32, formats[1].bitDepth)
-        assertEquals(24, formats[2].bitDepth)
-        assertEquals(24, formats[3].bitDepth)
-        assertEquals(16, formats[4].bitDepth)
-        assertEquals(16, formats[5].bitDepth)
-    }
-
-    @Test
-    fun buildSupportedFormats_defaultBitDepthIs16Only() {
-        val formats = MessageBuilder.buildSupportedFormats(
-            preferredCodec = "pcm",
-            isCodecSupported = { it == "pcm" }
-        )
-        assertEquals(2, formats.size)
-        assertTrue(formats.all { it.bitDepth == 16 })
+        // flac at 16-bit stereo + mono = 2
+        // pcm at 16-bit stereo + mono = 2 (default supportedBitDepths = [16])
+        // total = 4
+        assertEquals(4, formats.size)
+        val channelSet = formats.map { it.channels }.toSet()
+        assertEquals(setOf(2, 1), channelSet)
     }
 
     @Test
@@ -170,17 +169,24 @@ class MessageBuilderTest {
             supportedBitDepths = listOf(16, 32)
         )
         // flac: 16-bit only (stereo + mono) = 2
-        // pcm:  32-bit stereo/mono + 16-bit stereo/mono = 4
+        // pcm:  32-bit stereo/mono + 16-bit stereo/mono = 4 (higher depths first)
         assertEquals(6, formats.size)
-        // First 2 are flac at 16-bit only
         assertEquals("flac", formats[0].codec)
         assertEquals(16, formats[0].bitDepth)
-        assertEquals("flac", formats[1].codec)
-        // Last 4 are pcm with higher depths first
         assertEquals("pcm", formats[2].codec)
         assertEquals(32, formats[2].bitDepth)
         assertEquals("pcm", formats[4].codec)
         assertEquals(16, formats[4].bitDepth)
+    }
+
+    @Test
+    fun buildSupportedFormats_defaultBitDepthIs16Only() {
+        val formats = MessageBuilder.buildSupportedFormats(
+            preferredCodec = "pcm",
+            isCodecSupported = { it == "pcm" }
+        )
+        assertEquals(2, formats.size)
+        assertTrue(formats.all { it.bitDepth == 16 })
     }
 
     // --- calculateBufferCapacity ---

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilderTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilderTest.kt
@@ -132,6 +132,8 @@ class MessageBuilderTest {
             preferredCodec = "pcm",
             isCodecSupported = { it == "pcm" }
         )
+        // Pin the dedup: pcm stereo + pcm mono = 2, not 4.
+        assertEquals(2, formats.size)
         assertTrue(formats.all { it.codec == "pcm" })
     }
 
@@ -145,6 +147,21 @@ class MessageBuilderTest {
         )
         val codecsAdvertised = formats.map { it.codec }.toSet()
         assertEquals(setOf("pcm"), codecsAdvertised)
+        // Default supportedBitDepths = [16], so pcm stereo + pcm mono = 2.
+        assertEquals(2, formats.size)
+    }
+
+    @Test
+    fun buildSupportedFormats_noCodecsSupportedReturnsEmpty() {
+        // Pins the current behaviour for the degenerate case where not even PCM
+        // is supported. A real Android device should never produce this (PCM is
+        // always supported) but we lock it in so a future refactor can't
+        // silently change the contract.
+        val formats = MessageBuilder.buildSupportedFormats(
+            preferredCodec = "opus",
+            isCodecSupported = { false }
+        )
+        assertTrue(formats.isEmpty())
     }
 
     @Test

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -143,13 +143,16 @@ object MessageBuilder {
     /**
      * Build the supported_formats list for the client/hello message.
      *
-     * The advertised list is always `[preferredCodec, pcm]` (each with stereo+mono
-     * variants at the appropriate bit depths), with these simplifications:
+     * The advertised list never contains a codec other than [preferredCodec] or
+     * `"pcm"`, and when both are present the preferred codec appears first
+     * (each with stereo+mono variants at the appropriate bit depths). Edge cases:
      * - If [preferredCodec] is not supported on this device, it is silently dropped
-     *   and only PCM is advertised. The Settings UI surfaces device support
+     *   and only PCM is advertised. The Settings UI surfaces supported codecs
      *   explicitly; this fallback exists so a connection can still succeed even
      *   if support state was stale at the time the preference was set.
      * - If [preferredCodec] is `"pcm"`, PCM is advertised once (not twice).
+     * - If neither the preferred codec nor PCM is supported (shouldn't happen on
+     *   any real Android device; PCM is always supported), the list is empty.
      *
      * Compressed codecs (FLAC, Opus) are always advertised at 16-bit. PCM is
      * advertised at every entry in [supportedBitDepths], highest first (so the

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -140,6 +140,21 @@ object MessageBuilder {
         return durationSec * maxPcmBytesPerSec
     }
 
+    /**
+     * Build the supported_formats list for the client/hello message.
+     *
+     * The advertised list is always `[preferredCodec, pcm]` (each with stereo+mono
+     * variants at the appropriate bit depths), with these simplifications:
+     * - If [preferredCodec] is not supported on this device, it is silently dropped
+     *   and only PCM is advertised. The Settings UI surfaces device support
+     *   explicitly; this fallback exists so a connection can still succeed even
+     *   if support state was stale at the time the preference was set.
+     * - If [preferredCodec] is `"pcm"`, PCM is advertised once (not twice).
+     *
+     * Compressed codecs (FLAC, Opus) are always advertised at 16-bit. PCM is
+     * advertised at every entry in [supportedBitDepths], highest first (so the
+     * server picks the best-quality match).
+     */
     fun buildSupportedFormats(
         preferredCodec: String,
         isCodecSupported: (String) -> Boolean,
@@ -149,12 +164,6 @@ object MessageBuilder {
 
         if (preferredCodec != "pcm" && isCodecSupported(preferredCodec)) {
             codecOrder.add(preferredCodec)
-        }
-
-        for (codec in listOf("flac", "opus")) {
-            if (codec != preferredCodec && isCodecSupported(codec)) {
-                codecOrder.add(codec)
-            }
         }
 
         if (isCodecSupported("pcm")) {


### PR DESCRIPTION
## Summary

Fixes issue #26: user has 3 Android devices, sets Preferred Codec to OPUS on all 3, but one device always uses FLAC with audio breakup. Root cause was a combination of silent auto-selection paths that made the user's preference invisible.

Three cleanups bundled:

**1. `MessageBuilder.buildSupportedFormats` stops advertising a competing codec.**
The hardcoded `[flac, opus]` secondary codec loop is gone. The advertised list is now exactly `[preferredCodec, pcm]`. A server that previously could pick FLAC from a list like `[opus, flac, pcm]` now receives `[opus, pcm]` and has no alternative to pick if OPUS is what the user wants.

**2. Delete `getCodecForNetwork` / `setCodecForNetwork` from `UserSettings`.**
These backed the \"WiFi Codec\" and \"Cellular Codec\" settings rows. Research confirmed they were UI-only theater - the wire-message path calls `getPreferredCodec()` unconditionally and never reads the network-specific values. Users who configured \"WiFi: OPUS, Cellular: FLAC\" were having their intent silently ignored.

**3. Collapse Settings UI + surface device codec support.**
Three codec rows become one \"Preferred Codec\" row. The picker now lists Opus / FLAC / PCM and **greys out codecs the device's MediaCodec can't decode**, with a \"Not available on this device\" hint. Users whose device lacks OPUS see it unavailable before picking it - eliminating the apparent-bug path that generated issue #26.

## What changes for existing users

- Users with working OPUS setups: no observable change. Advertised list narrows from `[opus, flac, pcm]` to `[opus, pcm]`; server still picks OPUS.
- Users on devices where OPUS isn't supported: dialog now surfaces \"Not available on this device\" instead of silently picking FLAC.
- Users who had WiFi/Cellular codec overrides set: those settings were never honoured by the wire path. Their `preferredCodec` continues to be honoured as before.
- Orphaned `codec_wifi` / `codec_cellular` SharedPreferences keys are left in place (~40 bytes/device). No migration; they're inert.

## Test Plan

Automated: 27 `MessageBuilderTest` cases pass, including a new regression-guard test (`buildSupportedFormats_onlyPreferredAndPcm_noSecondaryCodec`) referenced from issue #26. `testDebugUnitTest` passes cleanly in this worktree. `assembleDebug` succeeds.

Manual:

- [ ] Settings screen renders with a single \"Preferred Codec\" row (no \"WiFi Codec\" / \"Cellular Codec\" rows).
- [ ] Tapping the row opens a dialog with three options: Opus / FLAC / PCM.
- [ ] On a device supporting all three codecs, all three are selectable (radio buttons + text at normal color).
- [ ] On a device missing a codec (test with a legacy device if available), that codec appears greyed out with a \"Not available on this device\" subtitle and cannot be tapped.
- [ ] Picking each codec persists across app restarts.
- [ ] Connecting with OPUS selected advertises `[opus, pcm]` on the wire (verify in logcat: `buildSupportedFormats` output or the client/hello JSON).
- [ ] Connecting with PCM selected streams uncompressed audio correctly.

## Known follow-ups (not blocking this PR)

1. **Settings summary row** does not indicate when the stored preferred codec is unavailable on the current device. A user who doesn't open the picker won't see the fallback. Worth a follow-up issue to append \"(unavailable, using PCM)\" to the summary.
2. **PCM has no bandwidth warning.** 48 kHz / 16-bit / stereo is ~1.5 Mbps (~650 MB/hour on cellular). A curious user could burn through a metered plan. Worth an informational sub-label on the PCM row.

## Commits

```
338f956 chore: address code review on codec UI collapse
021a244 feat: collapse codec settings to one row with device-support indicator
3b57b97 refactor: remove network-specific codec settings from UserSettings + ViewModel
cb058c4 chore: address code review on buildSupportedFormats simplification
f831a71 fix: advertise only preferred codec plus PCM (drop hardcoded secondary)
```

Note: commit `3b57b97` intentionally leaves the build broken; `021a244` restores it. The two form one atomic refactor (delete ViewModel API + update its only consumer). Consider squash-merging those two if you prefer a bisect-friendly history.

Closes #26.