### PR TITLE
fix: auto-reselect connection mode on network-type change (hotfix for drive-time blackout)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -387,10 +387,27 @@ class PlaybackService : MediaLibraryService() {
             // 2. Cancelling backoff for immediate retry (existing onNetworkAvailable behavior)
             sendSpinClient?.setNetworkAvailable(true)
 
-            // Only trigger time filter reset if we had a previous network and it changed
+            // Only trigger time filter reset + reselection if we had a previous network
+            // and it changed (not the very first callback on connect).
             if (lastNetworkId != -1 && lastNetworkId != networkId) {
                 Log.i(TAG, "Network changed from $lastNetworkId to $networkId")
                 sendSpinClient?.onNetworkChanged()
+
+                // A network identity change means the old transport address may no
+                // longer be reachable (typical case: WiFi -> Cellular while a LAN
+                // LOCAL connection is in use). The inner reconnect loop would retry
+                // the old mode forever; instead, cleanly yield so the outer
+                // AutoReconnectManager loop re-runs ConnectionSelector against the
+                // new network and picks the right mode. Unconditional because the
+                // cost of an unnecessary reselection is one extra reconnect cycle,
+                // while the cost of a missed reselection is ~50s of blackout.
+                val connState = sendSpinClient?.connectionState?.value
+                val shouldReselect = connState is SendSpinClient.ConnectionState.Connected ||
+                                     connState is SendSpinClient.ConnectionState.Connecting
+                if (shouldReselect) {
+                    Log.i(TAG, "Triggering connection reselection for new network")
+                    sendSpinClient?.disconnectForReselection()
+                }
             }
             lastNetworkId = networkId
         }
@@ -398,12 +415,24 @@ class PlaybackService : MediaLibraryService() {
         override fun onLost(network: Network) {
             Log.d(TAG, "Network lost: id=${network.hashCode()}")
             // Don't reset lastNetworkId here - we want to detect when a new network comes up
-            // Update network evaluator to reflect disconnected state
-            networkEvaluator?.evaluateCurrentNetwork(null)
+            // Update network evaluator to reflect disconnected state only if nothing else is up
+            val stillHaveNetwork = connectivityManager?.activeNetwork != null
+            networkEvaluator?.evaluateCurrentNetwork(
+                if (stillHaveNetwork) connectivityManager?.activeNetwork else null
+            )
             // Cancel any pending validation-loss debounce; onLost is authoritative.
             mainHandler.removeCallbacks(validationLossRunnable)
-            // Notify client so reconnection pauses instead of wasting attempts
-            sendSpinClient?.setNetworkAvailable(false)
+            // Only signal unavailability if we have no active network. During a
+            // transport handover (WiFi -> Cellular), onLost(WiFi) fires AFTER
+            // onAvailable(Cellular); blindly calling setNetworkAvailable(false)
+            // there would pause the reconnect loop despite having a working
+            // network, making the observable blackout longer.
+            if (!stillHaveNetwork) {
+                Log.i(TAG, "No active network remaining - pausing client reconnect")
+                sendSpinClient?.setNetworkAvailable(false)
+            } else {
+                Log.d(TAG, "Another network still active - keeping client reconnect running")
+            }
         }
 
         override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -628,6 +628,44 @@ class SendSpinClient(
     }
 
     /**
+     * Disconnect from the current server for reasons that should trigger an
+     * upward auto-reconnect, such as the underlying network transport type
+     * changing (WiFi -> Cellular). Unlike [disconnect], this does NOT set
+     * [userInitiatedDisconnect]. Fires `onDisconnected(wasUserInitiated=false,
+     * wasReconnectExhausted=false)`, which MainActivity's STATE_DISCONNECTED
+     * handler interprets as "start AutoReconnectManager" -- the outer reconnect
+     * loop re-runs `ConnectionSelector` fresh and picks the right mode for
+     * whatever network we are on now.
+     *
+     * The reason for existing: [disconnect] is a user action (tap 'Switch Server'
+     * etc.) and explicitly suppresses auto-reconnect. We want the opposite here:
+     * the user did nothing wrong, the network changed out from under us, and the
+     * inner reconnect loop is going to spin forever on the wrong mode. Yield
+     * cleanly and let the outer loop re-select.
+     */
+    fun disconnectForReselection() {
+        stopStallWatchdog()
+        Log.i(TAG, "Disconnecting for reselection (transport-type change)")
+
+        // Cancel any pending reconnect coroutine to prevent races
+        reconnectJob?.cancel()
+        reconnectJob = null
+
+        stopTimeSync()
+        reconnecting.set(false)
+        waitingForNetwork.set(false)
+        sendGoodbye("network_type_changed")
+        // Clear the transport listener BEFORE closing to prevent the async onClosed
+        // callback from firing a second onDisconnected after we fire one synchronously below.
+        transport?.setListener(null)
+        transport?.close(1000, "Reselection")
+        transport = null
+        handshakeComplete = false
+        _connectionState.value = ConnectionState.Disconnected
+        callback.onDisconnected(wasUserInitiated = false, wasReconnectExhausted = false)
+    }
+
+    /**
      * Disconnect from the current server.
      */
     fun disconnect() {

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientDisconnectForReselectionTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientDisconnectForReselectionTest.kt
@@ -1,0 +1,155 @@
+package com.sendspindroid.sendspin
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.preference.PreferenceManager
+import com.sendspindroid.UserSettings
+import com.sendspindroid.sendspin.decoder.AudioDecoderFactory
+import com.sendspindroid.sendspin.transport.SendSpinTransport
+import com.sendspindroid.sendspin.transport.TransportState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SendSpinClientDisconnectForReselectionTest {
+
+    private lateinit var mockContext: Context
+    private lateinit var mockCallback: SendSpinClient.Callback
+    private lateinit var client: SendSpinClient
+    private lateinit var fakeTransport: FakeTransport
+
+    private class FakeTransport : SendSpinTransport {
+        var closeCalled = false
+        var closeCode: Int = -1
+        var listenerCleared = false
+        override val state = TransportState.Connected
+        override val isConnected = true
+        override fun connect() {}
+        override fun send(text: String) = true
+        override fun send(bytes: ByteArray) = true
+        override fun setListener(listener: SendSpinTransport.Listener?) {
+            if (listener == null) listenerCleared = true
+        }
+        override fun close(code: Int, reason: String) {
+            closeCalled = true
+            closeCode = code
+        }
+        override fun destroy() {}
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+
+        mockkStatic(Log::class)
+        every { Log.v(any(), any()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.e(any(), any<String>()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+
+        mockkObject(UserSettings)
+        every { UserSettings.getPlayerId() } returns "test-player-id"
+        every { UserSettings.getPreferredCodec() } returns "opus"
+        every { UserSettings.lowMemoryMode } returns false
+        every { UserSettings.highPowerMode } returns false
+
+        mockkObject(AudioDecoderFactory)
+        every { AudioDecoderFactory.isCodecSupported(any()) } returns true
+
+        mockkStatic(PreferenceManager::class)
+        val mockPrefs = mockk<SharedPreferences>(relaxed = true)
+        every { PreferenceManager.getDefaultSharedPreferences(any()) } returns mockPrefs
+
+        mockContext = mockk(relaxed = true)
+        mockCallback = mockk(relaxed = true)
+
+        client = SendSpinClient(mockContext, "TestDevice", mockCallback)
+        fakeTransport = FakeTransport()
+
+        // Seed connected-state so disconnectForReselection has something to tear down.
+        val addrField = SendSpinClient::class.java.getDeclaredField("serverAddress")
+        addrField.isAccessible = true
+        addrField.set(client, "127.0.0.1:8080")
+
+        val transportField = SendSpinClient::class.java.getDeclaredField("transport")
+        transportField.isAccessible = true
+        transportField.set(client, fakeTransport)
+
+        val handshakeField = SendSpinClient::class.java.superclass.getDeclaredField("handshakeComplete")
+        handshakeField.isAccessible = true
+        handshakeField.set(client, true)
+    }
+
+    @After
+    fun tearDown() {
+        client.destroy()
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `disconnectForReselection fires onDisconnected with wasUserInitiated false and wasReconnectExhausted false`() {
+        client.disconnectForReselection()
+
+        verify(exactly = 1) {
+            mockCallback.onDisconnected(
+                wasUserInitiated = false,
+                wasReconnectExhausted = false
+            )
+        }
+    }
+
+    @Test
+    fun `disconnectForReselection closes the transport`() {
+        client.disconnectForReselection()
+
+        assertTrue("Transport close should be called", fakeTransport.closeCalled)
+        assertEquals(1000, fakeTransport.closeCode)
+    }
+
+    @Test
+    fun `disconnectForReselection clears transport listener before closing`() {
+        client.disconnectForReselection()
+
+        assertTrue("Transport listener should be cleared", fakeTransport.listenerCleared)
+    }
+
+    @Test
+    fun `disconnectForReselection cancels in-flight reconnect coroutine`() {
+        val reconnectingField = SendSpinClient::class.java.getDeclaredField("reconnecting")
+        reconnectingField.isAccessible = true
+        (reconnectingField.get(client) as AtomicBoolean).set(true)
+
+        client.disconnectForReselection()
+
+        assertFalse("Reconnecting flag should be cleared",
+            (reconnectingField.get(client) as AtomicBoolean).get())
+    }
+
+    @Test
+    fun `disconnectForReselection does not set userInitiatedDisconnect`() {
+        client.disconnectForReselection()
+
+        val userInitiatedField = SendSpinClient::class.java.getDeclaredField("userInitiatedDisconnect")
+        userInitiatedField.isAccessible = true
+        assertFalse("userInitiatedDisconnect must stay false so MainActivity auto-reconnects",
+            (userInitiatedField.get(client) as AtomicBoolean).get())
+    }
+}


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by PR #119. Real user drove from home WiFi into cellular coverage and hit ~50 seconds of audio blackout before the app finally recovered on PROXY.

### Root cause

`SendSpinClient.attemptReconnect` uses the stored `connectionMode` and never yields when the underlying network changes. Before PR #119's unbounded-retry change, the normal-mode 5-attempt cap would have surfaced an \"exhausted\" error after ~15s, which flowed into MainActivity's auto-reconnect branch and kicked off `AutoReconnectManager.startReconnecting` (which DOES run ConnectionSelector fresh). PR #119 removed that cap to fix the zombie-WiFi case, but broke this one.

### Reproduction timeline (from ADB log, abridged)

| Time | Event |
|---|---|
| 15:26:10 | Connect on WiFi. LOCAL picked, ws://10.0.2.8:8927/sendspin |
| 15:26:11 | Network switches WiFi -> Cellular |
| 15:26:20 | LOCAL socket dies (Software caused connection abort) |
| 15:26:20-25 | Client retries LOCAL from cellular 464xlat IP - times out |
| 15:26:25 | setNetworkAvailable(false) from VALIDATED-loss pauses the loop |
| 15:26:25-49 | Audio buffer plays out (~24s) - user hears \"15-30s of audio\" |
| 15:26:49 | Buffer exhausted, Error state fires, MainActivity falls back to auto-discovery |
| 15:26:55 | ConnectionSelector finally runs, picks PROXY |
| 15:27:07 | PROXY handshake completes |

Total: ~50s blackout. The client was locked onto a dead LAN IP the entire time because nothing triggered a fresh ConnectionSelector evaluation.

## Fix

Two changes, both in app module:

**1. `SendSpinClient.disconnectForReselection()` (new method)** - mirrors `disconnect()` but does NOT set `userInitiatedDisconnect=true`, and fires `onDisconnected(wasUserInitiated=false, wasReconnectExhausted=false)`. That trips MainActivity's STATE_DISCONNECTED handler at `MainActivity.kt:2050-2067` which calls `AutoReconnectManager.startReconnecting(server)` - the outer loop that runs ConnectionSelector fresh on every attempt and tries all configured methods in priority order.

**2. `PlaybackService.networkCallback` two hooks:**
- **`onAvailable`:** when the network identity changes (existing `lastNetworkId != networkId` path), also call `disconnectForReselection()` if the client is currently Connected or Connecting. Triggers the reselection path above.
- **`onLost`:** skip the `setNetworkAvailable(false)` signal if `connectivityManager.activeNetwork` is non-null. During a WiFi -> Cellular handover, `onAvailable(Cellular)` fires *before* `onLost(WiFi)`, so blindly pausing the reconnect loop on `onLost` made the blackout longer than it had to be.

Together these remove the 15-30s LOCAL-retry-then-buffer-drain window and take us directly from \"WiFi died\" to \"PROXY handshake starting\" in roughly one cellular TLS-handshake latency (~10-15s instead of ~50s).

## Test Plan

Automated:
- 5 new unit tests in `SendSpinClientDisconnectForReselectionTest.kt` verify the method fires the correct `onDisconnected` flags, closes transport with code 1000, clears the transport listener before close (pre-existing anti-race pattern), cancels in-flight reconnect, and does NOT set `userInitiatedDisconnect`.
- Full `:app:testDebugUnitTest` passes with no regressions.

Manual:

- [ ] **Drive repro:** start playback on home WiFi, drive out of range. Expect audio to resume on PROXY within ~15s of WiFi dropping instead of ~50s. Logcat should show `Triggering connection reselection for new network` followed by `Selected PROXY for Music Assistant on CELLULAR`.
- [ ] **Same-network reconnect:** toggle WiFi off and on at home. Should NOT trigger the reselection log - the network id is usually the same on rejoin.
- [ ] **Cellular-only:** disable WiFi, start fresh. PROXY should be selected immediately with zero LOCAL-retry churn.
- [ ] **Home-WiFi steady state:** let the app run on WiFi for minutes. Should NOT see any unexpected reselection logs.

## Commits

```
16ffeaa fix: trigger AutoReconnectManager on network-type change
d4f8401 feat: add SendSpinClient.disconnectForReselection for clean mode handoff
```

Plan: `docs/superpowers/plans/2026-04-20-hotfix-network-type-reselection.md` in the branch.

Related: #119 (the PR this hotfixes a regression from).