### PR TITLE
feat: idle stall watchdog + LOCAL->PROXY fallback (#126, #127)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -1768,6 +1768,17 @@ class PlaybackService : MediaLibraryService() {
         currentServerId = serverId
         currentConnectionMode = connectionMode
         Log.d(TAG, "Set current server: $serverId, mode=$connectionMode")
+
+        // Configure PROXY fallback for internal LOCAL->PROXY switchover in the
+        // reconnect loop. Only applies when connecting in LOCAL mode with a server
+        // that also has a PROXY config; cleared (null/null) otherwise so a later
+        // server-switch doesn't carry stale fallback data. Issue #126.
+        val proxy = if (connectionMode == ConnectionMode.LOCAL) {
+            serverId?.let { UnifiedServerRepository.getServer(it) }?.proxy
+        } else {
+            null
+        }
+        sendSpinClient?.setProxyFallback(proxy?.url, proxy?.authToken)
     }
 
     /**

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -89,6 +89,20 @@ class SendSpinClient(
         private const val STALL_TIMEOUT_MS = 7_000L
         private const val STALL_CHECK_INTERVAL_MS = 3_000L
 
+        // Idle-mode stall threshold. Larger than the streaming threshold because during
+        // idle the only regular server->client traffic is server/time responses to our
+        // TimeSyncManager bursts. Burst cadence is 500ms-3s once converged, so ~9s is
+        // the worst-case natural silence; 20s gives 2x headroom while still catching
+        // server death with headroom for reconnect + resync inside the ~30s audio buffer.
+        // Issue #127.
+        private const val IDLE_STALL_TIMEOUT_MS = 20_000L
+
+        // After this many consecutive LOCAL-mode reconnect failures in a row, switch
+        // internally to PROXY if a fallback was configured via setProxyFallback().
+        // Prevents indefinite retry of a dead LAN address when the server is no longer
+        // reachable on this network. Issue #126.
+        private const val LOCAL_RECONNECT_FALLBACK_THRESHOLD = 3
+
     }
 
     /**
@@ -164,6 +178,13 @@ class SendSpinClient(
     // Proxy authentication state
     private var authToken: String? = null
     private var awaitingAuthResponse = false
+
+    // Optional PROXY fallback config. When set and the client is reconnecting in
+    // LOCAL mode after [LOCAL_RECONNECT_FALLBACK_THRESHOLD] consecutive failures,
+    // the client switches internally to PROXY using these values instead of
+    // continuing to retry a dead LAN address. See setProxyFallback(). Issue #126.
+    private var proxyFallbackUrl: String? = null
+    private var proxyFallbackAuthToken: String? = null
 
     // Client identity - persisted across app launches
     private val clientId = UserSettings.getPlayerId()
@@ -449,6 +470,23 @@ class SendSpinClient(
      */
     fun connect(address: String, path: String = SendSpinProtocol.ENDPOINT_PATH) {
         connectLocal(address, path)
+    }
+
+    /**
+     * Configure a PROXY fallback for LOCAL mode. When set, the client will switch
+     * internally to PROXY after [LOCAL_RECONNECT_FALLBACK_THRESHOLD] consecutive
+     * LOCAL-mode reconnect failures, instead of retrying the dead LAN address
+     * indefinitely. Closes the "moved off LAN but saved LOCAL address is still
+     * being tried" gap from issue #126.
+     *
+     * Call with (null, null) to clear (e.g., when switching servers, or when
+     * connecting to a server that has no PROXY configured).
+     *
+     * Safe to call at any time; takes effect on the next reconnect cycle.
+     */
+    fun setProxyFallback(url: String?, authToken: String?) {
+        proxyFallbackUrl = url
+        proxyFallbackAuthToken = authToken
     }
 
     /**
@@ -770,10 +808,16 @@ class SendSpinClient(
 
     /**
      * Check whether the transport has gone silent for too long and force-close it
-     * if so. Only acts when the client is connected, handshake is complete, a
-     * stream is active (server has announced stream/start and not stream/stop),
-     * and we are not already in a reconnect cycle. Keeps the watchdog from
-     * false-tripping during idle periods when the server has nothing to send.
+     * if so. Only acts when the client is connected, handshake is complete, and we
+     * are not already in a reconnect cycle.
+     *
+     * Uses a two-tier threshold: [STALL_TIMEOUT_MS] while a stream is active (audio
+     * frames should arrive continuously), and [IDLE_STALL_TIMEOUT_MS] when idle
+     * (only regular traffic is server/time responses to our TimeSyncManager bursts).
+     * The idle threshold catches server death during kiosk/dashboard-style
+     * deployments where music is rarely flowing -- without it, detection relied on
+     * OkHttp's 30s ping timeout alone which consumes the entire audio buffer.
+     * Issue #127.
      *
      * Private for production; reached via reflection from SendSpinClientStallWatchdogTest.
      */
@@ -783,15 +827,15 @@ class SendSpinClient(
         if (!handshakeComplete) return
         val t = transport ?: return
         if (!t.isConnected) return
-        // Don't trip during idle - server may send nothing between streams, and
-        // WebSocket pings (which keep the socket alive) don't update lastByteReceivedAtMs.
-        if (!streamActive.get()) return
 
+        val streaming = streamActive.get()
+        val threshold = if (streaming) STALL_TIMEOUT_MS else IDLE_STALL_TIMEOUT_MS
         val sinceLastByte = System.currentTimeMillis() - lastByteReceivedAtMs.get()
-        if (sinceLastByte > STALL_TIMEOUT_MS) {
-            Log.w(TAG, "Stall watchdog: no data received in ${sinceLastByte}ms (threshold ${STALL_TIMEOUT_MS}ms) - forcing transport close")
+        if (sinceLastByte > threshold) {
+            val mode = if (streaming) "streaming" else "idle"
+            Log.w(TAG, "Stall watchdog: no data received in ${sinceLastByte}ms ($mode threshold ${threshold}ms) - forcing transport close")
             // 1001 "Going Away" is non-1000 so onClosed path triggers reconnection
-            t.close(1001, "stall watchdog")
+            t.close(1001, "stall watchdog ($mode)")
         }
     }
 
@@ -823,6 +867,36 @@ class SendSpinClient(
         }
 
         val attempts = reconnectAttempts.incrementAndGet()
+
+        // LOCAL -> PROXY internal fallback: if LOCAL reconnect has failed
+        // [LOCAL_RECONNECT_FALLBACK_THRESHOLD] times in a row and a PROXY fallback
+        // is configured, switch modes internally instead of retrying a LAN address
+        // that is apparently unreachable on this network. Issue #126.
+        //
+        // Note: we intentionally do NOT call disconnectForReselection() here.
+        // That would trigger MainActivity.startReconnecting -> AutoReconnectManager,
+        // but AutoReconnectManager's performAutoReconnect() returns optimistically
+        // and would re-select LOCAL first, creating an infinite ping-pong. Doing
+        // the mode switch internally keeps this fix self-contained.
+        val fbUrl = proxyFallbackUrl
+        val fbToken = proxyFallbackAuthToken
+        if (connectionMode == ConnectionMode.LOCAL &&
+            attempts > LOCAL_RECONNECT_FALLBACK_THRESHOLD &&
+            !fbUrl.isNullOrBlank() &&
+            !fbToken.isNullOrBlank()) {
+            Log.i(TAG, "LOCAL reconnect failed $attempts times; switching internally to PROXY fallback")
+            connectionMode = ConnectionMode.PROXY
+            serverAddress = fbUrl
+            serverPath = null  // PROXY URL already carries the path; matches connectProxy()
+            authToken = fbToken
+            // Reset so PROXY attempt counting starts fresh (backoff from attempt 1).
+            reconnectAttempts.set(0)
+            // Re-invoke attemptReconnect so the PROXY path goes through the same
+            // freeze/backoff/transport-creation flow. This also re-checks
+            // canReconnect and userInitiatedDisconnect cleanly.
+            attemptReconnect()
+            return
+        }
 
         // On first reconnection attempt, freeze the time filter
         if (attempts == 1) {

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientLocalFallbackTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientLocalFallbackTest.kt
@@ -1,0 +1,218 @@
+package com.sendspindroid.sendspin
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.preference.PreferenceManager
+import com.sendspindroid.UserSettings
+import com.sendspindroid.sendspin.decoder.AudioDecoderFactory
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests for the LOCAL -> PROXY internal fallback in SendSpinClient.attemptReconnect.
+ *
+ * Covers issue #126: when LOCAL reconnect has failed [LOCAL_RECONNECT_FALLBACK_THRESHOLD]
+ * times in a row and a PROXY fallback has been configured via setProxyFallback(),
+ * the client switches connectionMode to PROXY internally rather than retrying a
+ * LAN address that's apparently unreachable on the current network.
+ *
+ * These tests drive attemptReconnect() via reflection and inspect the private
+ * connectionMode / serverAddress / authToken fields to confirm the switch happens.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SendSpinClientLocalFallbackTest {
+
+    private lateinit var mockContext: Context
+    private lateinit var mockCallback: SendSpinClient.Callback
+    private lateinit var client: SendSpinClient
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+
+        mockkStatic(Log::class)
+        every { Log.v(any(), any()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.e(any(), any<String>()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+
+        mockkObject(UserSettings)
+        every { UserSettings.getPlayerId() } returns "test-player-id"
+        every { UserSettings.getPreferredCodec() } returns "opus"
+        every { UserSettings.lowMemoryMode } returns false
+        every { UserSettings.highPowerMode } returns false
+
+        mockkObject(AudioDecoderFactory)
+        every { AudioDecoderFactory.isCodecSupported(any()) } returns true
+
+        mockkStatic(PreferenceManager::class)
+        val mockPrefs = mockk<SharedPreferences>(relaxed = true)
+        every { PreferenceManager.getDefaultSharedPreferences(any()) } returns mockPrefs
+
+        mockContext = mockk(relaxed = true)
+        mockCallback = mockk(relaxed = true)
+
+        client = SendSpinClient(mockContext, "TestDevice", mockCallback)
+
+        // Seed connection info so canReconnect passes and attemptReconnect proceeds
+        setField("serverAddress", "192.168.1.42:8927")
+        setField("serverPath", "/sendspin")
+        setField("connectionMode", SendSpinClient.ConnectionMode.LOCAL)
+    }
+
+    @After
+    fun tearDown() {
+        client.destroy()
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `switches to PROXY after threshold LOCAL failures when fallback is set`() {
+        client.setProxyFallback("wss://proxy.example.com/sendspin", "token-abc")
+
+        // Simulate 3 prior failed attempts. The threshold check fires when attempts > 3,
+        // so the 4th call should trigger the switch.
+        getAtomicInt("reconnectAttempts").set(3)
+
+        invokeAttemptReconnect()
+
+        assertEquals(
+            "connectionMode should switch to PROXY after exceeding threshold",
+            SendSpinClient.ConnectionMode.PROXY,
+            getField("connectionMode")
+        )
+        assertEquals(
+            "serverAddress should be set to the fallback PROXY URL",
+            "wss://proxy.example.com/sendspin",
+            getField("serverAddress")
+        )
+        assertEquals(
+            "authToken should be set to the fallback token",
+            "token-abc",
+            getField("authToken")
+        )
+        assertNull(
+            "serverPath should be cleared for PROXY mode (path lives in URL)",
+            getField("serverPath")
+        )
+    }
+
+    @Test
+    fun `does not switch before threshold`() {
+        client.setProxyFallback("wss://proxy.example.com/sendspin", "token-abc")
+
+        // Two prior attempts; third call hits attempts=3 which is NOT > threshold=3.
+        getAtomicInt("reconnectAttempts").set(2)
+
+        invokeAttemptReconnect()
+
+        assertEquals(
+            "connectionMode should remain LOCAL below threshold",
+            SendSpinClient.ConnectionMode.LOCAL,
+            getField("connectionMode")
+        )
+    }
+
+    @Test
+    fun `does not switch when no fallback is configured`() {
+        // setProxyFallback was not called — both fields are null.
+        getAtomicInt("reconnectAttempts").set(10)  // well past threshold
+
+        invokeAttemptReconnect()
+
+        assertEquals(
+            "connectionMode should remain LOCAL when no PROXY fallback is available",
+            SendSpinClient.ConnectionMode.LOCAL,
+            getField("connectionMode")
+        )
+    }
+
+    @Test
+    fun `does not switch when only one fallback field is set (incomplete config)`() {
+        client.setProxyFallback("wss://proxy.example.com/sendspin", null)
+        getAtomicInt("reconnectAttempts").set(10)
+
+        invokeAttemptReconnect()
+
+        assertEquals(
+            "connectionMode should remain LOCAL when fallback is incomplete",
+            SendSpinClient.ConnectionMode.LOCAL,
+            getField("connectionMode")
+        )
+    }
+
+    @Test
+    fun `setProxyFallback with null clears a previously configured fallback`() {
+        client.setProxyFallback("wss://proxy.example.com/sendspin", "token-abc")
+        client.setProxyFallback(null, null)
+
+        getAtomicInt("reconnectAttempts").set(10)
+        invokeAttemptReconnect()
+
+        assertEquals(
+            "connectionMode should remain LOCAL after fallback is cleared",
+            SendSpinClient.ConnectionMode.LOCAL,
+            getField("connectionMode")
+        )
+    }
+
+    @Test
+    fun `does not switch when already in PROXY mode`() {
+        // Simulating a stuck PROXY retry; fallback logic is LOCAL-only.
+        setField("connectionMode", SendSpinClient.ConnectionMode.PROXY)
+        setField("authToken", "existing-token")
+        client.setProxyFallback("wss://other-proxy.example.com/sendspin", "token-xyz")
+        getAtomicInt("reconnectAttempts").set(10)
+
+        invokeAttemptReconnect()
+
+        assertEquals(
+            "connectionMode should stay PROXY; fallback does not override an in-progress PROXY connection",
+            SendSpinClient.ConnectionMode.PROXY,
+            getField("connectionMode")
+        )
+    }
+
+    // --- helpers ---
+
+    private fun invokeAttemptReconnect() {
+        val m = SendSpinClient::class.java.getDeclaredMethod("attemptReconnect")
+        m.isAccessible = true
+        m.invoke(client)
+    }
+
+    private fun setField(name: String, value: Any?) {
+        val f = SendSpinClient::class.java.getDeclaredField(name)
+        f.isAccessible = true
+        f.set(client, value)
+    }
+
+    private fun getField(name: String): Any? {
+        val f = SendSpinClient::class.java.getDeclaredField(name)
+        f.isAccessible = true
+        return f.get(client)
+    }
+
+    private fun getAtomicInt(name: String): AtomicInteger {
+        val f = SendSpinClient::class.java.getDeclaredField(name)
+        f.isAccessible = true
+        return f.get(client) as AtomicInteger
+    }
+}

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientStallWatchdogTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientStallWatchdogTest.kt
@@ -223,14 +223,15 @@ class SendSpinClientStallWatchdogTest {
     }
 
     @Test
-    fun `checkStall does not close when no stream is active`() {
-        // Seed a stale timestamp that would normally trip the watchdog
+    fun `checkStall does not close during idle when recently active (under idle threshold)`() {
+        // Idle threshold is 20s; 15s stale should NOT trip. Issue #127: idle watchdog
+        // uses a longer threshold than streaming to accommodate TimeSyncManager burst
+        // cadence, but still detects genuine server death well inside the 30s buffer.
         val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
         lastByteField.isAccessible = true
         val atomicLong = lastByteField.get(client) as AtomicLong
-        atomicLong.set(System.currentTimeMillis() - 60_000L)
+        atomicLong.set(System.currentTimeMillis() - 15_000L)  // 15s stale — under idle threshold
 
-        // Ensure streamActive is false (it defaults to false, but be explicit)
         val streamActiveField = SendSpinClient::class.java.getDeclaredField("streamActive")
         streamActiveField.isAccessible = true
         val streamActive = streamActiveField.get(client) as AtomicBoolean
@@ -240,7 +241,51 @@ class SendSpinClientStallWatchdogTest {
         checkStall.isAccessible = true
         checkStall.invoke(client)
 
-        assertFalse("Watchdog should NOT close while no stream is active",
+        assertFalse("Watchdog should NOT close during idle when within the idle threshold",
+            fakeTransport.closeCalled)
+    }
+
+    @Test
+    fun `checkStall closes during idle when past idle threshold`() {
+        // Idle threshold is 20s; 25s stale should trip even with no stream active. Issue #127.
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as AtomicLong
+        atomicLong.set(System.currentTimeMillis() - 25_000L)  // 25s stale — past idle threshold
+
+        val streamActiveField = SendSpinClient::class.java.getDeclaredField("streamActive")
+        streamActiveField.isAccessible = true
+        val streamActive = streamActiveField.get(client) as AtomicBoolean
+        streamActive.set(false)
+
+        val checkStall = SendSpinClient::class.java.getDeclaredMethod("checkStall")
+        checkStall.isAccessible = true
+        checkStall.invoke(client)
+
+        assertTrue("Watchdog should close during idle when past the 20s idle threshold",
+            fakeTransport.closeCalled)
+        assertNotEquals(1000, fakeTransport.closeCode)
+    }
+
+    @Test
+    fun `checkStall does not close streaming within streaming threshold`() {
+        // Streaming threshold is 7s; 5s stale should NOT trip. Regression guard against
+        // accidental tightening of the streaming threshold.
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as AtomicLong
+        atomicLong.set(System.currentTimeMillis() - 5_000L)  // 5s stale — under streaming threshold
+
+        val streamActiveField = SendSpinClient::class.java.getDeclaredField("streamActive")
+        streamActiveField.isAccessible = true
+        val streamActive = streamActiveField.get(client) as AtomicBoolean
+        streamActive.set(true)
+
+        val checkStall = SendSpinClient::class.java.getDeclaredMethod("checkStall")
+        checkStall.isAccessible = true
+        checkStall.invoke(client)
+
+        assertFalse("Watchdog should NOT close while streaming within the 7s threshold",
             fakeTransport.closeCalled)
     }
 


### PR DESCRIPTION
## Summary

Two P1 connection-resilience fixes from the recent gap analysis, both targeting the ~30 s audio-buffer budget. Builds directly on PR #124 (`disconnectForReselection`, `AutoReconnectManager`) and PR #121 (OkHttp pings).

### Issue #127 — idle stall watchdog

Previously `checkStall()` early-returned when `!streamActive`. During idle (paused playback, kiosk-style dashboard between tracks), dead-server detection relied solely on OkHttp's 30 s ping timeout — consuming the entire audio buffer with no headroom for reconnect.

**Fix:** two-tier threshold.
- Streaming: `STALL_TIMEOUT_MS = 7 s` (unchanged).
- Idle: `IDLE_STALL_TIMEOUT_MS = 20 s` (new).

Idle threshold sized against `TimeSyncManager` burst cadence (500 ms–3 s once converged, ~9 s worst case). 2× headroom against natural silence, still catches genuine server death well inside the buffer.

### Issue #126 — LOCAL→PROXY fallback

Previously `attemptReconnect` retried the saved LAN address forever in LOCAL mode. PR #124 wired `AutoReconnectManager` onto network-identity change, but "same network, server unreachable" (router subnet change, server LAN move) had no recovery.

**Rejected approach:** call `disconnectForReselection()` from within `attemptReconnect` on LOCAL exhaustion. `MainActivity.performAutoReconnect` returns `true` optimistically without awaiting real connection state (existing TODO in code acknowledges this), so `AutoReconnectManager` would always re-pick LOCAL as first-priority on WiFi. Each yield would spawn a fresh `AutoReconnectManager` cycle → infinite ping-pong. Fixing `performAutoReconnect` is a separate, larger change tracked as a candidate follow-up.

**Chosen approach:** fully self-contained internal mode switch.
- `SendSpinClient.setProxyFallback(url, authToken)` receives a PROXY endpoint from `PlaybackService`. `null/null` clears.
- After `LOCAL_RECONNECT_FALLBACK_THRESHOLD` (3) consecutive LOCAL failures with a configured fallback, `attemptReconnect` flips `connectionMode` to PROXY, substitutes URL/token into `serverAddress`/`authToken`, resets the attempt counter, and re-invokes itself. Existing backoff / transport / handshake path takes over from there.
- `PlaybackService.setCurrentServer` looks up the server's PROXY config at connect time and pushes it in. Passes `null/null` for REMOTE/PROXY modes so a server switch can't leak stale fallback.

**Budget impact:** ~2–4 s to detect LOCAL dead (backoff at 500 ms / 1 s / 2 s), then an immediate PROXY attempt. Well inside 30 s. Users without PROXY configured see unchanged behavior.

## Test plan

- [x] `./gradlew assembleDebug` clean compile; no new warnings on touched files.
- [x] `./gradlew :app:testDebugUnitTest` clean: all 7 SendSpinClient test suites pass (45 tests).
  - `SendSpinClientStallWatchdogTest` grew from 7 to 10 tests (replaced the "!streamActive suppresses" test with "idle-under-threshold doesn't trip"; added "idle-past-20s trips"; added "streaming-under-7s doesn't trip" regression guard).
  - New `SendSpinClientLocalFallbackTest` (6 tests) covers threshold / no-fallback / incomplete-fallback / clear / PROXY-mode cases.
- [ ] **Field verification for #127:** start playback, pause (stream inactive, client still connected), kill MA server, verify reconnect starts within 20–25 s.
- [ ] **Field verification for #126:** configure a server with both LOCAL and PROXY URLs, connect on LOCAL, simulate LAN-only server disappearance (iptables DROP on the LAN port; keep PROXY reachable), verify reconnect via PROXY within ~5–8 s.

## Out of scope (explicit)

- **Fix `performAutoReconnect` to wait for real connection state.** Would let the `AutoReconnectManager` path handle LOCAL→PROXY natively via `ConnectionSelector`, but is a separate architectural change. Current self-contained fallback is sufficient for the reported scenario and more conservative (no risk of ping-pong).
- **Periodic LAN re-probe when on PROXY** (Issue #126's proposal 3). The client stays on PROXY after a successful fallback; user can manually reconnect if they want to try LAN again. Deferred until there's evidence it's needed.
- **500 ms TCP probe** as an optimization path for Issue #126's proposal 1. Current N-failures approach adds ~2–4 s of latency on the fallback path, which is well inside the budget.

Closes #126.
Closes #127.