### PR TITLE
feat: surface Reconnecting state on MediaSession (#132)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/MetadataForwardingPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/MetadataForwardingPlayer.kt
@@ -55,6 +55,14 @@ class MetadataForwardingPlayer(player: Player) : ForwardingPlayer(player) {
     @Volatile
     private var cachedMetadata: MediaMetadata = MediaMetadata.EMPTY
 
+    // Reconnecting overlay: when non-null, the rebuilt metadata substitutes
+    // "Reconnecting to {serverName}..." for the title (preserving artwork and
+    // subtitle) and getPlaybackState() returns STATE_BUFFERING. This surfaces
+    // recovery visibly on the lock screen, Android Auto, and AVRCP instead of
+    // leaving the stale track title during reconnect storms. Issue #132.
+    @Volatile
+    private var reconnectingOverlay: String? = null
+
     /**
      * Updates the current track metadata.
      *
@@ -120,6 +128,11 @@ class MetadataForwardingPlayer(player: Player) : ForwardingPlayer(player) {
 
     /**
      * Rebuilds the cached MediaMetadata from current values.
+     *
+     * When [reconnectingOverlay] is non-null, the title and displayTitle are
+     * replaced with "Reconnecting to {server}..." while subtitle and artwork
+     * are preserved; the lock screen keeps the album art but clearly reads as
+     * recovering. Issue #132.
      */
     private fun rebuildMetadata() {
         // Build subtitle for Android Auto's DISPLAY_SUBTITLE (e.g. "Artist - Album")
@@ -131,9 +144,12 @@ class MetadataForwardingPlayer(player: Player) : ForwardingPlayer(player) {
             }
         }.ifEmpty { null }
 
+        val overlayServer = reconnectingOverlay
+        val displayTitle = if (overlayServer != null) "Reconnecting to $overlayServer..." else currentTitle
+
         cachedMetadata = MediaMetadata.Builder()
-            .setTitle(currentTitle)
-            .setDisplayTitle(currentTitle)
+            .setTitle(displayTitle)
+            .setDisplayTitle(displayTitle)
             .setSubtitle(subtitle)  // Android Auto uses DISPLAY_SUBTITLE for second line
             .setArtist(currentArtist)
             .setAlbumTitle(currentAlbum)
@@ -146,6 +162,46 @@ class MetadataForwardingPlayer(player: Player) : ForwardingPlayer(player) {
                 currentArtworkUri?.let { setArtworkUri(it) }
             }
             .build()
+    }
+
+    /**
+     * Show a "Reconnecting to {serverName}..." overlay on the MediaSession while
+     * the client is in ConnectionState.Reconnecting. Also forces
+     * [getPlaybackState] to return [Player.STATE_BUFFERING] so lock screen /
+     * Auto / AVRCP render the system buffering indicator.
+     *
+     * Idempotent: calling with the same [serverName] twice is a no-op after
+     * the first call, so it is safe to call on every retry attempt.
+     *
+     * Issue #132.
+     */
+    fun setReconnectingOverlay(serverName: String) {
+        if (reconnectingOverlay == serverName) return
+        reconnectingOverlay = serverName
+        rebuildMetadata()
+        val newState = getPlaybackState()
+        listeners.forEach { listener ->
+            listener.onMediaMetadataChanged(cachedMetadata)
+            listener.onPlaybackStateChanged(newState)
+        }
+    }
+
+    /**
+     * Clear any active reconnecting overlay and restore normal metadata /
+     * playback-state behavior. Called on [ConnectionState.Connected],
+     * [ConnectionState.Disconnected], or [ConnectionState.Error].
+     *
+     * Idempotent: no-op if no overlay is active. Issue #132.
+     */
+    fun clearReconnectingOverlay() {
+        if (reconnectingOverlay == null) return
+        reconnectingOverlay = null
+        rebuildMetadata()
+        val newState = getPlaybackState()
+        listeners.forEach { listener ->
+            listener.onMediaMetadataChanged(cachedMetadata)
+            listener.onPlaybackStateChanged(newState)
+        }
     }
 
     /**
@@ -171,13 +227,27 @@ class MetadataForwardingPlayer(player: Player) : ForwardingPlayer(player) {
      * for lock screen and notifications.
      */
     override fun getMediaMetadata(): MediaMetadata {
-        // If we have metadata, return it; otherwise fall back to underlying player
-        return if (currentTitle != null || currentArtist != null) {
+        // The reconnecting overlay always takes precedence: even if no track
+        // metadata has ever been set, the user should see "Reconnecting to..."
+        // rather than an empty lock screen.
+        return if (reconnectingOverlay != null ||
+            currentTitle != null ||
+            currentArtist != null) {
             cachedMetadata
         } else {
             super.getMediaMetadata()
         }
     }
+
+    /**
+     * Forces [Player.STATE_BUFFERING] while a reconnecting overlay is active,
+     * so the lock screen / Android Auto / AVRCP render the buffering indicator
+     * rather than showing the old "playing" state. Falls through to the
+     * underlying player's state otherwise. Issue #132.
+     */
+    override fun getPlaybackState(): Int =
+        if (reconnectingOverlay != null) Player.STATE_BUFFERING
+        else super.getPlaybackState()
 
     /**
      * Returns the current media item with our enhanced metadata injected.

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -858,6 +858,9 @@ class PlaybackService : MediaLibraryService() {
                 _connectionState.value = ConnectionState.Connected(serverName)
                 sendSpinPlayer?.updateConnectionState(true, serverName)
                 sendSpinPlayer?.clearError()
+                // Restore MediaSession metadata / playback state after any reconnect.
+                // Idempotent: no-op when no overlay is active. Issue #132.
+                forwardingPlayer?.clearReconnectingOverlay()
 
                 // Refresh browse tree root so "Connect" disappears
                 mediaSession?.notifyChildrenChanged(MEDIA_ID_ROOT, 0, null)
@@ -903,6 +906,10 @@ class PlaybackService : MediaLibraryService() {
                 // Stop debug logging session
                 stopDebugLogging()
                 AppLog.session.end()
+
+                // Any active reconnect overlay is no longer meaningful once we've
+                // transitioned out of Reconnecting into a terminal state. Issue #132.
+                forwardingPlayer?.clearReconnectingOverlay()
 
                 // Check if we're in DRAINING state (reconnection in progress)
                 // If so, keep the audio player alive to continue playback from buffer
@@ -1183,6 +1190,9 @@ class PlaybackService : MediaLibraryService() {
                 // Show error on Android Auto
                 sendSpinPlayer?.setError(message)
 
+                // Terminal error supersedes any reconnecting overlay. Issue #132.
+                forwardingPlayer?.clearReconnectingOverlay()
+
                 // Broadcast error to controllers (MainActivity)
                 broadcastConnectionState(STATE_ERROR, errorMessage = message)
             }
@@ -1387,6 +1397,11 @@ class PlaybackService : MediaLibraryService() {
 
                 // Broadcast to UI
                 broadcastConnectionState(STATE_RECONNECTING, serverName)
+
+                // Surface the reconnect on the MediaSession so lock screen / Android Auto
+                // / AVRCP show "Reconnecting to {server}..." and the buffering indicator
+                // instead of the stale track title. Issue #132.
+                forwardingPlayer?.setReconnectingOverlay(serverName)
             }
         }
 

--- a/android/app/src/test/java/com/sendspindroid/playback/MetadataForwardingPlayerReconnectingTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/playback/MetadataForwardingPlayerReconnectingTest.kt
@@ -1,0 +1,142 @@
+package com.sendspindroid.playback
+
+import androidx.media3.common.Player
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for the reconnecting-overlay behavior on [MetadataForwardingPlayer]
+ * introduced by issue #132. The overlay substitutes
+ * "Reconnecting to {server}..." for the title and forces
+ * [Player.STATE_BUFFERING] so lock screen / Android Auto / AVRCP render a
+ * recovering indicator while [SendSpinClient] is in the `Reconnecting` state.
+ */
+class MetadataForwardingPlayerReconnectingTest {
+
+    private lateinit var mockPlayer: Player
+    private lateinit var forwardingPlayer: MetadataForwardingPlayer
+
+    @Before
+    fun setUp() {
+        mockPlayer = mockk(relaxed = true)
+        every { mockPlayer.playbackState } returns Player.STATE_READY
+        forwardingPlayer = MetadataForwardingPlayer(mockPlayer)
+    }
+
+    @Test
+    fun `setReconnectingOverlay substitutes title while preserving subtitle and album`() {
+        forwardingPlayer.updateMetadata(title = "Song Title", artist = "Some Artist", album = "Some Album")
+
+        forwardingPlayer.setReconnectingOverlay("Living Room")
+
+        val metadata = forwardingPlayer.mediaMetadata
+        assertEquals("Reconnecting to Living Room...", metadata.title.toString())
+        assertEquals("Reconnecting to Living Room...", metadata.displayTitle.toString())
+        // Subtitle / artist / album preserved so lock-screen layout + album-art match last known.
+        assertEquals("Some Artist - Some Album", metadata.subtitle.toString())
+        assertEquals("Some Artist", metadata.artist.toString())
+        assertEquals("Some Album", metadata.albumTitle.toString())
+    }
+
+    @Test
+    fun `getPlaybackState returns STATE_BUFFERING while overlay is set`() {
+        every { mockPlayer.playbackState } returns Player.STATE_READY
+
+        forwardingPlayer.setReconnectingOverlay("Kitchen")
+
+        assertEquals(Player.STATE_BUFFERING, forwardingPlayer.playbackState)
+    }
+
+    @Test
+    fun `getPlaybackState falls through to underlying player when no overlay`() {
+        every { mockPlayer.playbackState } returns Player.STATE_READY
+        assertEquals(Player.STATE_READY, forwardingPlayer.playbackState)
+
+        every { mockPlayer.playbackState } returns Player.STATE_IDLE
+        assertEquals(Player.STATE_IDLE, forwardingPlayer.playbackState)
+    }
+
+    @Test
+    fun `clearReconnectingOverlay restores the underlying title`() {
+        forwardingPlayer.updateMetadata(title = "Song Title", artist = "Artist", album = "Album")
+        forwardingPlayer.setReconnectingOverlay("Office")
+        assertEquals("Reconnecting to Office...", forwardingPlayer.mediaMetadata.title.toString())
+
+        forwardingPlayer.clearReconnectingOverlay()
+
+        assertEquals("Song Title", forwardingPlayer.mediaMetadata.title.toString())
+        assertEquals("Song Title", forwardingPlayer.mediaMetadata.displayTitle.toString())
+        // Playback state falls through again.
+        every { mockPlayer.playbackState } returns Player.STATE_READY
+        assertEquals(Player.STATE_READY, forwardingPlayer.playbackState)
+    }
+
+    @Test
+    fun `updateMetadata during reconnecting keeps overlay title`() {
+        forwardingPlayer.updateMetadata(title = "Original", artist = "A", album = "B")
+        forwardingPlayer.setReconnectingOverlay("Dining")
+
+        // A server metadata update arrives mid-reconnect. It must not unseat the overlay --
+        // the lock screen should keep reading "Reconnecting to Dining..." until connected.
+        forwardingPlayer.updateMetadata(title = "Different Song", artist = "Different Artist", album = "Different Album")
+
+        val metadata = forwardingPlayer.mediaMetadata
+        assertEquals("Reconnecting to Dining...", metadata.title.toString())
+        // Underlying state is still updated -- once overlay clears, the latest will surface.
+        assertEquals("Different Artist - Different Album", metadata.subtitle.toString())
+
+        forwardingPlayer.clearReconnectingOverlay()
+        assertEquals("Different Song", forwardingPlayer.mediaMetadata.title.toString())
+    }
+
+    @Test
+    fun `setReconnectingOverlay is idempotent (same server fires listeners only once)`() {
+        val listener = mockk<Player.Listener>(relaxed = true)
+        forwardingPlayer.addListener(listener)
+
+        forwardingPlayer.setReconnectingOverlay("Garage")
+        forwardingPlayer.setReconnectingOverlay("Garage")
+        forwardingPlayer.setReconnectingOverlay("Garage")
+
+        verify(exactly = 1) { listener.onMediaMetadataChanged(any()) }
+        verify(exactly = 1) { listener.onPlaybackStateChanged(any()) }
+    }
+
+    @Test
+    fun `setReconnectingOverlay with different server rebuilds and notifies`() {
+        val listener = mockk<Player.Listener>(relaxed = true)
+        forwardingPlayer.addListener(listener)
+
+        forwardingPlayer.setReconnectingOverlay("Garage")
+        forwardingPlayer.setReconnectingOverlay("Basement")  // different server, e.g. user switched
+
+        verify(exactly = 2) { listener.onMediaMetadataChanged(any()) }
+        assertEquals("Reconnecting to Basement...", forwardingPlayer.mediaMetadata.title.toString())
+    }
+
+    @Test
+    fun `clearReconnectingOverlay is idempotent when no overlay is active`() {
+        val listener = mockk<Player.Listener>(relaxed = true)
+        forwardingPlayer.addListener(listener)
+
+        forwardingPlayer.clearReconnectingOverlay()
+        forwardingPlayer.clearReconnectingOverlay()
+
+        verify(exactly = 0) { listener.onMediaMetadataChanged(any()) }
+        verify(exactly = 0) { listener.onPlaybackStateChanged(any()) }
+    }
+
+    @Test
+    fun `overlay works even when no prior metadata was set`() {
+        // Fresh client, no updateMetadata call has been made yet.
+        forwardingPlayer.setReconnectingOverlay("FirstBoot")
+
+        val metadata = forwardingPlayer.mediaMetadata
+        assertEquals("Reconnecting to FirstBoot...", metadata.title.toString())
+        assertEquals(Player.STATE_BUFFERING, forwardingPlayer.playbackState)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #132. Makes the lock screen, Android Auto, and Bluetooth AVRCP show a clear "Reconnecting to {server}..." indicator during reconnect storms instead of the stale track title with a phantom-playing indicator.

The in-app `ReconnectingBanner` already handles the Compose UI. This PR extends the same signal to the MediaSession surfaces users actually look at while audio is out.

## Changes

### `MetadataForwardingPlayer`
- New `reconnectingOverlay: String?` field.
- New `setReconnectingOverlay(serverName)` / `clearReconnectingOverlay()` idempotent methods. Both rebuild cached metadata and notify listeners via `onMediaMetadataChanged` + `onPlaybackStateChanged`.
- Existing `rebuildMetadata()` substitutes `"Reconnecting to {serverName}..."` for the title/displayTitle while preserving subtitle ("Artist - Album"), artwork, album title — lock screen keeps art intact, just reads as recovering.
- `getMediaMetadata()` returns cached metadata when an overlay is set even if no title was ever set (cold-boot reconnect case).
- New `getPlaybackState()` override returns `Player.STATE_BUFFERING` while the overlay is set; falls through to underlying player otherwise. `STATE_BUFFERING` is already in the app's state vocabulary (used during stream init / reanchor), so existing Auto / lock-screen UIs handle it correctly — no new UI to worry about.

### `PlaybackService.SendSpinClientCallback`
- `onReconnecting` → `setReconnectingOverlay(serverName)`.
- `onConnected` / `onDisconnected` / `onError` → `clearReconnectingOverlay()`.
- Idempotent, so redundant clears on non-reconnect paths are harmless.

## Test plan

- [x] `./gradlew assembleDebug` — clean compile, no new warnings on touched files.
- [x] `./gradlew :app:testDebugUnitTest` clean:
  - New `MetadataForwardingPlayerReconnectingTest` (9 tests): title substitution + preservation of subtitle/album, `STATE_BUFFERING` while set, fall-through when clear, restore on clear, updateMetadata-during-reconnect keeps overlay, idempotency, different-server rebuild, no-op when not set, cold-boot case.
  - Existing `MetadataForwardingPlayerTest` (9 tests) continues to pass.
  - Full `:app:testDebugUnitTest` BUILD SUCCESSFUL.
- [ ] **Manual verification:** connect to a server with album art, start playback, kill the server. Lock screen / Auto should show "Reconnecting to {server}..." with the album art retained + buffering indicator. Restore connection → title reverts to the real track.

## Out of scope

- **Dedicated Android Auto browse-tree "Reconnecting..." node.** Users look at the now-playing surface during reconnect, not the browse tree.
- **MediaSession error state / `setPlayerError`.** Using an error would trigger more aggressive UI (error icon, unavailable controls). `STATE_BUFFERING` matches "temporary, recovering" better.
- **Custom reconnecting icon / notification layout.** The title-override + `STATE_BUFFERING` combo is the standard Media3 idiom and works across Auto / lock screen / AVRCP / Wear with no custom assets.