### PR TITLE
fix: make PlaybackService.lastNetworkId @Volatile

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -338,6 +338,11 @@ class PlaybackService : MediaLibraryService() {
 
     // Network change detection - resets time filter when network changes
     private var connectivityManager: ConnectivityManager? = null
+
+    // @Volatile: written only from a binder thread (NetworkCallback.onAvailable) and
+    // may be read from other threads (future reconnect-coroutine paths). Single-writer
+    // contract: all writes occur inside onAvailable. -1 means "no prior network seen".
+    @Volatile
     private var lastNetworkId: Int = -1
     private var networkEvaluator: NetworkEvaluator? = null
 


### PR DESCRIPTION
## Summary

Makes `PlaybackService.lastNetworkId: Int` thread-safe by adding `@Volatile`, matching the pattern already used for `lastValidatedState` in the same file. Single-writer contract documented in an inline comment: all writes happen inside `NetworkCallback.onAvailable` (binder thread); reads may come from other threads.

Closes #131.

## Test Plan

- [x] `./gradlew :app:compileDebugKotlin` - BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest` - BUILD SUCCESSFUL (no behavior change; existing tests unaffected)
- [ ] Manual smoke: toggle WiFi/cellular on device - reconnect + time-filter-reset still fire on network change (same behavior as before).