### PR TITLE
feat: expose connection-health telemetry + [disconnect] logs (#128)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -2839,6 +2839,17 @@ class PlaybackService : MediaLibraryService() {
             bundle.putInt("reconnect_attempts", client.getReconnectAttempts())
             bundle.putBoolean("clock_frozen", timeFilter.isFrozen)
             bundle.putDouble("static_delay_ms", timeFilter.staticDelayMs)
+
+            // Connection health telemetry (issue #128). Keys left absent when
+            // the underlying value is null so StatsViewModel can distinguish
+            // "no disconnect yet" from "last disconnect was code=0".
+            bundle.putLong("last_byte_received_ago_ms", client.getLastByteReceivedAgoMs())
+            bundle.putBoolean("stall_watchdog_armed", client.isStallWatchdogArmed())
+            bundle.putInt("reconnect_attempts_total", client.getReconnectAttemptsTotal())
+            client.getLastDisconnectCode()?.let { bundle.putInt("last_disconnect_code", it) }
+            client.getLastDisconnectReason()?.let { bundle.putString("last_disconnect_reason", it) }
+            bundle.putDouble("time_filter_stability", timeFilter.stability)
+            bundle.putLong("time_filter_convergence_ms", timeFilter.convergenceTimeMillis)
         }
 
         // Get network stats from NetworkEvaluator

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import android.util.Log
 import com.sendspindroid.UserSettings
+import com.sendspindroid.logging.AppLog
 import com.sendspindroid.remote.WebRTCTransport
 import com.sendspindroid.sendspin.transport.ProxyWebSocketTransport
 import com.sendspindroid.sendspin.protocol.GroupInfo
@@ -214,6 +215,17 @@ class SendSpinClient(
     // nothing for long periods, which would cause false-positive stalls.
     private val streamActive = AtomicBoolean(false)
 
+    // -- Connection health telemetry (issue #128). All observational: updated on
+    // event paths that already touch state (handshake-complete, onClosed,
+    // onFailure, attemptReconnect); read by the stats poll and the structured
+    // [disconnect]/[reconnect-ok] log lines. No hot-path cost.
+    private val reconnectAttemptsTotal = AtomicInteger(0)
+    @Volatile private var connectedAtMs: Long? = null
+    @Volatile private var lastDisconnectAtMs: Long? = null
+    @Volatile private var lastDisconnectCode: Int? = null
+    @Volatile private var lastDisconnectReason: String? = null
+    @Volatile private var lastDisconnectMode: ConnectionMode? = null
+
     val isConnected: Boolean
         get() = _connectionState.value is ConnectionState.Connected
 
@@ -221,6 +233,35 @@ class SendSpinClient(
      * Get the number of reconnection attempts since last successful connect.
      */
     fun getReconnectAttempts(): Int = reconnectAttempts.get()
+
+    // -- Connection health accessors (issue #128) --
+
+    /** Milliseconds since the transport last delivered a text or binary frame. */
+    fun getLastByteReceivedAgoMs(): Long =
+        System.currentTimeMillis() - lastByteReceivedAtMs.get()
+
+    /**
+     * True when the stall watchdog would actually evaluate: handshake is
+     * complete, the client isn't mid-reconnect, and the user hasn't asked to
+     * disconnect. Note: this does NOT check `streamActive` -- the watchdog
+     * fires in both streaming (7 s threshold) and idle (20 s threshold) states
+     * per #127, so "armed" means "the watchdog is running and will trip if
+     * the appropriate silence threshold is exceeded."
+     */
+    fun isStallWatchdogArmed(): Boolean =
+        handshakeComplete && !userInitiatedDisconnect.get() && !reconnecting.get()
+
+    /** Lifetime reconnect attempts (survives across sessions within the process). */
+    fun getReconnectAttemptsTotal(): Int = reconnectAttemptsTotal.get()
+
+    /** Most recent close code seen on an abnormal disconnect; null if none. */
+    fun getLastDisconnectCode(): Int? = lastDisconnectCode
+
+    /** Most recent close reason / error message. null if no disconnect yet. */
+    fun getLastDisconnectReason(): String? = lastDisconnectReason
+
+    /** When the current session handshake completed (null if not connected). */
+    fun getConnectedAtMs(): Long? = connectedAtMs
 
     init {
         // Initialize time sync manager with our time filter
@@ -273,12 +314,35 @@ class SendSpinClient(
             Log.i(TAG, "Time filter thawed after reconnection - re-syncing with increased covariance")
         }
 
+        // Capture telemetry for the structured [reconnect-ok] line before resetting
+        // current-cycle counters. Issue #128.
+        val attemptsThisCycle = reconnectAttempts.get()
+        val disconnectAtMs = lastDisconnectAtMs
+
         reconnecting.set(false)
         reconnectAttempts.set(0)
         waitingForNetwork.set(false)
         _connectionState.value = ConnectionState.Connected(serverName)
 
+        // Mark session start for uptime calculation and clear the disconnect marker.
+        // Issue #128.
+        connectedAtMs = System.currentTimeMillis()
+        lastDisconnectAtMs = null
+
         if (wasReconnecting) {
+            // Emit a structured recovery log line so shared on-device logs show
+            // end-to-end reconnect outcomes (disconnect -> handshake complete).
+            // Issue #128.
+            if (disconnectAtMs != null) {
+                val tookSeconds = (System.currentTimeMillis() - disconnectAtMs) / 1000.0
+                AppLog.Network.i(
+                    "[reconnect-ok] took_s=%.1f attempts_this_cycle=%d attempts_total=%d".format(
+                        tookSeconds,
+                        attemptsThisCycle,
+                        reconnectAttemptsTotal.get(),
+                    )
+                )
+            }
             callback.onReconnected()
             Log.i(TAG, "Reconnection successful")
         }
@@ -840,6 +904,55 @@ class SendSpinClient(
     }
 
     /**
+     * Record disconnect state and emit a structured `[disconnect]` log line
+     * consumable by anyone reading the on-device log file shared via Settings.
+     *
+     * Invariants (issue #128):
+     *   * Fires on every disconnect path -- normal, abnormal, pre-handshake, or
+     *     user-initiated. The stats screen's "last disconnect" is informational
+     *     regardless of whether reconnect is scheduled.
+     *   * Uptime is derived from [connectedAtMs] (null -> "preconnect" when
+     *     handshake had not yet completed).
+     *   * Logs at INFO so `AppLog.level = WARN or above` suppresses emission
+     *     without any formatting cost.
+     */
+    private fun recordDisconnectTelemetry(
+        code: Int?,
+        reasonText: String,
+        isNormalClosure: Boolean,
+    ) {
+        val now = System.currentTimeMillis()
+        val connectedAt = connectedAtMs
+
+        // Persist for the stats screen. Keep the "abnormal" flag for Part B's
+        // reconnect-result correlation: lastDisconnectAtMs only gates the
+        // [reconnect-ok] emission on a subsequent handshake complete, not the
+        // user-facing stats, so only set it on abnormal closures that will
+        // actually trigger a retry cycle.
+        lastDisconnectCode = code
+        lastDisconnectReason = reasonText
+        lastDisconnectMode = connectionMode
+        if (!isNormalClosure && !userInitiatedDisconnect.get()) {
+            lastDisconnectAtMs = now
+        }
+
+        // Session ended for uptime purposes regardless of whether we reconnect.
+        connectedAtMs = null
+
+        val codeField = code?.toString() ?: "none"
+        val uptimeField = if (connectedAt != null) {
+            "%.1f".format((now - connectedAt) / 1000.0)
+        } else {
+            "preconnect"
+        }
+        AppLog.Network.i(
+            "[disconnect] code=$codeField reason=${reasonText.ifBlank { "unknown" }} " +
+                "mode=$connectionMode uptime_s=$uptimeField " +
+                "attempts_total=${reconnectAttemptsTotal.get()}"
+        )
+    }
+
+    /**
      * Attempt reconnection with exponential backoff.
      *
      * Exponential backoff for the first 5 attempts (500ms -> 8s), then 30s
@@ -867,6 +980,8 @@ class SendSpinClient(
         }
 
         val attempts = reconnectAttempts.incrementAndGet()
+        // Lifetime counter survives across reconnect cycles. Issue #128.
+        reconnectAttemptsTotal.incrementAndGet()
 
         // LOCAL -> PROXY internal fallback: if LOCAL reconnect has failed
         // [LOCAL_RECONNECT_FALLBACK_THRESHOLD] times in a row and a PROXY fallback
@@ -1124,6 +1239,16 @@ class SendSpinClient(
             // This is NOT an error that should trigger reconnection
             val isNormalClosure = code == 1000
 
+            // Record telemetry for the stats screen + emit the structured [disconnect]
+            // log line. Issue #128. Safe for all paths (normal, abnormal,
+            // user-initiated): the stats screen shows "last disconnect" which is
+            // informational regardless of whether we reconnect.
+            recordDisconnectTelemetry(
+                code = code,
+                reasonText = reason.ifEmpty { "code=$code" },
+                isNormalClosure = isNormalClosure,
+            )
+
             val hasConnectionInfo = when (connectionMode) {
                 ConnectionMode.LOCAL -> serverAddress != null
                 ConnectionMode.REMOTE -> remoteId != null
@@ -1154,6 +1279,15 @@ class SendSpinClient(
 
         override fun onFailure(error: Throwable, isRecoverable: Boolean) {
             Log.e(TAG, "Transport failure", error)
+
+            // Record telemetry for the stats screen + emit the structured [disconnect]
+            // log line. onFailure has no WebSocket close code -- use `null` code and
+            // the error class/message as the reason. Issue #128.
+            recordDisconnectTelemetry(
+                code = null,
+                reasonText = error.message ?: error::class.java.simpleName,
+                isNormalClosure = false,
+            )
 
             val hasConnectionInfo = when (connectionMode) {
                 ConnectionMode.LOCAL -> serverAddress != null

--- a/android/app/src/main/java/com/sendspindroid/ui/stats/StatsBottomSheetContent.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/stats/StatsBottomSheetContent.kt
@@ -80,6 +80,29 @@ fun StatsContent(
         StatRow(stringResource(R.string.stats_state), state.connectionState, getStatusColor(getConnectionStatus(state.connectionState)))
         StatRow(stringResource(R.string.stats_codec), state.audioCodec)
         StatRow(stringResource(R.string.stats_reconnects), state.reconnectAttempts.toString(), getStatusColor(state.reconnectAttempts == 0))
+        if (state.reconnectAttemptsTotal > 0) {
+            StatRow(stringResource(R.string.stats_reconnects_total), state.reconnectAttemptsTotal.toString())
+        }
+        if (state.lastByteReceivedAgoMs >= 0) {
+            StatRow(
+                stringResource(R.string.stats_last_byte_received),
+                String.format("%.1fs ago", state.lastByteReceivedAgoMs / 1000.0),
+                getLastSyncColor(state.lastByteReceivedAgoMs),
+            )
+        }
+        StatRow(
+            stringResource(R.string.stats_stall_watchdog),
+            if (state.stallWatchdogArmed) stringResource(R.string.stats_watchdog_armed) else stringResource(R.string.stats_watchdog_idle),
+            if (state.stallWatchdogArmed) ColorGood else null,
+        )
+        if (state.lastDisconnectCode != null || state.lastDisconnectReason != null) {
+            val code = state.lastDisconnectCode?.toString() ?: "--"
+            val reason = state.lastDisconnectReason?.take(40) ?: ""
+            StatRow(
+                stringResource(R.string.stats_last_disconnect),
+                "code=$code ${if (reason.isNotEmpty()) "\"$reason\"" else ""}".trim(),
+            )
+        }
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
 
@@ -136,6 +159,20 @@ fun StatsContent(
         StatRow(stringResource(R.string.stats_converged), if (state.clockConverged) stringResource(R.string.action_yes) else stringResource(R.string.action_no),
             if (state.clockConverged) ColorGood else ColorWarning)
         StatRow(stringResource(R.string.stats_measurements), state.measurementCount.toString())
+        // Kalman-filter health. `stability` should be ~1.0 for a well-tuned filter;
+        // < 1 = over-responsive, > 1 = sluggish. `convergence` is time from first
+        // measurement to first isConverged==true. Issue #128.
+        StatRow(
+            stringResource(R.string.stats_stability),
+            String.format("%.2f", state.timeFilterStability),
+            getStabilityColor(state.timeFilterStability),
+        )
+        if (state.timeFilterConvergenceMs > 0) {
+            StatRow(
+                stringResource(R.string.stats_convergence_time),
+                String.format("%.1fs", state.timeFilterConvergenceMs / 1000.0),
+            )
+        }
 
         if (state.lastTimeSyncAgeMs >= 0) {
             StatRow(stringResource(R.string.stats_last_sync), String.format("%.1fs ago", state.lastTimeSyncAgeMs / 1000.0),
@@ -287,6 +324,17 @@ private fun getLastSyncColor(ageMs: Long): Color {
         ageMs < 10_000L -> ColorWarning
         else -> ColorBad
     }
+}
+
+/**
+ * Kalman-filter stability score (issue #128). Ideal ~1.0; departures in either
+ * direction indicate a mis-tuned or noisy filter. Generous band around 1.0 is
+ * fine for "healthy" because jitter is normal on real networks.
+ */
+private fun getStabilityColor(stability: Double): Color? = when {
+    stability in 0.7..1.5 -> ColorGood
+    stability in 0.5..2.5 -> ColorWarning
+    else -> ColorBad
 }
 
 private fun formatNumber(value: Long): String {

--- a/android/app/src/main/java/com/sendspindroid/ui/stats/StatsViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/stats/StatsViewModel.kt
@@ -174,7 +174,16 @@ class StatsViewModel(application: Application) : AndroidViewModel(application) {
             framesInserted = bundle.getLong("frames_inserted", 0L),
             framesDropped = bundle.getLong("frames_dropped", 0L),
             syncCorrections = bundle.getLong("sync_corrections", 0L),
-            reanchorCount = bundle.getLong("reanchor_count", 0L)
+            reanchorCount = bundle.getLong("reanchor_count", 0L),
+
+            // Connection health (issue #128)
+            lastByteReceivedAgoMs = bundle.getLong("last_byte_received_ago_ms", -1L),
+            stallWatchdogArmed = bundle.getBoolean("stall_watchdog_armed", false),
+            reconnectAttemptsTotal = bundle.getInt("reconnect_attempts_total", 0),
+            lastDisconnectCode = if (bundle.containsKey("last_disconnect_code")) bundle.getInt("last_disconnect_code") else null,
+            lastDisconnectReason = bundle.getString("last_disconnect_reason", null),
+            timeFilterStability = bundle.getDouble("time_filter_stability", 1.0),
+            timeFilterConvergenceMs = bundle.getLong("time_filter_convergence_ms", 0L),
         )
     }
 
@@ -249,7 +258,18 @@ data class StatsState(
     val framesInserted: Long = 0L,
     val framesDropped: Long = 0L,
     val syncCorrections: Long = 0L,
-    val reanchorCount: Long = 0L
+    val reanchorCount: Long = 0L,
+
+    // Connection health (issue #128). Exposes keepalive freshness, watchdog
+    // state, lifetime reconnect count, last-disconnect details, and
+    // time-filter stability for field triage.
+    val lastByteReceivedAgoMs: Long = -1L,
+    val stallWatchdogArmed: Boolean = false,
+    val reconnectAttemptsTotal: Int = 0,
+    val lastDisconnectCode: Int? = null,
+    val lastDisconnectReason: String? = null,
+    val timeFilterStability: Double = 1.0,
+    val timeFilterConvergenceMs: Long = 0L,
 ) {
     // Derived values
     val syncErrorMs: Double get() = syncErrorUs / 1000.0

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -767,6 +767,14 @@
     <string name="stats_state">State</string>
     <string name="stats_codec">Codec</string>
     <string name="stats_reconnects">Reconnects</string>
+    <string name="stats_reconnects_total">Reconnects (lifetime)</string>
+    <string name="stats_last_byte_received">Last Byte Received</string>
+    <string name="stats_stall_watchdog">Stall Watchdog</string>
+    <string name="stats_watchdog_armed">Armed</string>
+    <string name="stats_watchdog_idle">Idle</string>
+    <string name="stats_last_disconnect">Last Disconnect</string>
+    <string name="stats_stability">Filter Stability</string>
+    <string name="stats_convergence_time">Convergence Time</string>
     <string name="stats_type">Type</string>
     <string name="stats_quality">Quality</string>
     <string name="stats_metered">Metered</string>

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientDisconnectTelemetryTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientDisconnectTelemetryTest.kt
@@ -1,0 +1,271 @@
+package com.sendspindroid.sendspin
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.preference.PreferenceManager
+import com.sendspindroid.UserSettings
+import com.sendspindroid.logging.AppLog
+import com.sendspindroid.logging.LogLevel
+import com.sendspindroid.sendspin.decoder.AudioDecoderFactory
+import com.sendspindroid.sendspin.transport.SendSpinTransport
+import com.sendspindroid.sendspin.transport.TransportState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.net.SocketException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Verifies the connection-health telemetry introduced by issue #128.
+ *
+ * State being tracked on every disconnect event:
+ *  - lastDisconnectCode / lastDisconnectReason / lastDisconnectMode
+ *  - lastDisconnectAtMs (only for abnormal, non-user-initiated)
+ *  - connectedAtMs cleared
+ *
+ * Plus: reconnectAttemptsTotal increments per attempt, and the
+ * isStallWatchdogArmed() accessor is gated on handshake + not-reconnecting
+ * + not-user-initiated.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SendSpinClientDisconnectTelemetryTest {
+
+    private lateinit var mockContext: Context
+    private lateinit var mockCallback: SendSpinClient.Callback
+    private lateinit var client: SendSpinClient
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+
+        mockkStatic(Log::class)
+        every { Log.v(any(), any()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.e(any(), any<String>()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+
+        // AppLog writes to android.util.Log under the hood; with level=OFF the
+        // permit check short-circuits so the mocks above aren't even exercised,
+        // but set OFF explicitly for robustness if the default ever changes.
+        AppLog.setLevel(LogLevel.OFF)
+
+        mockkObject(UserSettings)
+        every { UserSettings.getPlayerId() } returns "test-player-id"
+        every { UserSettings.getPreferredCodec() } returns "opus"
+        every { UserSettings.lowMemoryMode } returns false
+        every { UserSettings.highPowerMode } returns false
+
+        mockkObject(AudioDecoderFactory)
+        every { AudioDecoderFactory.isCodecSupported(any()) } returns true
+
+        mockkStatic(PreferenceManager::class)
+        val mockPrefs = mockk<SharedPreferences>(relaxed = true)
+        every { PreferenceManager.getDefaultSharedPreferences(any()) } returns mockPrefs
+
+        mockContext = mockk(relaxed = true)
+        mockCallback = mockk(relaxed = true)
+
+        client = SendSpinClient(mockContext, "TestDevice", mockCallback)
+
+        // Seed connection info so the disconnect paths execute fully.
+        setField("serverAddress", "127.0.0.1:8080")
+        setField("serverPath", "/sendspin")
+        setField("connectionMode", SendSpinClient.ConnectionMode.LOCAL)
+
+        val fakeTransport = object : SendSpinTransport {
+            override val state = TransportState.Connected
+            override val isConnected = true
+            override fun connect() {}
+            override fun send(text: String) = true
+            override fun send(bytes: ByteArray) = true
+            override fun setListener(listener: SendSpinTransport.Listener?) {}
+            override fun close(code: Int, reason: String) {}
+            override fun destroy() {}
+        }
+        setField("transport", fakeTransport)
+    }
+
+    @After
+    fun tearDown() {
+        client.destroy()
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    // =========================================================================
+    // Disconnect telemetry on onClosed / onFailure
+    // =========================================================================
+
+    @Test
+    fun `onClosed abnormal populates lastDisconnectCode, reason, mode, and lastDisconnectAtMs`() {
+        setHandshakeComplete(true)
+        val listener = buildTransportListener()
+
+        val before = System.currentTimeMillis()
+        listener.onClosed(code = 1006, reason = "ping-timeout")
+
+        assertEquals(Integer.valueOf(1006), client.getLastDisconnectCode())
+        assertEquals("ping-timeout", client.getLastDisconnectReason())
+        val disconnectAt = getField("lastDisconnectAtMs") as Long?
+        assertNotNull("lastDisconnectAtMs should be set on abnormal close", disconnectAt)
+        assertTrue(
+            "lastDisconnectAtMs should be set to a recent timestamp",
+            disconnectAt!! >= before && disconnectAt <= System.currentTimeMillis(),
+        )
+        assertNull("connectedAtMs should be cleared after disconnect", client.getConnectedAtMs())
+    }
+
+    @Test
+    fun `onClosed normal-closure still records code 1000 but does not set lastDisconnectAtMs`() {
+        // Normal closure isn't a retryable error, so lastDisconnectAtMs stays null
+        // (it's the "for a [reconnect-ok] correlation" marker).
+        setHandshakeComplete(true)
+        val listener = buildTransportListener()
+
+        listener.onClosed(code = 1000, reason = "server shutdown")
+
+        assertEquals(Integer.valueOf(1000), client.getLastDisconnectCode())
+        assertEquals("server shutdown", client.getLastDisconnectReason())
+        assertNull(
+            "lastDisconnectAtMs should NOT be set on normal closure",
+            getField("lastDisconnectAtMs"),
+        )
+    }
+
+    @Test
+    fun `onFailure populates code=null, reason=error message, and lastDisconnectAtMs`() {
+        setHandshakeComplete(true)
+        val listener = buildTransportListener()
+
+        val error = SocketException("connection reset")
+        listener.onFailure(error, isRecoverable = true)
+
+        assertNull("code should be null for onFailure", client.getLastDisconnectCode())
+        assertEquals("connection reset", client.getLastDisconnectReason())
+        assertNotNull("lastDisconnectAtMs should be set on recoverable failure", getField("lastDisconnectAtMs"))
+    }
+
+    @Test
+    fun `onFailure with null message falls back to exception class name`() {
+        setHandshakeComplete(true)
+        val listener = buildTransportListener()
+
+        listener.onFailure(SocketException(), isRecoverable = true)
+
+        // SocketException() without a message => error.message is null => reason = class simple name
+        assertEquals("SocketException", client.getLastDisconnectReason())
+    }
+
+    // =========================================================================
+    // Lifetime reconnect counter
+    // =========================================================================
+
+    @Test
+    fun `reconnectAttemptsTotal increments on each attemptReconnect call`() {
+        setHandshakeComplete(true)
+        assertEquals(0, client.getReconnectAttemptsTotal())
+
+        // Triggering attemptReconnect directly via reflection bypasses the listener
+        // so we can assert the counter in isolation.
+        val m = SendSpinClient::class.java.getDeclaredMethod("attemptReconnect")
+        m.isAccessible = true
+        m.invoke(client)
+        m.invoke(client)
+        m.invoke(client)
+
+        assertEquals(3, client.getReconnectAttemptsTotal())
+    }
+
+    // =========================================================================
+    // isStallWatchdogArmed accessor
+    // =========================================================================
+
+    @Test
+    fun `isStallWatchdogArmed is false pre-handshake`() {
+        setHandshakeComplete(false)
+        assertFalse(client.isStallWatchdogArmed())
+    }
+
+    @Test
+    fun `isStallWatchdogArmed is true when handshake complete and not reconnecting or user-initiated`() {
+        setHandshakeComplete(true)
+        assertTrue(client.isStallWatchdogArmed())
+    }
+
+    @Test
+    fun `isStallWatchdogArmed is false while reconnecting`() {
+        setHandshakeComplete(true)
+        val reconnectingField = SendSpinClient::class.java.getDeclaredField("reconnecting")
+        reconnectingField.isAccessible = true
+        (reconnectingField.get(client) as AtomicBoolean).set(true)
+        assertFalse(client.isStallWatchdogArmed())
+    }
+
+    @Test
+    fun `isStallWatchdogArmed is false after user-initiated disconnect`() {
+        setHandshakeComplete(true)
+        val userField = SendSpinClient::class.java.getDeclaredField("userInitiatedDisconnect")
+        userField.isAccessible = true
+        (userField.get(client) as AtomicBoolean).set(true)
+        assertFalse(client.isStallWatchdogArmed())
+    }
+
+    // =========================================================================
+    // getLastByteReceivedAgoMs accessor
+    // =========================================================================
+
+    @Test
+    fun `getLastByteReceivedAgoMs returns positive elapsed time from lastByteReceivedAtMs`() {
+        // Force the timestamp to ~5 seconds ago via reflection.
+        val lastByteField = SendSpinClient::class.java.getDeclaredField("lastByteReceivedAtMs")
+        lastByteField.isAccessible = true
+        val atomicLong = lastByteField.get(client) as java.util.concurrent.atomic.AtomicLong
+        atomicLong.set(System.currentTimeMillis() - 5_000L)
+
+        val ago = client.getLastByteReceivedAgoMs()
+        assertTrue("ago should be around 5000ms, got $ago", ago in 4_500L..6_000L)
+    }
+
+    // --- helpers ---
+
+    private fun buildTransportListener(): SendSpinTransport.Listener {
+        val innerClasses = SendSpinClient::class.java.declaredClasses
+        val listenerClass = innerClasses.find { it.simpleName == "TransportEventListener" }!!
+        val constructor = listenerClass.getDeclaredConstructor(SendSpinClient::class.java)
+        constructor.isAccessible = true
+        return constructor.newInstance(client) as SendSpinTransport.Listener
+    }
+
+    private fun setField(name: String, value: Any?) {
+        val f = SendSpinClient::class.java.getDeclaredField(name)
+        f.isAccessible = true
+        f.set(client, value)
+    }
+
+    private fun getField(name: String): Any? {
+        val f = SendSpinClient::class.java.getDeclaredField(name)
+        f.isAccessible = true
+        return f.get(client)
+    }
+
+    private fun setHandshakeComplete(value: Boolean) {
+        val f = SendSpinClient::class.java.superclass.getDeclaredField("handshakeComplete")
+        f.isAccessible = true
+        f.set(client, value)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #128. Surfaces the keepalive / reconnect / disconnect state that investigations for #105 and #114 had to dig out of debug-APK logs manually. Ships in two layers:

1. **On the stats screen** (Compose bottom sheet, already polled at 500 ms): new Connection-health rows plus Kalman-filter stability and convergence.
2. **In the shared log file** (post-PR #125 `AppLog` + `LogFileWriter`): structured `[disconnect]` and `[reconnect-ok]` lines users can share from Settings without `adb`.

## Change map

**`SendSpinClient`**
- State: `reconnectAttemptsTotal: AtomicInteger`, `connectedAtMs`, `lastDisconnectAtMs`, `lastDisconnectCode`, `lastDisconnectReason`, `lastDisconnectMode`. All `@Volatile`/`Atomic*`.
- Public accessors: `getLastByteReceivedAgoMs`, `isStallWatchdogArmed`, `getReconnectAttemptsTotal`, `getLastDisconnectCode`, `getLastDisconnectReason`, `getConnectedAtMs`.
- Hooks: `onHandshakeComplete` stamps `connectedAtMs` + emits `[reconnect-ok]`; `attemptReconnect` bumps lifetime counter; `TransportEventListener.onClosed` / `onFailure` populate state via shared `recordDisconnectTelemetry()` + emit `[disconnect]`.

**`PlaybackService.getStats()`** — 7 new Bundle keys alongside the existing clock-sync/network blocks.

**`StatsViewModel.StatsState` + `updateStats(bundle)`** — 7 matching fields with sensible defaults.

**`StatsBottomSheetContent`** — new rows in Connection (lifetime reconnects, last-byte-ago, watchdog state, last disconnect) and Clock Sync (filter stability, convergence time). New `getStabilityColor()` helper. 8 new string resources in `values/strings.xml`.

## Hot-path audit

Nothing lands in the audio thread, WebSocket receive loop, time-sync bursts, or stall-watchdog tick. All new writes are on once-per-event paths (handshake, disconnect, reconnect attempt). Reads happen only in the 500 ms stats poll while the bottom sheet is open. Log emission is gated by `AppLog.level` — suppressed to a no-op permit check when the user has logging at WARN or higher.

## Test plan

- [x] `./gradlew assembleDebug` — clean.
- [x] `./gradlew :app:testDebugUnitTest` — clean.
- [x] New `SendSpinClientDisconnectTelemetryTest` (10 tests):
  - `onClosed` abnormal populates code/reason/mode/lastDisconnectAtMs
  - `onClosed` normal-closure records code=1000 but not lastDisconnectAtMs
  - `onFailure` populates code=null, reason=error message, lastDisconnectAtMs
  - `onFailure` with null message falls back to exception class name
  - lifetime counter increments per attemptReconnect
  - `isStallWatchdogArmed` truth table: pre-handshake / healthy / reconnecting / user-initiated
  - `getLastByteReceivedAgoMs` returns positive elapsed time
- [ ] **Manual:** connect, play 30 s, open stats → see Connection-health rows populated. Kill server briefly → reconnect fires → stats show `reconnect_attempts_total=1`, `last_disconnect_code=1006` (or platform equivalent). Settings → Logs → share → log contains `[disconnect]` and `[reconnect-ok]` lines.

## Out of scope

- Historical disconnect log (ring buffer of last N). Issue only asked for the "last" event.
- `reconnect_result` for user-initiated disconnect or final give-up — those aren't recovery events; `[reconnect-ok]` only fires after a real disconnect.
- Persisting stats across app restarts.