### PR TITLE
docs: align CLAUDE.md with shipped architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
 # SendSpinDroid Project Memory
 
-## Current Focus: Native Kotlin SendSpin Client
+## Overview
 
-This project is being rebuilt with a **native Kotlin** approach, removing the previous Go-based implementation.
+SendSpinDroid is a native Kotlin Android client for SendSpin. It acts as a **Player**-role client: it connects to a SendSpin server over WebSocket, synchronizes its local clock to the server, and renders timestamped PCM audio with continuous sync correction.
 
 ## Application Architecture
 
 SendSpinDroid is a **synchronized audio player** that connects to SendSpin servers:
 
 ```
-SendSpin Server ──WebSocket──► SendSpinClient ──AAudio──► Audio Output
+SendSpin Server ──WebSocket──► SendSpinClient ──► SyncAudioPlayer (AudioTrack) ──► Audio Output
                     │
                     ├── JSON messages (metadata, state)
                     └── Binary messages (timestamped audio PCM)
@@ -34,7 +34,7 @@ SendSpin Server ──WebSocket──► SendSpinClient ──AAudio──► Au
 - `server/state` - Server state and track metadata
 - `group/update` - Group playback state changes
 - `stream/start` - Audio stream beginning
-- `stream/stop` - Audio stream ending
+- `stream/end` - Audio stream ending
 
 ### Binary Messages
 ```
@@ -62,12 +62,17 @@ Reports player state to server:
 - `muted`: boolean
 - `static_delay_ms`: device audio output latency compensation (milliseconds)
 
-## Implementation Phases
+## Audio Pipeline
 
-1. **Protocol** - WebSocket connection, JSON/binary parsing
-2. **Clock Sync** - Kalman filter for time synchronization
-3. **Audio Buffer** - Timestamped chunk storage
-4. **AAudio Output** - Native audio with sync correction
+The shipped audio pipeline uses Android's `AudioTrack` (Java API) in `MODE_STREAM` (push mode). Incoming binary WebSocket frames are decoded to PCM (if encoded), anchored against the synchronized server clock via a Kalman time filter, and written to `AudioTrack` with sample insert/drop correction to maintain sync.
+
+Key modules:
+- **Protocol** - WebSocket connection, JSON/binary frame parsing (`sendspin/protocol/`)
+- **Clock Sync** - 2D Kalman time filter (`SendspinTimeFilter.kt`)
+- **Audio Buffer** - Timestamped chunk queue and state machine (`SyncAudioPlayer.kt`)
+- **Audio Output** - `AudioTrack` in `SyncAudioPlayer.kt` with DAC-aware start gating and sample insert/drop sync correction
+
+AAudio/Oboe would provide callback-precise hardware latency and lower-latency writes, and is a **possible future migration** — but is not the currently shipped path. Code and docs should describe `AudioTrack` as the present audio output.
 
 ## Development Environment
 
@@ -140,8 +145,13 @@ Key files to study:
 - `protocol.py` - WebSocket protocol handling
 - `clocksync.py` - Clock synchronization algorithm
 
-The CLI shows the correct approach:
+The CLI shows the canonical approach:
 - Uses `sounddevice` which provides `outputBufferDacTime` in callback
-- State machine: WAITING_FOR_START → PLAYING → REANCHORING
-- Sync correction via sample insert/drop (±4% rate adjustment)
+- State machine: WAITING_FOR_START -> PLAYING -> REANCHORING
+- Sync correction via sample insert/drop (+/-4% rate adjustment)
 - Measures sync error: `expected_play_time - actual_dac_time`
+
+### Android Deviations from the Python Reference
+
+- **Speed-correction cap**: `SyncAudioPlayer.MAX_SPEED_CORRECTION = 0.02` (+/-2%), vs the reference's +/-4%. The tighter cap is a safety margin against over-correction given that `AudioTrack` DAC-timing jitter on Android can be larger than desktop `sounddevice`. Revisit if high-drift scenarios fail to converge.
+- **Audio output API**: `AudioTrack` in `MODE_STREAM` instead of `sounddevice`. DAC position is read via `AudioTrack.getTimestamp()` for sync-error measurement and start-gating.

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -104,22 +104,16 @@ import kotlinx.coroutines.withContext
  * - Bluetooth/headset button support
  * - Android Auto browse tree support
  *
- * ## Architecture (Native Kotlin)
+ * ## Architecture
  * ```
- * MainActivity ──MediaController──► PlaybackService
- *                                        │
- *                                   ┌────┴────┐
- *                                   │ SendSpinClient │
- *                                   │ AAudio (TODO)  │
- *                                   │ MediaSession   │
- *                                   └────────────────┘
+ * MainActivity --MediaController--> PlaybackService
+ *                                        |
+ *                                   +----+----+
+ *                                   | SendSpinClient  |
+ *                                   | SyncAudioPlayer |
+ *                                   | MediaSession    |
+ *                                   +-----------------+
  * ```
- *
- * ## TODO: Implementation phases
- * 1. WebSocket connection and protocol (SendSpinClient)
- * 2. Clock synchronization
- * 3. AAudio/Oboe playback with sync correction
- * 4. Remove ExoPlayer dependency
  */
 @OptIn(UnstableApi::class)
 class PlaybackService : MediaLibraryService() {


### PR DESCRIPTION
## Summary

Refreshes `CLAUDE.md` and strips stale TODO comments in `PlaybackService.kt` so the project documentation matches what actually ships. No runtime behavior changes.

This is **Group 1** of a planned sequence of small, file-scoped PRs addressing findings from an architecture audit. It intentionally closes only the documentation/comment findings so subsequent code-level PRs can be reviewed against accurate architectural documentation.

## Findings addressed

| ID | Finding | Fix |
|---|---|---|
| H-1 (doc side) | CLAUDE.md says phase 4 is "AAudio Output — Native audio with sync correction" but the code ships `AudioTrack` in `MODE_STREAM` via `SyncAudioPlayer` | Replace "Implementation Phases" with "Audio Pipeline" describing the shipped `AudioTrack` path. AAudio/Oboe is called out as possible future work, not current. |
| M-1 | Protocol doc lists `stream/stop`; code uses `stream/end` (`SendSpinProtocol.kt:85`) | Update JSON message list to `stream/end`. |
| M-2 (doc side) | CLAUDE.md says "Sync correction via sample insert/drop (±4% rate adjustment)" but `SyncAudioPlayer.MAX_SPEED_CORRECTION = 0.02` intentionally caps at +/-2% | Add "Android Deviations from the Python Reference" subsection documenting the 2% safety margin rationale. Code constant is **not** changed in this PR. |
| L-2 | Stale TODO comments in `PlaybackService.kt:107-122`: `AAudio (TODO)` label in the diagram, and a 4-item "TODO: Implementation phases" list (ExoPlayer is gone, AAudio is covered by CLAUDE.md) | Remove the TODO block; change `AAudio (TODO)` to `SyncAudioPlayer`. ASCII-ify the diagram for consistency inside the code file. |
| L-8 | Opening line "This project is being rebuilt with a native Kotlin approach, removing the previous Go-based implementation" is stale; the Kotlin impl is mature | Replace with a present-tense Player-role description. |

## Deliberately out of scope

- No changes to `SyncAudioPlayer.kt`, `SendSpinClient.kt`, `SendspinTimeFilter.kt`, or any protocol file.
- `MAX_SPEED_CORRECTION` is **not** changed — the 4%-vs-2% decision is documented, not re-adjudicated.
- No AAudio/Oboe migration work.
- Other audit findings (concurrency cluster in `SyncAudioPlayer`, `SendSpinClient` lifecycle, decoder-path TOCTOU, `static_delay_ms` auto-measurement) are planned as separate PRs so each stays small and file-scoped to avoid merge conflicts.

## Test plan

- [ ] Render `CLAUDE.md` in GitHub/VS Code preview — diagrams and tables look correct
- [ ] `PlaybackService.kt` docstring renders cleanly in Android Studio's Quick Documentation popup (Ctrl+Q on `PlaybackService`)
- [ ] CI build passes (comment + markdown only, so this is a formality)