### PR TITLE
fix: close watchdog race and stale authToken across mode changes

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -206,7 +206,13 @@ class SendSpinClient(
 
     // Stall watchdog state. lastByteReceivedAtMs is updated on EVERY text/binary
     // message from the transport. stallWatchdogJob is the polling coroutine.
+    // watchdogLock serializes the cancel+reassign dance in startStallWatchdog /
+    // stopStallWatchdog so a concurrent start-from-WS-thread + stop-from-main
+    // cannot orphan a job or leave the field pointing at a running watchdog
+    // that the caller believed was stopped. @Volatile is still needed for any
+    // reader that observes the field without taking the lock.
     private val lastByteReceivedAtMs = AtomicLong(System.currentTimeMillis())
+    private val watchdogLock = Any()
     @Volatile
     private var stallWatchdogJob: Job? = null
 
@@ -574,6 +580,11 @@ class SendSpinClient(
         serverAddress = address
         serverPath = normalizedPath
         remoteId = null
+        // Clear any stale PROXY credential so it can't be observed after a
+        // mode transition. createLocalTransport doesn't use it, but leaving a
+        // valid token in the field across modes is a code smell and a future
+        // footgun if any new reader forgets to re-check connectionMode.
+        authToken = null
 
         createLocalTransport(address, normalizedPath)
     }
@@ -596,6 +607,8 @@ class SendSpinClient(
         this.remoteId = remoteId
         serverAddress = null
         serverPath = null
+        // Clear any stale PROXY credential; see connectLocal for rationale.
+        authToken = null
 
         createRemoteTransport(remoteId)
     }
@@ -805,13 +818,14 @@ class SendSpinClient(
     fun destroy() {
         stopStallWatchdog()
         stopTimeSync()
-        userInitiatedDisconnect.set(true)
 
         // Cancel any pending reconnect coroutine
         reconnectJob?.cancel()
         reconnectJob = null
 
         reconnecting.set(false)
+        // disconnect() sets userInitiatedDisconnect unconditionally; no need
+        // to pre-set it here.
         disconnect()
     }
 
@@ -849,25 +863,35 @@ class SendSpinClient(
     /**
      * Start the stall watchdog. Called when the connection reaches a state where
      * we expect data to be flowing. Cancels any previous instance.
+     *
+     * Serialized against [stopStallWatchdog] via [watchdogLock]: the cancel +
+     * reassign pair must be atomic so a concurrent stop() cannot null the
+     * field after this method launches a new job (which would leave the new
+     * job orphaned and running).
      */
     private fun startStallWatchdog() {
-        stallWatchdogJob?.cancel()
-        // Reset so we don't false-trip using a stale pre-handshake timestamp
-        lastByteReceivedAtMs.set(System.currentTimeMillis())
-        stallWatchdogJob = scope.launch {
-            while (true) {
-                delay(STALL_CHECK_INTERVAL_MS)
-                checkStall()
+        synchronized(watchdogLock) {
+            stallWatchdogJob?.cancel()
+            // Reset so we don't false-trip using a stale pre-handshake timestamp
+            lastByteReceivedAtMs.set(System.currentTimeMillis())
+            stallWatchdogJob = scope.launch {
+                while (true) {
+                    delay(STALL_CHECK_INTERVAL_MS)
+                    checkStall()
+                }
             }
         }
     }
 
     /**
      * Stop the stall watchdog. Called on disconnect or during reconnect attempts.
+     * Serialized against [startStallWatchdog] via [watchdogLock].
      */
     private fun stopStallWatchdog() {
-        stallWatchdogJob?.cancel()
-        stallWatchdogJob = null
+        synchronized(watchdogLock) {
+            stallWatchdogJob?.cancel()
+            stallWatchdogJob = null
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Three related lifecycle cleanups in `SendSpinClient.kt`, surfaced by a read-only architecture audit. One file touched, +34 / -10, no behavior change in the happy path -- these close latent races and state-leak footguns.

This is **Group 4** of a planned sequence of small, file-scoped PRs. Groups 1 (#139) and 2 (#140) have landed.

## Findings addressed

| ID | Finding | Fix |
|---|---|---|
| **M-3** | Watchdog cancel+reassign race. `startStallWatchdog` and `stopStallWatchdog` both do `stallWatchdogJob?.cancel(); stallWatchdogJob = ...`. `@Volatile` (added in #128) gives visibility but not atomicity. A concurrent start-from-WS-handshake + stop-from-main can leave the field pointing at a running watchdog the caller thinks is stopped, or orphan a just-launched job. | New `private val watchdogLock = Any()` colocated with the watchdog field. Both method bodies wrapped in `synchronized(watchdogLock)`. `@Volatile` retained for readers outside these methods. |
| **M-7** | `authToken` set by `connectProxy`, never cleared on mode transitions. Current readers all gate on `connectionMode == PROXY` so the stale value isn't observable today -- but leaving a valid credential in the field across modes is a latent footgun for any future reader that forgets the guard. | `authToken = null` added after the mode switch in `connectLocal` and `connectRemote`. Pairs with `connectProxy`'s write so the field lifetime matches the PROXY session. |
| **L-7** | `destroy()` sets `userInitiatedDisconnect.set(true)` and then calls `disconnect()`, which sets it unconditionally. | Removed the redundant pre-set. One-line comment notes that `disconnect()` handles it. Removes a pattern that invites future refactors to silently decouple the two calls. |

## Deferred, tracked as follow-ups

| ID | Reason for deferring |
|---|---|
| **M-4** (Dispatchers.IO for reconnect/watchdog timers) | Audit itself labeled "low priority." Multi-second interval timers are insensitive to IO-pool jitter of ~100ms. Fix would require a dedicated dispatcher -- disproportionate for theoretical benefit. Revisit if field telemetry shows reconnect SLA slippage. |
| **L-5** (`isRecoverableError` default-true + no retry cap -> infinite reconnect) | Overlaps active connection-resilience work (#129 / #130 / #137 / #138). Needs team discussion before changing recovery policy. |

## Deliberately out of scope

- No changes to reconnection logic, backoff, or error-handling policy.
- No changes to other files.
- No changes to public API of `SendSpinClient`.

## Verified

- [x] `./gradlew assembleDebug`
- [x] `com.sendspindroid.sendspin.SendSpinClient*Test` (stall watchdog, disconnect, reconnect backoff, pre-handshake reconnect, local fallback, time-filter freeze, disconnect-for-reselection, network pause, connection state, disconnect telemetry)
- [x] `com.sendspindroid.e2e.ProxyConnectAuthTest`

## Test plan

- [ ] CI build passes
- [ ] On-device: stall-watchdog triggers correctly on a stalled connection (disable Wi-Fi mid-stream); starts back up on successful handshake
- [ ] On-device: switching between LOCAL and PROXY modes works cleanly, no stale credential attempts
- [ ] On-device: no regression in `destroy()` -> `onDestroy` path during service shutdown