### PR TITLE
refactor: move decoder ownership to a single-thread executor

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -93,6 +93,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 /**
  * Background playback service for SendSpinDroid.
@@ -123,7 +127,18 @@ class PlaybackService : MediaLibraryService() {
     private var forwardingPlayer: MetadataForwardingPlayer? = null
     private var sendSpinClient: SendSpinClient? = null
     @Volatile private var syncAudioPlayer: SyncAudioPlayer? = null
+    // Decoder is owned exclusively by [decodeExecutor]. Every mutation -- release,
+    // create, flush -- is submitted as a task so only one thread touches the
+    // native resource. Reads inside decode tasks are safe because the single-
+    // threaded executor serializes all work. No @Volatile: there are no
+    // cross-thread readers.
     private var audioDecoder: AudioDecoder? = null
+
+    // Single-threaded executor that owns the decoder and performs PCM decode
+    // off the WebSocket IO thread. Bounded queue with drop-oldest semantics:
+    // audio is real-time, so a stale chunk is useless. Initialized in onCreate,
+    // shut down in onDestroy.
+    private lateinit var decodeExecutor: ExecutorService
 
     // When true, the next state/group message should call exitDraining() AFTER processing.
     // This ensures the DRAINING check in onStateChanged/onGroupUpdate fires while still
@@ -530,6 +545,18 @@ class PlaybackService : MediaLibraryService() {
         // Debug logging interval (1 sample per second)
         private const val DEBUG_LOG_INTERVAL_MS = 1000L
 
+        // Bounded backlog for the decode executor. At 48 kHz / 20 ms chunks
+        // (~50 chunks/sec), 100 tasks is roughly 2 seconds of runway before
+        // drop-oldest kicks in. Sized large enough to absorb brief GC pauses
+        // or codec hiccups, small enough that sustained backlog doesn't pile
+        // up perceptible staleness.
+        private const val DECODE_QUEUE_CAPACITY = 100
+
+        // Max time to wait for in-flight decode tasks to finish during
+        // onDestroy. After this the executor is forcibly shut down -- any
+        // outstanding decoder release is lost, which is fine during teardown.
+        private const val DECODE_EXECUTOR_SHUTDOWN_TIMEOUT_MS = 500L
+
         // Debounce before acting on NET_CAPABILITY_VALIDATED loss. Android's
         // validation probe can flicker briefly during WiFi roaming or captive-portal
         // probes; 3s rides through those while still firing well before the ~30s
@@ -658,6 +685,25 @@ class PlaybackService : MediaLibraryService() {
     override fun onCreate() {
         super.onCreate()
         Log.i(TAG, "PlaybackService.onCreate() started")
+
+        // Build the decode executor before anything else that may rely on it.
+        // Bounded queue (DECODE_QUEUE_CAPACITY) with drop-oldest rejection so
+        // sustained decode underruns cannot grow the queue without limit.
+        // Audio is real-time, so the oldest queued chunk is the least useful
+        // to keep.
+        decodeExecutor = ThreadPoolExecutor(
+            1, 1,
+            0L, TimeUnit.MILLISECONDS,
+            LinkedBlockingQueue(DECODE_QUEUE_CAPACITY),
+            java.util.concurrent.ThreadFactory { r ->
+                Thread(r, "SendSpinDecode").apply { isDaemon = true }
+            },
+            { r, executor ->
+                executor.queue.poll()
+                executor.execute(r)
+                Log.w(TAG, "Decode queue full, dropping oldest chunk")
+            }
+        )
 
         // Create notification channel for foreground service
         NotificationHelper.createNotificationChannel(this)
@@ -1252,7 +1298,8 @@ class PlaybackService : MediaLibraryService() {
 
         override fun onStreamStart(codec: String, sampleRate: Int, channels: Int, bitDepth: Int, codecHeader: ByteArray?) {
             // Mark decoder as not ready IMMEDIATELY (on WebSocket thread) before posting.
-            // This prevents onAudioChunk from using the old (about-to-be-released) decoder.
+            // This prevents onAudioChunk from submitting further decode tasks until
+            // the new decoder is ready on the decode thread.
             decoderReady = false
             mainHandler.post {
                 Log.d(TAG, "Stream started: codec=$codec, rate=$sampleRate, channels=$channels, bits=$bitDepth, header=${codecHeader?.size ?: 0} bytes")
@@ -1261,26 +1308,34 @@ class PlaybackService : MediaLibraryService() {
                 completePendingExitDraining()
                 currentCodec = codec
 
-                // Release existing decoder and create new one for this stream
-                audioDecoder?.release()
-                audioDecoder = null
-                try {
-                    audioDecoder = AudioDecoderFactory.create(codec)
-                    audioDecoder?.configure(sampleRate, channels, bitDepth, codecHeader)
-                    Log.i(TAG, "Audio decoder created: $codec")
-                    decoderReady = true
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to create decoder for $codec, falling back to PCM", e)
+                // Release + recreate the decoder on the decode thread so this
+                // submission is ordered after any in-flight decode tasks for
+                // the previous stream (they finish with the old decoder first,
+                // then this task releases and creates the new one).
+                decodeExecutor.execute {
+                    audioDecoder?.release()
+                    audioDecoder = null
                     try {
-                        val fallback = AudioDecoderFactory.create("pcm")
-                        fallback.configure(sampleRate, channels, bitDepth)
-                        audioDecoder = fallback
-                        Log.i(TAG, "PCM fallback decoder configured")
+                        val created = AudioDecoderFactory.create(codec).also {
+                            it.configure(sampleRate, channels, bitDepth, codecHeader)
+                        }
+                        audioDecoder = created
+                        Log.i(TAG, "Audio decoder created: $codec")
                         decoderReady = true
-                    } catch (fallbackEx: Exception) {
-                        Log.e(TAG, "PCM fallback decoder also failed", fallbackEx)
-                        audioDecoder = null
-                        // decoderReady stays false -- onAudioChunk will drop chunks
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to create decoder for $codec, falling back to PCM", e)
+                        try {
+                            val fallback = AudioDecoderFactory.create("pcm").also {
+                                it.configure(sampleRate, channels, bitDepth)
+                            }
+                            audioDecoder = fallback
+                            Log.i(TAG, "PCM fallback decoder configured")
+                            decoderReady = true
+                        } catch (fallbackEx: Exception) {
+                            Log.e(TAG, "PCM fallback decoder also failed", fallbackEx)
+                            audioDecoder = null
+                            // decoderReady stays false -- onAudioChunk will drop chunks
+                        }
                     }
                 }
 
@@ -1335,7 +1390,10 @@ class PlaybackService : MediaLibraryService() {
             mainHandler.post {
                 Log.i(TAG, "[cmd-trace] T3 onStreamClear.post ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name}")
                 Log.d(TAG, "Stream clear - flushing audio and decoder buffers")
-                audioDecoder?.flush()
+                // Flush on the decode thread so it is ordered relative to any
+                // in-flight decode tasks: chunks queued before the flush decode
+                // with pre-flush state, subsequent chunks with post-flush state.
+                decodeExecutor.execute { audioDecoder?.flush() }
                 syncAudioPlayer?.clearBuffer()
             }
         }
@@ -1352,32 +1410,37 @@ class PlaybackService : MediaLibraryService() {
         }
 
         override fun onAudioChunk(serverTimeMicros: Long, audioData: ByteArray) {
-            // Guard: don't try to decode if the decoder is being replaced (race with onStreamStart)
+            // WS-IO thread fast path: gate on decoderReady (flipped false by
+            // onStreamStart so chunks from the old stream don't get submitted
+            // after a reconfigure), and capture the player reference cheaply.
+            // Actual decode + queue happens on [decodeExecutor] so the WS-IO
+            // thread stays responsive for other frames (notably time-sync
+            // replies whose latency feeds back into the Kalman filter).
             if (!decoderReady) return
-
-            // Capture local references to avoid TOCTOU race: the main thread can null
-            // and release these between a null-check and method call.
             val player = syncAudioPlayer ?: return
-            val decoder = audioDecoder
 
-            // Decode compressed data to PCM, or pass through for PCM codec.
-            // If decoder is null mid-reconfiguration, only PCM raw data is safe
-            // to forward -- compressed bytes (Opus/FLAC) would be garbled.
-            val pcmData = try {
-                if (decoder != null) {
-                    decoder.decode(audioData)
-                } else if (currentCodec == "pcm") {
-                    audioData
-                } else {
-                    return // compressed codec with no decoder -- drop chunk
+            decodeExecutor.execute {
+                // Read audioDecoder inside the task. The single-threaded
+                // executor serializes all decoder mutations with all decode
+                // tasks, so there is no TOCTOU: this read sees the decoder
+                // that was current when this task was submitted, not a newer
+                // (possibly released) one.
+                val decoder = audioDecoder
+                val pcmData = try {
+                    if (decoder != null) {
+                        decoder.decode(audioData)
+                    } else if (currentCodec == "pcm") {
+                        audioData
+                    } else {
+                        return@execute // compressed codec with no decoder -- drop
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Decode error, dropping chunk", e)
+                    return@execute
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "Decode error, dropping chunk", e)
-                return
+                if (pcmData == null) return@execute
+                player.queueChunk(serverTimeMicros, pcmData)
             }
-            if (pcmData == null) return
-            // Queue decoded PCM - SyncAudioPlayer handles threading internally
-            player.queueChunk(serverTimeMicros, pcmData)
         }
 
         override fun onVolumeChanged(volume: Int) {
@@ -3751,9 +3814,25 @@ class PlaybackService : MediaLibraryService() {
         serviceScope.cancel()
         imageLoader?.shutdown()
 
-        // Release audio decoder and player, then playback locks and foreground notification
-        audioDecoder?.release()
-        audioDecoder = null
+        // Submit final decoder release on the decode thread, then shut down
+        // the executor. Any tasks still queued here are for a connection that
+        // is already tearing down -- dropping them is fine.
+        decoderReady = false
+        decodeExecutor.execute {
+            audioDecoder?.release()
+            audioDecoder = null
+        }
+        decodeExecutor.shutdown()
+        try {
+            if (!decodeExecutor.awaitTermination(DECODE_EXECUTOR_SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                Log.w(TAG, "Decode executor did not terminate within ${DECODE_EXECUTOR_SHUTDOWN_TIMEOUT_MS}ms; forcing shutdown")
+                decodeExecutor.shutdownNow()
+            }
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            decodeExecutor.shutdownNow()
+        }
+
         syncAudioPlayer?.release()
         syncAudioPlayer = null
         releasePlaybackLocks()


### PR DESCRIPTION
## Summary

Moves `audioDecoder` ownership to a dedicated single-threaded `ExecutorService`. One file touched (`PlaybackService.kt`), +124 / -45, no public API changes.

This is **Group 3** of a planned sequence of small, file-scoped PRs addressing findings from an architecture audit. Groups 1 (#139), 2 (#140), and 4 (#141) have landed.

## Findings addressed

| ID | Finding | Fix |
|---|---|---|
| **H-4** | Audio decode ran on the OkHttp WebSocket IO thread. Slow decode (Opus/FLAC at ~5 ms/chunk) could back up subsequent frames, including time-sync responses whose RTT feeds the Kalman clock filter -- a direct sync-quality regression. | New `decodeExecutor` (single-threaded, bounded queue, drop-oldest). `onAudioChunk` now gates on `decoderReady` on WS-IO, then submits `{ decode + queueChunk }` to the executor. WS-IO returns in constant time. |
| **M-8** | TOCTOU race: main thread could release+recreate the decoder between a WS-IO `decoderReady` check and the subsequent `decoder.decode()` call. Local-ref capture narrowed the window but the captured reference could still point at a released native resource. | `audioDecoder` is now only mutated from the decode thread. All release / create / flush operations are submitted to `decodeExecutor`. Single-owner model eliminates the race structurally -- no lock, no TOCTOU. `@Volatile` removed from the field (single writer). `decoderReady` kept `@Volatile` for the WS-IO submission gate. |

## M-6 non-bug

The original audit flagged a race between `onArtwork` (binary artwork path) and `fetchArtwork` (URL path) over `currentArtwork`. Re-audit confirms both already update `currentArtwork` on the **main thread** -- `onArtwork` via `serviceScope.launch` (main dispatcher, with an inner `withContext(Dispatchers.IO)` only for bitmap decode), and `fetchArtwork` via `mainHandler.post`. The "race" is inherent last-write-wins between two server-driven signals; not a correctness bug. No code change for M-6.

## Design properties

- **Ordering preserved by the single-threaded executor**: decode tasks submitted before a stream/start release+recreate run first with the old decoder, then the recreate task runs, then subsequent tasks use the new decoder. `stream/clear` flush is ordered relative to in-flight decodes.
- **Backpressure**: bounded queue (100 tasks, ~2 s of runway at 50 chunks/sec) with drop-oldest rejection. Audio is real-time -- the oldest chunk is the least useful to keep. Unbounded queue would trade memory for staleness.
- **Teardown**: `onDestroy` submits final decoder release, then `shutdown() + awaitTermination(500 ms)`. Forced shutdown after the timeout.
- **Thread naming**: decode thread is named `SendSpinDecode` (daemon) for visibility in `adb shell ps -T`.

## Sites touched

| Site | Before | After |
|---|---|---|
| `onAudioChunk` | decode + queueChunk on WS-IO | gate on WS-IO, submit decode to executor |
| `onStreamStart` | decoder release+create on main | submit release+create to executor |
| `onStreamClear` | `audioDecoder?.flush()` on main | submit flush to executor |
| `onDestroy` | `audioDecoder?.release()` on main | submit release to executor, then shutdown + await |

## Deliberately out of scope

- `SyncAudioPlayer.kt` is not touched. `queueChunk` is already thread-safe (#140) and the decode thread calls it identically to how WS-IO did.
- No changes to artwork handling, protocol, or reconnection logic.
- No new external dependencies.

## Verified

- [x] `./gradlew assembleDebug`
- [x] `com.sendspindroid.playback.*` (PauseFlushTest, PlaybackServiceConnectionLifecycleTest, ReconnectStateSyncTest, StreamStartDecoderPipelineTest, BrowseTreeTest)
- [x] `com.sendspindroid.sendspin.SyncAudioPlayerTest`

## Test plan

- [ ] CI build passes
- [ ] On-device: start/stop/restart a stream with each codec (PCM, Opus, FLAC) -- no glitches on the first chunk after reconfigure
- [ ] On-device: disconnect/reconnect cycle -- decoder released and recreated cleanly
- [ ] On-device: under sustained CPU pressure (e.g., another background app), check logcat for `Decode queue full, dropping oldest chunk` warnings. Occasional under pressure is OK; sustained would mean the queue capacity needs tuning
- [ ] On-device: service teardown (force-stop or swipe from recents) -- logcat should not show "Decode executor did not terminate within 500ms" under normal conditions