### PR TITLE
fix: wizard crash when two servers share a friendly name

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/server/AddServerWizardActivity.kt
@@ -292,9 +292,15 @@ class AddServerWizardActivity : FragmentActivity() {
     }
 
     private fun updateDiscoveredServersInViewModel() {
-        val servers = discoveredServers.values.map { server ->
+        // Use the map key (the mDNS service instance name) as the UI id,
+        // not server.name (the friendly/display name). Friendly names are
+        // not required to be unique -- e.g. two Music Assistant instances
+        // on the same LAN both advertise friendlyName="Music Assistant",
+        // and using the friendly name as the id would produce duplicate
+        // Compose LazyColumn keys and crash the wizard.
+        val servers = discoveredServers.map { (instanceName, server) ->
             DiscoveredServerUi(
-                id = server.name,
+                id = instanceName,
                 name = server.name,
                 address = server.address
             )


### PR DESCRIPTION
## Summary

Fix a Compose `IllegalArgumentException` that crashes `AddServerWizardActivity` when mDNS discovers two SendSpin servers sharing the same friendly name (e.g. two Music Assistant instances on the same LAN, both advertising \`friendlyName=\"Music Assistant\"\`).

## Root cause

\`AddServerWizardActivity.updateDiscoveredServersInViewModel\` was iterating \`discoveredServers.values\` and setting \`DiscoveredServerUi.id = server.name\` — the friendly name. The map is keyed by the mDNS service instance name (unique by protocol), but the stored \`DiscoveredServer\` record only retains the friendly name, so the unique id was being thrown away at the transformation boundary.

\`FindServerStep\` renders the list with a \`LazyColumn { items(..., key = { it.id }) }\`. With duplicate ids, Compose throws:

\`\`\`
java.lang.IllegalArgumentException: Key \"Music Assistant\" was already used.
If you are using LazyColumn/Row please make sure you provide a unique key for each item.
  at androidx.compose.ui.layout.LayoutNodeSubcompositionsState.subcompose (SubcomposeLayout.kt:453)
\`\`\`

The exception propagates to Android's crash handler; the app process is terminated mid-interaction.

## Fix

Iterate \`discoveredServers.map { (instanceName, server) -> ... }\` so the unique map key becomes \`DiscoveredServerUi.id\`, while the friendly name stays as the display label. Inline comment explains why the map key (not the value) is the id source.

## Reproduction

- Two Music Assistant instances on the LAN:
  - 10.0.2.8:8927 — instance \`229588722dfd42aa956f45be62b554fb\`
  - 10.0.1.6:8927 — instance \`c2a9e2bfa0ff4ea5a8f3a2d7f109a5b7\`
- Both advertise \`friendlyName = \"Music Assistant\"\`.
- Open wizard → Discover. Before this PR: app self-terminates within ~100 ms of the second TXT-record resolution. After this PR: both servers list correctly and are independently selectable.

## Verified

- [x] \`./gradlew assembleDebug\`
- [ ] On-device re-test (user to confirm)

## Test plan

- [ ] CI build passes
- [ ] On-device: run wizard with two same-named MA servers on the LAN; both appear in the list; tapping each routes to the correct server-setup flow

## Not-a-regression note

This bug predates the architecture-audit rollup (PRs #139–#145). None of those PRs touched \`AddServerWizardActivity.kt\`, \`FindServerStep.kt\`, or \`DiscoveredServerUi\`.