### PR TITLE
fix: resolve MA player id server-authoritatively (groups/players sheet)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
+++ b/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
@@ -468,6 +468,33 @@ object MusicAssistantManager {
      */
     fun getThisDevicePlayerId(): String = UserSettings.getPlayerId()
 
+    /**
+     * Resolve this device's id to Music Assistant's internal player id.
+     *
+     * MA registers SendSpin-provider players under a transformed id
+     * (e.g. `up` + UUID-with-dashes-stripped), which means the raw UUID
+     * we registered with the SendSpin server will not match entries
+     * returned by `players/all`. Ask the server to do the mapping
+     * authoritatively via `player_queues/get_active_queue`.
+     *
+     * Returns `null` if the server could not resolve. Callers can
+     * fall back to the raw UUID (via [getThisDevicePlayerId]).
+     *
+     * Note: when this device is synced to another player in a group,
+     * the resolved id may be the group's queue id rather than this
+     * device's own player id. That is intentional — for UI purposes
+     * ("show me the active player we are participating with") the
+     * queue id is usually the right entity.
+     */
+    suspend fun resolveThisDeviceMaPlayerId(): String? {
+        val playerId = UserSettings.getPlayerId()
+        return try {
+            commandClient.getEffectiveQueueId(playerId)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     // ========================================================================
     // Delegated Command Methods
     // ========================================================================

--- a/android/app/src/main/java/com/sendspindroid/ui/player/PlayerViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/player/PlayerViewModel.kt
@@ -68,10 +68,18 @@ class PlayerViewModel : ViewModel() {
             val thisDevicePlayerId = MusicAssistantManager.getThisDevicePlayerId()
             Log.d(TAG, "This device player ID: $thisDevicePlayerId")
 
+            // MA represents SendSpin-provider players under a transformed id
+            // (e.g. "up" + UUID-without-dashes). Ask the server to resolve our
+            // raw UUID to its internal id before matching against players/all.
+            // Falls back to the raw UUID if resolution fails; [buildSuccessState]
+            // still tries that as a secondary lookup.
+            val resolvedMaPlayerId = MusicAssistantManager.resolveThisDeviceMaPlayerId()
+            Log.d(TAG, "Resolved MA player ID: $resolvedMaPlayerId")
+
             val result = MusicAssistantManager.getAllPlayers()
             result.fold(
                 onSuccess = { allPlayers ->
-                    buildSuccessState(thisDevicePlayerId, allPlayers)
+                    buildSuccessState(thisDevicePlayerId, resolvedMaPlayerId, allPlayers)
                 },
                 onFailure = { error ->
                     Log.e(TAG, "Failed to load players", error)
@@ -167,11 +175,23 @@ class PlayerViewModel : ViewModel() {
 
     /**
      * Build the Success UI state from the active player and full player list.
+     *
+     * @param thisDevicePlayerId raw UUID we registered with SendSpin
+     * @param resolvedMaPlayerId server-resolved MA-internal id (may be null if
+     *        resolution failed); preferred match since MA uses a transformed id
+     *        for SendSpin-provider players
      */
-    private fun buildSuccessState(thisDevicePlayerId: String, allPlayers: List<MaPlayer>) {
-        val currentPlayer = allPlayers.find { it.playerId == thisDevicePlayerId }
+    private fun buildSuccessState(
+        thisDevicePlayerId: String,
+        resolvedMaPlayerId: String?,
+        allPlayers: List<MaPlayer>,
+    ) {
+        val currentPlayer = resolvedMaPlayerId?.let { id ->
+            allPlayers.find { it.playerId == id }
+        } ?: allPlayers.find { it.playerId == thisDevicePlayerId }
         if (currentPlayer == null) {
-            Log.e(TAG, "This device player $thisDevicePlayerId not found in player list " +
+            Log.e(TAG, "This device player $thisDevicePlayerId " +
+                "(resolved=$resolvedMaPlayerId) not found in player list " +
                 "(${allPlayers.size} players: ${allPlayers.map { "${it.playerId}=${it.name}" }})")
             _uiState.value = PlayerUiState.Error("This device not found in player list")
             return
@@ -239,10 +259,11 @@ class PlayerViewModel : ViewModel() {
     private fun reloadSilently() {
         viewModelScope.launch {
             val thisDevicePlayerId = MusicAssistantManager.getThisDevicePlayerId()
+            val resolvedMaPlayerId = MusicAssistantManager.resolveThisDeviceMaPlayerId()
             val result = MusicAssistantManager.getAllPlayers()
             result.fold(
                 onSuccess = { allPlayers ->
-                    buildSuccessState(thisDevicePlayerId, allPlayers)
+                    buildSuccessState(thisDevicePlayerId, resolvedMaPlayerId, allPlayers)
                 },
                 onFailure = { error ->
                     Log.e(TAG, "Silent reload failed", error)


### PR DESCRIPTION
## Summary

Fixes the \"Failed to load players\" error in the groups/players sheet. PlayerViewModel was comparing MA's player list against our raw SendSpin UUID, but MA stores SendSpin-provider players under a transformed id (\`up\` + UUID-without-dashes). The naive equality check never matched even though our device was in the list under the transformed id.

## Observed failure

On-device log with 59 players fetched successfully from MA:

\`\`\`
D PlayerViewModel: Loading players...
D MaCommandClient: Sending command: players/all
I MaCommandClient: Fetched 59 players
E PlayerViewModel: This device player cca98b82-3281-4132-a07c-0c21f1f71e48
  not found in player list (59 players: [..., upcca98b8232814132a07c0c21f1f71e48=NX809J, ...])
\`\`\`

Our id: \`cca98b82-3281-4132-a07c-0c21f1f71e48\`
MA's id for us: \`upcca98b8232814132a07c0c21f1f71e48\` (\"up\" + UUID stripped of dashes)

## Fix

\`MaCommandClient\` already resolves this gap via \`player_queues/get_active_queue\` — the server maps our raw UUID to its internal id. Expose that via a new public \`MusicAssistantManager.resolveThisDeviceMaPlayerId()\`, then have \`PlayerViewModel\` call it before matching:

\`\`\`kotlin
val resolvedMaPlayerId = MusicAssistantManager.resolveThisDeviceMaPlayerId()
// ...
val currentPlayer = resolvedMaPlayerId?.let { id ->
    allPlayers.find { it.playerId == id }
} ?: allPlayers.find { it.playerId == thisDevicePlayerId }  // fallback
\`\`\`

- Primary match: server-resolved id (authoritative, works regardless of MA's internal transform).
- Fallback: raw UUID (handles the case where resolution fails — e.g. brief MA disconnect mid-call).
- Error only if both fail.

## Edge case: sync groups

When this device is synced to another player, \`get_active_queue\` returns the GROUP's queue id rather than this device's individual player id. That is acceptable and arguably correct: the groups/players UI should show the group we are participating in, not our standalone follower identity. Noted in the code comment.

## Scope

- \`MusicAssistantManager.kt\`: new public \`resolveThisDeviceMaPlayerId(): String?\`
- \`PlayerViewModel.kt\`: 2 call-sites updated (\`loadPlayers\`, \`reloadSilently\`); \`buildSuccessState\` takes one additional parameter.

Not caused by recent audit work — the id-format mismatch has been present since \`PlayerViewModel\` was introduced.

## Verified

- [x] \`./gradlew assembleDebug\`
- [x] On-device re-test (user to confirm)

## Test plan

- [ ] CI build + tests pass
- [ ] On-device: groups/players sheet loads; current device shown as the active player; other 58 players visible as groupable targets
- [ ] On-device: if in a sync group, the sheet shows the group's player rather than our standalone id (this is the intended edge-case behavior)