### PR TITLE
feat(ma): fast track-change metadata via queue_updated

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
+++ b/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistantManager.kt
@@ -18,13 +18,21 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import com.sendspindroid.musicassistant.transport.MaTransportException
 import java.io.IOException
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.longOrNull
 
 /** Map app ConnectionMode to shared MaConnectionMode. */
 private fun ConnectionMode.toMaMode(): MaConnectionMode = when (this) {
@@ -56,6 +64,22 @@ private fun ConnectionMode.toMaMode(): MaConnectionMode = when (this) {
  * - Connection lifecycle
  * - Token/credential authentication flow
  */
+/**
+ * Metadata extracted from a Music Assistant `queue_updated` event.
+ *
+ * Null fields mean "no information available"; callers should preserve existing
+ * state for null fields (matching the null-preserves-existing semantics of
+ * [com.sendspindroid.model.PlaybackState.withMetadata]).
+ */
+data class QueueUpdate(
+    val queueId: String?,
+    val currentItemId: String?,
+    val title: String?,
+    val artist: String?,
+    val album: String?,
+    val durationMs: Long?
+)
+
 object MusicAssistantManager {
 
     private const val TAG = "MusicAssistantManager"
@@ -68,6 +92,15 @@ object MusicAssistantManager {
      * different scenarios (error messages, re-login prompts, etc.).
      */
     val connectionState: StateFlow<MaConnectionState> = _connectionState.asStateFlow()
+
+    // Queue update events from the MA command-channel (fix 8a).
+    // Emitted when a `queue_updated` event arrives, roughly 1 second before
+    // the equivalent SendSpin server/state broadcast with the same metadata.
+    private val _queueUpdates = MutableSharedFlow<QueueUpdate>(
+        replay = 0,
+        extraBufferCapacity = 16
+    )
+    val queueUpdates: SharedFlow<QueueUpdate> = _queueUpdates.asSharedFlow()
 
     // Current server info (when connected)
     private var currentServer: UnifiedServer? = null
@@ -212,6 +245,7 @@ object MusicAssistantManager {
         connectJob = null
 
         // Disconnect the persistent transport
+        apiTransport?.setEventListener(null)
         apiTransport?.disconnect()
         apiTransport = null
 
@@ -242,6 +276,7 @@ object MusicAssistantManager {
         clearTokenForServer: String? = null
     ) {
         Log.e(TAG, "$logPrefix failed", e)
+        apiTransport?.setEventListener(null)
         apiTransport?.disconnect()
         apiTransport = null
         commandClient.setTransport(null, null, false)
@@ -261,6 +296,61 @@ object MusicAssistantManager {
         )
     }
 
+    // ========================================================================
+    // Event listener: queue_updated fast metadata path (fix 8a)
+    // ========================================================================
+
+    /**
+     * Receives server-push events from the MA command channel and emits
+     * [QueueUpdate] for `queue_updated` events.
+     *
+     * This provides title/artist/album roughly 1 second before the equivalent
+     * SendSpin `server/state` broadcast arrives. See fix 8a in
+     * docs/architecture/sendspin-ma-metadata-flow.md.
+     */
+    private val queueEventListener = object : MaApiTransport.EventListener {
+        override fun onEvent(event: kotlinx.serialization.json.JsonObject) {
+            try {
+                val eventType = event["event"]?.jsonPrimitive?.contentOrNull
+                if (eventType != "queue_updated") return
+
+                val data = event["data"]?.jsonObject ?: return
+                val currentItem = data["current_item"]?.jsonObject ?: return
+
+                val queueId = data["queue_id"]?.jsonPrimitive?.contentOrNull
+                val currentItemId = data["current_item_id"]?.jsonPrimitive?.contentOrNull
+                val durationMs = currentItem["duration"]?.jsonPrimitive?.longOrNull?.let { it * 1000L }
+
+                val mediaItem = currentItem["media_item"]?.jsonObject
+                val title = mediaItem?.get("name")?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+                val artist = mediaItem?.get("artists")?.jsonArray
+                    ?.firstOrNull()?.jsonObject
+                    ?.get("name")?.jsonPrimitive?.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+                val album = mediaItem?.get("album")?.jsonObject
+                    ?.get("name")?.jsonPrimitive?.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+
+                val update = QueueUpdate(
+                    queueId = queueId,
+                    currentItemId = currentItemId,
+                    title = title,
+                    artist = artist,
+                    album = album,
+                    durationMs = durationMs
+                )
+                Log.v(TAG, "queue_updated: title=$title artist=$artist album=$album durationMs=$durationMs")
+                _queueUpdates.tryEmit(update)
+            } catch (e: Exception) {
+                Log.v(TAG, "Failed to parse queue_updated event, ignoring", e)
+            }
+        }
+
+        override fun onDisconnected(reason: String) {
+            Log.d(TAG, "Event transport disconnected: $reason")
+        }
+    }
+
     /**
      * Connect a transport and store it for subsequent API calls.
      *
@@ -273,6 +363,7 @@ object MusicAssistantManager {
         serverId: String,
         authenticate: suspend (MaApiTransport) -> Unit
     ): MaServerInfo {
+        apiTransport?.setEventListener(null)
         apiTransport?.disconnect()
         apiTransport = null
 
@@ -282,6 +373,7 @@ object MusicAssistantManager {
         authenticate(transport)
 
         apiTransport = transport
+        transport.setEventListener(queueEventListener)
         val isRemote = apiUrl == MaApiEndpoint.WEBRTC_SENTINEL_URL
         commandClient.setTransport(transport, apiUrl, isRemote)
 

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -66,6 +66,7 @@ import com.sendspindroid.musicassistant.MaQueueItem
 import com.sendspindroid.musicassistant.MaRadio
 import com.sendspindroid.musicassistant.MaTrack
 import com.sendspindroid.musicassistant.MusicAssistantManager
+import com.sendspindroid.musicassistant.QueueUpdate
 import com.sendspindroid.sendspin.SendSpinClient
 import com.sendspindroid.discovery.NsdDiscoveryManager
 import com.sendspindroid.UnifiedServerRepository
@@ -674,6 +675,16 @@ class PlaybackService : MediaLibraryService() {
 
         // Initialize MusicAssistantManager for MA API integration
         MusicAssistantManager.initialize(this)
+
+        // Fast metadata path: subscribe to MA command-channel queue_updated events
+        // to update title/artist/album as soon as the server's queue advances,
+        // roughly 1 second before the SendSpin server/state broadcast arrives.
+        // See docs/architecture/sendspin-ma-metadata-flow.md section 8a.
+        serviceScope.launch {
+            MusicAssistantManager.queueUpdates.collect { update ->
+                applyFastQueueUpdate(update)
+            }
+        }
 
         // Initialize UnifiedServerRepository for server lookups
         UnifiedServerRepository.initialize(this)
@@ -1472,6 +1483,58 @@ class PlaybackService : MediaLibraryService() {
                 // Connection state will be updated by onConnected() callback which follows
             }
         }
+    }
+
+    // ========================================================================
+    // Fast metadata path: queue_updated event from MA command channel (fix 8a)
+    // ========================================================================
+
+    /**
+     * Apply title/artist/album from a Music Assistant `queue_updated` event.
+     *
+     * Called from [MusicAssistantManager.queueUpdates] roughly 1 second before
+     * the SendSpin `server/state` broadcast with the same metadata. Updates
+     * [_playbackState] and [sendSpinPlayer]'s MediaItem so the lock screen,
+     * Android Auto, and Bluetooth AVRCP reflect the new track immediately.
+     *
+     * Artwork is intentionally NOT updated here; the SendSpin `server/state`
+     * that follows will carry a fully-resolved artwork_url and is the
+     * authoritative source for imagery. See fix 8b for URL-preferred artwork.
+     *
+     * Must run on the Main thread (serviceScope dispatcher is Main).
+     */
+    @OptIn(UnstableApi::class)
+    private fun applyFastQueueUpdate(update: QueueUpdate) {
+        // Skip if there is no new title information.
+        if (update.title == null && update.artist == null && update.album == null) return
+
+        val current = _playbackState.value
+
+        // Skip if the title is already up to date to avoid redundant writes.
+        // When SendSpin server/state arrives ~1s later with the same title,
+        // the withMetadata call below is a no-op (null-preserves semantics ensure
+        // no visible flicker). But we skip early here to avoid the sendSpinPlayer
+        // round-trip when nothing has changed.
+        if (update.title != null && update.title == current.title) return
+
+        Log.d(TAG, "Fast metadata via queue_updated: ${update.title} / ${update.artist} / ${update.album}")
+
+        _playbackState.value = current.withMetadata(
+            title = update.title,
+            artist = update.artist,
+            album = update.album,
+            artworkUrl = null,  // preserve existing; server/state will update this
+            durationMs = update.durationMs ?: current.durationMs,
+            positionMs = current.positionMs,
+            playbackSpeed = current.playbackSpeed
+        )
+
+        sendSpinPlayer?.updateMediaItem(
+            title = update.title,
+            artist = update.artist,
+            album = update.album,
+            durationMs = update.durationMs ?: 0L
+        )
     }
 
     /**


### PR DESCRIPTION
## Summary

Implements fix 8a from `docs/architecture/sendspin-ma-metadata-flow.md §8a`.

- Registers a `MaApiTransport.EventListener` on the MA command channel to receive `queue_updated` push events, which arrive ~1 second before the equivalent SendSpin `server/state` broadcast
- Parses `title`, `artist`, `album`, and `durationMs` from the `current_item.media_item` payload and emits them on a new `MusicAssistantManager.queueUpdates: SharedFlow<QueueUpdate>`
- `PlaybackService.onCreate` collects this flow and calls `applyFastQueueUpdate`, which updates `_playbackState` and `sendSpinPlayer`'s MediaItem immediately — closing the user-visible metadata-lag gap on track advance
- Artwork URL resolution is explicitly out of scope (fix 8b handles that); the SendSpin `server/state` arriving ~1s later is still authoritative for artwork and overwrites via the existing `onMetadataUpdate` path

## Implementation notes

- `QueueUpdate` data class uses null fields (not empty strings) to match `withMetadata`'s null-preserves-existing semantics — no risk of accidentally clearing title/artist/album already in state
- Event listener is defensive: wrapped in try/catch, logs at V-level on parse error, never crashes on malformed payloads
- Listener is set on transport connect and cleared on all three disconnect/cleanup sites (`connectTransport` re-entry, `onServerDisconnected`, `handleConnectionFailure`)
- Early-exit guard in `applyFastQueueUpdate`: skips write if `update.title == current.title` to avoid a redundant `sendSpinPlayer` round-trip when `server/state` arrives with identical data

## Test plan

- [x] `assembleDebug` — clean build, no new errors or warnings
- [x] `:app:testDebugUnitTest --tests "com.sendspindroid.musicassistant.*" --tests "com.sendspindroid.playback.*"` — all pass
- [x] `:shared:testAndroidHostTest --tests "com.sendspindroid.musicassistant.*"` — 126 tests, 1 pre-existing failure (`MaCommandMultiplexerTest.partial result with empty array does not accumulate`), no new failures