### PR TITLE
fix(artwork): prefer URL over binary + per-track invalidation

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -267,9 +267,23 @@ class PlaybackService : MediaLibraryService() {
     private var lastSyncOffsetMs: Double = 0.0
     private var lastSyncOffsetSource: String = ""
 
-    // Artwork state
+    // Artwork state. Two independent sources are maintained so the lock-screen
+    // widget and app UI don't diverge when the SendSpin server sends a binary
+    // artwork payload whose contents don't match the `artwork_url` in the
+    // accompanying `server/state` metadata (observed with MA in playlist
+    // contexts; see docs/architecture/sendspin-ma-metadata-flow.md §7 Q4/Q5).
+    //
+    // Policy: URL artwork is authoritative when available. Binary artwork is
+    // used only as a bridge before the URL fetch completes, matching what the
+    // app's own mini-player already does via Coil on the `artworkUrl` state.
+    //
+    // effectiveArtwork is recomputed on every write and passed to MediaSession.
     private var lastArtworkUrl: String? = null
-    private var currentArtwork: Bitmap? = null
+    private var lastTrackTitle: String? = null
+    private var urlArtwork: Bitmap? = null
+    private var binaryArtwork: Bitmap? = null
+    private val effectiveArtwork: Bitmap?
+        get() = urlArtwork ?: binaryArtwork
     // ImageLoader is null when low memory mode is enabled
     private var imageLoader: ImageLoader? = null
 
@@ -1002,7 +1016,9 @@ class PlaybackService : MediaLibraryService() {
                 // Clear playback state on disconnect
                 _playbackState.value = PlaybackState()
                 lastArtworkUrl = null
-                currentArtwork = null
+                lastTrackTitle = null
+                urlArtwork = null
+                binaryArtwork = null
 
                 // Clear lock screen metadata
                 forwardingPlayer?.clearMetadata()
@@ -1182,10 +1198,27 @@ class PlaybackService : MediaLibraryService() {
                 // Populate the player's timeline with queue items for native queue UI
                 populatePlayerQueue()
 
-                // Handle artwork URL changes
+                // Handle artwork URL changes + track changes.
+                //
+                // On title change we invalidate urlArtwork and re-fetch the URL
+                // even when the URL string itself is unchanged. MA reuses the
+                // album URL across tracks on the same album, so without this
+                // invalidation the MediaSession keeps whatever bitmap was set at
+                // the first track of the album (commonly the binary artwork,
+                // which MA may have populated with a playlist-context image
+                // rather than the actual album cover -- see
+                // docs/architecture/sendspin-ma-metadata-flow.md §7 Q4).
+                // Coil caches the URL so re-fetching is essentially free.
+                val newTitle = title.ifEmpty { null }
+                val titleChanged = newTitle != lastTrackTitle
+                if (titleChanged) {
+                    lastTrackTitle = newTitle
+                    urlArtwork = null
+                }
+
                 if (effectiveArtworkUrl.isEmpty()) {
                     lastArtworkUrl = null
-                } else if (effectiveArtworkUrl != lastArtworkUrl) {
+                } else if (effectiveArtworkUrl != lastArtworkUrl || titleChanged) {
                     lastArtworkUrl = effectiveArtworkUrl
                     fetchArtwork(effectiveArtworkUrl)
                 }
@@ -1213,8 +1246,12 @@ class PlaybackService : MediaLibraryService() {
                         bitmap?.let { scaleArtwork(it) }
                     }
                     if (scaled != null) {
-                        currentArtwork = scaled
-                        updateMediaSessionArtwork(scaled)
+                        binaryArtwork = scaled
+                        // Only push to MediaSession if we don't already have URL-based
+                        // artwork; URL is preferred (see urlArtwork field comment).
+                        if (urlArtwork == null) {
+                            updateMediaSessionArtwork(scaled)
+                        }
                     }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to decode artwork", e)
@@ -1225,7 +1262,7 @@ class PlaybackService : MediaLibraryService() {
         override fun onArtworkCleared() {
             mainHandler.post {
                 Log.d(TAG, "Artwork cleared by server (empty payload)")
-                currentArtwork = null
+                binaryArtwork = null
                 updateMediaMetadata(
                     _playbackState.value.title ?: "",
                     _playbackState.value.artist ?: "",
@@ -1501,7 +1538,9 @@ class PlaybackService : MediaLibraryService() {
                     val bitmap = result.drawable.toBitmap()
                     val scaled = scaleArtwork(bitmap)
                     mainHandler.post {
-                        currentArtwork = scaled
+                        urlArtwork = scaled
+                        // URL is preferred over binary; push this to MediaSession
+                        // unconditionally.
                         updateMediaSessionArtwork(scaled)
                     }
                 }
@@ -1590,7 +1629,7 @@ class PlaybackService : MediaLibraryService() {
             title = state.title,
             artist = state.artist,
             album = state.album,
-            artwork = currentArtwork,
+            artwork = effectiveArtwork,
             artworkUri = state.artworkUrl?.let { Uri.parse(it) }
         )
 


### PR DESCRIPTION
## Summary

Implements fix **8b** from `docs/architecture/sendspin-ma-metadata-flow.md`. Fixes the \"lock-screen widget shows wrong album art\" symptom the user reported on 2026-04-22 — where the app's own mini-player correctly displayed the Chicago album cover but the Android lock-screen / notification widget showed an unrelated pixel-character image for the same track.

Pairs with #151 (8a, fast metadata via MA `queue_updated` event) — neither depends on the other; the combination closes both the \"metadata lags audio\" and \"widget shows wrong artwork\" UX complaints.

## Root cause (copied from the doc)

MA sends two different artwork streams sourced from three different server-side image fields. Client's `onArtwork` (binary) and `fetchArtwork` (URL) both wrote into a single `currentArtwork` — last-writer-wins. When the first track of an album triggered a binary send with the \"wrong\" image and MA's dedupe then suppressed further binary sends for the rest of the album, `currentArtwork` stayed set to that wrong image.

## Fix

Two independent artwork fields with an explicit preference policy:

```kotlin
private var urlArtwork: Bitmap? = null
private var binaryArtwork: Bitmap? = null
private val effectiveArtwork: Bitmap?
    get() = urlArtwork ?: binaryArtwork
```

- `fetchArtwork` success path writes `urlArtwork` and always pushes to MediaSession.
- `onArtwork` (binary) writes `binaryArtwork` and only pushes to MediaSession when `urlArtwork` is still null (bridge case before Coil completes the URL fetch).
- `onArtworkCleared` clears `binaryArtwork` only.
- `onMetadataUpdate`: when `title` changed compared to `lastTrackTitle`, invalidate `urlArtwork` and kick `fetchArtwork(...)` even if the URL string is identical. Coil caches, so the re-fetch is free. This forces a fresh URL bitmap install per track, overriding any stale binary.

`updateMediaMetadata` and `updateMediaSessionArtwork` now both read `effectiveArtwork` via the computed getter.

## Rationale for preferring URL

Per §7 Q5 of the architecture doc, the SendSpin protocol spec does not require `artwork_url` and binary channel 0 to match. The client is free to pick a policy. User-observed evidence is that URL is typically correct (app UI uses it directly and is correct); binary can be wrong in playlist/radio contexts. URL-preferred is the pragmatic default.

The bridge behavior (binary fills in before URL fetch completes) preserves the \"Android Auto grey-box\" mitigation that the original inline comment warned about.

## Verified

- [x] `./gradlew assembleDebug`
- [ ] On-device smoke — pending install on device; behavior to confirm: lock-screen widget artwork now matches the in-app mini-player on every track change, including same-album sequences.

## Test plan

- [ ] CI build passes
- [ ] On-device: play a playlist where adjacent tracks are from the same album. Lock-screen widget shows the correct album cover for every track, not a stale / wrong image from the start of the album.
- [ ] On-device: switch between albums. Artwork updates promptly per track boundary.
- [ ] On-device: fresh connect — widget shows artwork once the URL fetch completes (Coil cache hits → near-instant; cold → a second or so; binary bridges the gap if it arrives first).

## Scope

Single file touched: `android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt`. ~49 / -10.

## Not in this PR

- Protocol-level `channel` parameter routing (fix B1 from the doc) — dormant since we only request channel 0 in our `client/hello`, but worth a future small PR to propagate channel properly.
- Upstream MA fix for the three-image-source inconsistency (§7 Q4) — this client-side change makes us resilient regardless; filing upstream is recommended but separate.