### PR TITLE
fix: tick latency estimator during WAITING_FOR_START to unblock playback

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -1490,6 +1490,16 @@ class SyncAudioPlayer(
      * @return true if we should continue waiting, false if ready to play
      */
     private fun handleStartGatingDacAware(track: AudioTrack): Boolean {
+        // Wind the estimator's timeout clock before checking its status. Once
+        // dacTimestampsStable flips to true, the WAITING_FOR_START branch of
+        // the main loop stops calling preCalibrateDacTiming() -- which was the
+        // only other path that ticked the estimator. Without this call, an
+        // estimator that hasn't accepted 20 samples before DAC stabilises
+        // stays in Measuring indefinitely, and the status check below holds
+        // us in WAITING_FOR_START forever. On-device that surfaces as
+        // MediaSession BUFFERING with a growing chunk queue and no audio.
+        latencyEstimator.tick()
+
         // Measurement-complete clause: don't transition to PLAYING until
         // the latency estimator has converged or timed out. If we don't
         // wait here, an unusually-early server-scheduled start could make


### PR DESCRIPTION
## Summary

On-device we observed the audio pipeline deadlock in `WAITING_FOR_START`: MediaSession reports `BUFFERING(6)`, the chunk queue grows unbounded (~32MB / 166s of buffered audio), and no audio is ever written. The server eventually ends the stream after 4+ minutes of client silence.

UI surfaces the server-reported state (`playing`), which is why the lock-screen / UI both show "Playing" even though nothing is coming out of the speaker.

## Root cause

`OutputLatencyEstimator` is passive — its 2s timeout only fires when `tick()` is called. In PR #144 (Group 5), `tick()` is invoked from only two paths:

1. `preCalibrateDacTiming()`, which the `WAITING_FOR_START` branch of the main loop stops calling once `dacTimestampsStable` flips to `true`.
2. The `PLAYING`-state chunk writer, which we cannot reach because the `Status.Measuring` guard in `handleStartGatingDacAware()` (`SyncAudioPlayer.kt:1498`) blocks the transition.

If the DAC stabilises before the estimator has accepted 20 samples — which happened on my device with only 3 samples accepted — the estimator is starved: no more DAC samples, no more ticks, status stays `Measuring` forever, and the state machine is wedged.

The 2s safety-net existed in the design but there was no-one winding the clock during the specific wedge window.

## Fix

Single call to `latencyEstimator.tick()` at the top of `handleStartGatingDacAware()`, directly above the `Status.Measuring` short-circuit that holds us in the state. That guarantees the 2s timeout is always evaluated on the code path that depends on its result.

When timeout fires, the existing `[delay-cal] timed out with N samples; falling back to 0` handler runs and `static_delay_ms` falls back to 0. The state machine then continues past the guard on the next iteration.

## Logs that proved the deadlock

From my on-device repro (PID 12208):

- `state=WAITING_FOR_START` for ~4 minutes with `queue` growing from ~20MB to ~32MB
- Zero `DAC-aware start gating complete: now PLAYING` lines
- One `[delay-cal] timed out with 3 samples; falling back to 0` line — fired only at stream-end (09:14:38), after the server gave up, triggered incidentally by `release()` tearing down the player

## Test plan

- [ ] Install on device, confirm `state=PLAYING` reached within a few seconds of pressing play
- [ ] Verify `[delay-cal]` either converges or times out during the WAITING_FOR_START window, not at stream-end
- [ ] Confirm no regression in normal-path playback (first-chunk to first-audio latency stays comparable)
- [ ] Spot-check spotty-Wi-Fi behavior isn't made worse

## Notes

- Existing `OutputLatencyEstimatorTest.times out after 2 seconds with partial sample count` already validates the estimator-side tick mechanism. No new unit test added because the bug is purely wiring-level and `handleStartGatingDacAware` requires a real `AudioTrack` to exercise via reflection.
- Follow-up: the estimator rejecting 90%+ of samples (only 3 of ~tens accepted before timeout) is worth investigating separately — likely a ring-buffer-size / DAC-frame-offset mismatch. Not addressed here.
- Follow-up: the "UI says Playing when audio silent" symptom is a surface-area problem worth its own fix (prefer MediaSession state over server-reported state in the UI).