### PR TITLE
feat: audio integration harness, stuck-state watchdog, JsonNull parse fix

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -342,6 +342,11 @@ class SyncAudioPlayer(
         private const val CHUNK_DROP_LOG_INTERVAL = 100  // Log every Nth dropped chunk when time sync not ready
         private const val DAC_PACING_LOG_INTERVAL_US = 10_000_000L  // Log DAC pacing stats every 10 seconds
 
+        // Stuck-state watchdog: detects when the state machine wedges in a
+        // non-PLAYING state while chunks are arriving (diagnostic only).
+        private const val STUCK_STATE_WARNING_US = 5_000_000L         // 5s
+        private const val STUCK_STATE_WARNING_INTERVAL_US = 10_000_000L  // 10s between warnings
+
         // Pre-sync buffering - buffer chunks while waiting for time sync to be ready
         private const val MAX_PENDING_CHUNKS = 500  // ~10 seconds at 48kHz/20ms chunks
 
@@ -524,6 +529,12 @@ class SyncAudioPlayer(
     @Volatile private var framesDropped = 0L
     @Volatile private var reanchorCount = 0L        // Count of reanchor events
     @Volatile private var bufferUnderrunCount = 0L  // Count of times queue was empty during playback
+
+    // Stuck-state watchdog: tracks when a non-PLAYING state was first entered.
+    // Used by the stats logger to surface state-machine deadlocks.
+    private var stuckStateEnteredAtUs: Long = 0L
+    private var lastObservedState: PlaybackState = PlaybackState.INITIALIZING
+    private var lastStuckWarningAtUs: Long = 0L
 
     // Pre-sync chunk buffer - holds chunks received before time sync is ready.
     // These will be processed once time sync completes. Mutations require the
@@ -2066,8 +2077,10 @@ class SyncAudioPlayer(
                 val pendingToDacUs = if (audioSink != null && dacTimestampsStable)
                     getPendingToDacUs(audioSink!!) else 0L
 
-                // Rate-limited DAC pacing diagnostics
+                // Rate-limited DAC pacing diagnostics. The watchdog shares this
+                // cadence so stuck-state warnings come out on the same log tick.
                 val nowMicros = nowNs() / 1000
+                checkStuckState()
                 if (dacTimestampsStable && nowMicros - lastDacPacingLogTimeUs > DAC_PACING_LOG_INTERVAL_US) {
                     lastDacPacingLogTimeUs = nowMicros
                     AppLog.Sync.d("DAC pacing: pending=${pendingToDacUs/1000}ms, syncErr=${syncErrorUs/1000}ms")
@@ -2094,6 +2107,51 @@ class SyncAudioPlayer(
 
             AppLog.Audio.d("Playback loop ended")
         }
+    }
+
+    /**
+     * Watchdog invoked once per stats-log cycle. Warns if the state machine
+     * has been in a non-PLAYING state for more than STUCK_STATE_WARNING_US
+     * while chunks are arriving (indicating the pipeline is wedged, not
+     * just idle).
+     *
+     * Diagnostic only -- no recovery action.
+     */
+    private fun checkStuckState() {
+        val nowUs = nowNs() / 1000
+        val state = playbackState
+
+        if (state != lastObservedState) {
+            lastObservedState = state
+            stuckStateEnteredAtUs = nowUs
+            return
+        }
+
+        if (state == PlaybackState.PLAYING) return
+
+        val stuckUs = nowUs - stuckStateEnteredAtUs
+        if (stuckUs < STUCK_STATE_WARNING_US) return
+
+        // Don't spam when there's no audio backlog -- that's a genuinely
+        // idle state (e.g. user paused), not a deadlock.
+        if (totalQueuedSamples.get() == 0L) return
+
+        // Rate-limit: once warned, stay quiet for STUCK_STATE_WARNING_INTERVAL_US.
+        // The `lastStuckWarningAtUs != 0L` guard ensures the first warning always
+        // fires -- otherwise `nowUs - 0` is trivially small and the watchdog
+        // would silently suppress its very first report.
+        if (lastStuckWarningAtUs != 0L &&
+            nowUs - lastStuckWarningAtUs < STUCK_STATE_WARNING_INTERVAL_US
+        ) return
+        lastStuckWarningAtUs = nowUs
+
+        val bufferedMs = (totalQueuedSamples.get() * 1000) / sampleRate
+        AppLog.Audio.w(
+            "WATCHDOG: state=$state stuck for ${stuckUs / 1000}ms, " +
+                "buffered=${bufferedMs}ms, chunks=${chunkQueue.size}, " +
+                "estimatorStatus=${latencyEstimator.status}, " +
+                "dacTimestampsStable=$dacTimestampsStable"
+        )
     }
 
     /**

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -3,12 +3,13 @@ package com.sendspindroid.sendspin
 import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.os.Build
-import android.media.AudioTimestamp
 import android.media.AudioTrack
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Process
 import com.sendspindroid.logging.AppLog
+import com.sendspindroid.sendspin.audio.AudioSink
+import com.sendspindroid.sendspin.audio.AudioTrackSink
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -337,7 +338,7 @@ class SyncAudioPlayer(
     )
 
     // Audio output
-    private var audioTrack: AudioTrack? = null
+    private var audioSink: AudioSink? = null
     private val isPlaying = AtomicBoolean(false)
     private val isPaused = AtomicBoolean(false)
 
@@ -376,7 +377,6 @@ class SyncAudioPlayer(
     @Volatile private var streamGeneration = 0  // Incremented on stream/clear to invalidate old chunks
 
     // Sync error tracking
-    private val audioTimestamp = AudioTimestamp()  // Reusable timestamp object
     private var syncUpdateCounter = 0  // Counter for update interval
     private val totalFramesWritten = AtomicLong(0)  // Total frames written to AudioTrack
 
@@ -501,7 +501,7 @@ class SyncAudioPlayer(
         }
 
         stateLock.withLock {
-            if (audioTrack != null) {
+            if (audioSink != null) {
                 AppLog.Audio.w("Already initialized")
                 return
             }
@@ -542,7 +542,7 @@ class SyncAudioPlayer(
         val bufferSize = maxOf(minBufferSize * BUFFER_SIZE_MULTIPLIER, sampleRate * bytesPerFrame) // ~1 second
 
         try {
-            audioTrack = AudioTrack.Builder()
+            val track = AudioTrack.Builder()
                 .setAudioAttributes(
                     AudioAttributes.Builder()
                         .setUsage(AudioAttributes.USAGE_MEDIA)
@@ -560,6 +560,7 @@ class SyncAudioPlayer(
                 .setTransferMode(AudioTrack.MODE_STREAM)
                 .setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
                 .build()
+            audioSink = AudioTrackSink(track, bytesPerFrame)
 
             // Pre-allocate frame buffers for sync correction (avoids GC in audio callback)
             lastOutputFrame = ByteArray(bytesPerFrame)
@@ -616,7 +617,7 @@ class SyncAudioPlayer(
                 return
             }
 
-            if (audioTrack == null) {
+            if (audioSink == null) {
                 AppLog.Audio.e("AudioTrack not initialized")
                 return
             }
@@ -640,7 +641,7 @@ class SyncAudioPlayer(
                 return
             }
 
-            val track = audioTrack
+            val track = audioSink
             if (track == null) {
                 AppLog.Audio.e("AudioTrack was released during playback loop cancellation")
                 return
@@ -681,8 +682,8 @@ class SyncAudioPlayer(
         stateLock.withLock {
             isPaused.set(true)
             pausedAtUs = nowNs() / 1000
-            audioTrack?.pause()
-            audioTrack?.flush()
+            audioSink?.pause()
+            audioSink?.flush()
             AppLog.Audio.d("Playback paused")
         }
     }
@@ -704,9 +705,9 @@ class SyncAudioPlayer(
             if (!isPaused.get()) {
                 // Even if our flag says not paused, the AudioTrack hardware might still be paused
                 // (e.g., after clearBuffer() was called while paused)
-                if (audioTrack?.playState != AudioTrack.PLAYSTATE_PLAYING) {
+                if (audioSink?.playState != AudioTrack.PLAYSTATE_PLAYING) {
                     AppLog.Audio.i("resume() - isPaused is false but AudioTrack is not playing, forcing play")
-                    audioTrack?.play()
+                    audioSink?.play()
                 } else {
                     AppLog.Audio.d("resume() called but not paused - ignoring")
                 }
@@ -753,7 +754,7 @@ class SyncAudioPlayer(
             playingStateEnteredAtUs = nowUs
 
             isPaused.set(false)
-            audioTrack?.play()
+            audioSink?.play()
             AppLog.Audio.d("Playback resumed after ${pauseDurationUs / 1000}ms pause - sync state reset")
         }
     }
@@ -801,8 +802,8 @@ class SyncAudioPlayer(
         stateLock.withLock {
             // Now safe to manipulate AudioTrack - playback loop has stopped
             isFlushPending.set(false)  // Clear any pending flush since we flush directly below
-            audioTrack?.stop()
-            audioTrack?.flush()
+            audioSink?.stop()
+            audioSink?.flush()
             chunkQueue.clear()
             totalQueuedSamples.set(0)
 
@@ -899,10 +900,10 @@ class SyncAudioPlayer(
             // Signal the playback loop to flush AudioTrack before its next write.
             // We must NOT flush here because the playback loop may be mid-write()
             // on the coroutine thread (H-11).
-            if (audioTrack != null && isPlaying.get()) {
+            if (audioSink != null && isPlaying.get()) {
                 isFlushPending.set(true)
             } else {
-                val track = audioTrack
+                val track = audioSink
                 if (track != null) {
                     try {
                         track.flush()
@@ -1032,13 +1033,13 @@ class SyncAudioPlayer(
 
             // Release AudioTrack
             try {
-                audioTrack?.stop()
+                audioSink?.stop()
             } catch (e: IllegalStateException) {
                 // AudioTrack may already be stopped
                 AppLog.Audio.v("AudioTrack already stopped during release")
             }
-            audioTrack?.release()
-            audioTrack = null
+            audioSink?.release()
+            audioSink = null
 
             // Clear all buffers and state
             chunkQueue.clear()
@@ -1088,11 +1089,11 @@ class SyncAudioPlayer(
             // We must NOT flush here because the playback loop may be mid-write()
             // on the coroutine thread -- concurrent pause()/flush() causes clicks/pops
             // and incorrect frame accounting (H-11).
-            if (audioTrack != null && isPlaying.get()) {
+            if (audioSink != null && isPlaying.get()) {
                 isFlushPending.set(true)
             } else {
                 // Not playing -- safe to flush directly (no concurrent writes)
-                val track = audioTrack
+                val track = audioSink
                 if (track != null) {
                     try {
                         track.flush()
@@ -1104,7 +1105,7 @@ class SyncAudioPlayer(
 
             // Ensure AudioTrack hardware matches software state after clearing pause flag
             if (wasPaused) {
-                audioTrack?.play()
+                audioSink?.play()
             }
 
             lastChunkServerTime = 0L
@@ -1472,7 +1473,7 @@ class SyncAudioPlayer(
      * @return true if we should continue waiting, false if ready to play
      */
     private fun handleStartGating(): Boolean {
-        val track = audioTrack
+        val track = audioSink
         if (track != null && dacTimestampsStable) {
             return handleStartGatingDacAware(track)
         }
@@ -1491,7 +1492,7 @@ class SyncAudioPlayer(
      *
      * @return true if we should continue waiting, false if ready to play
      */
-    private fun handleStartGatingDacAware(track: AudioTrack): Boolean {
+    private fun handleStartGatingDacAware(track: AudioSink): Boolean {
         // Measurement-complete clause: don't transition to PLAYING until
         // the latency estimator has converged or timed out. If we don't
         // wait here, an unusually-early server-scheduled start could make
@@ -1692,7 +1693,7 @@ class SyncAudioPlayer(
      * occur while waiting for calibration.
      */
     private fun preCalibrateDacTiming() {
-        val track = audioTrack ?: return
+        val track = audioSink ?: return
 
         // Write pre-allocated silence (10ms = 480 frames at 48kHz)
         val silenceBytes = silenceBuffer.size
@@ -1711,15 +1712,15 @@ class SyncAudioPlayer(
         latencyEstimator.recordWrite(totalFramesWritten.get(), silenceWriteTimeNs)
 
         // Try to get DAC timestamp for calibration and stability tracking
-        val dacTimestampSuccess = track.getTimestamp(audioTimestamp)
-        if (dacTimestampSuccess) {
-            val dacTimeUs = audioTimestamp.nanoTime / 1000
+        val ts = track.getTimestamp()
+        if (ts != null) {
+            val dacTimeUs = ts.nanoTime / 1000
             val loopTimeUs = nowNs() / 1000
 
             // Sanity check - only store valid timestamps (framePosition > 0 means DAC has started)
-            if (audioTimestamp.framePosition > 0) {
+            if (ts.framePosition > 0) {
                 storeDacCalibration(dacTimeUs, loopTimeUs)
-                latencyEstimator.recordDacTimestamp(audioTimestamp.framePosition, audioTimestamp.nanoTime)
+                latencyEstimator.recordDacTimestamp(ts.framePosition, ts.nanoTime)
 
                 // Track consecutive valid reads for DAC-aware start gating
                 consecutiveValidTimestamps++
@@ -1746,7 +1747,7 @@ class SyncAudioPlayer(
      * This saves CPU during long idle periods while keeping AudioTimestamp valid.
      */
     private fun writeSilenceKeepAlive() {
-        val track = audioTrack ?: return
+        val track = audioSink ?: return
 
         val pendingUs = getPendingToDacUs(track)
         if (pendingUs > SILENCE_KEEPALIVE_THRESHOLD_US) return
@@ -1795,7 +1796,7 @@ class SyncAudioPlayer(
             totalQueuedSamples.set(0)
 
             // Safely flush the AudioTrack
-            val track = audioTrack
+            val track = audioSink
             if (track != null) {
                 try {
                     track.pause()
@@ -1883,7 +1884,7 @@ class SyncAudioPlayer(
                 // Performed here (on the playback thread) rather than on the
                 // main thread to avoid flushing mid-write (H-11).
                 if (isFlushPending.compareAndSet(true, false)) {
-                    val track = audioTrack
+                    val track = audioSink
                     if (track != null) {
                         try {
                             track.pause()
@@ -2004,8 +2005,8 @@ class SyncAudioPlayer(
                 // AudioTrack ring buffer at a target depth. This replaces the old
                 // effectiveLead scheduling which drifted due to Kalman offset changes
                 // between chunk-queue time and chunk-play time.
-                val pendingToDacUs = if (audioTrack != null && dacTimestampsStable)
-                    getPendingToDacUs(audioTrack!!) else 0L
+                val pendingToDacUs = if (audioSink != null && dacTimestampsStable)
+                    getPendingToDacUs(audioSink!!) else 0L
 
                 // Rate-limited DAC pacing diagnostics
                 val nowMicros = nowNs() / 1000
@@ -2224,7 +2225,7 @@ class SyncAudioPlayer(
         chunkQueue.poll() // Remove from queue
         totalQueuedSamples.addAndGet(-chunk.sampleCount.toLong())
 
-        val track = audioTrack ?: return
+        val track = audioSink ?: return
 
         // Track samples consumed for sync error calculation
         samplesReadSinceStart += chunk.sampleCount
@@ -2370,7 +2371,7 @@ class SyncAudioPlayer(
      */
     private var crossfadeScratchBuf = ByteArray(0)
 
-    private fun applyCrossfadeAndWrite(track: AudioTrack, normalFrame: ByteArray, normalOff: Int = 0): Int {
+    private fun applyCrossfadeAndWrite(track: AudioSink, normalFrame: ByteArray, normalOff: Int = 0): Int {
         when (crossfadeState) {
             CrossfadeState.FADING_IN -> {
                 crossfadeProgress++
@@ -2426,7 +2427,7 @@ class SyncAudioPlayer(
      * @param pcmData The raw PCM data
      * @return Total bytes written to AudioTrack
      */
-    private fun writeWithCorrection(track: AudioTrack, pcmData: ByteArray): Int {
+    private fun writeWithCorrection(track: AudioSink, pcmData: ByteArray): Int {
         // For non-16-bit formats, use simplified insert/drop without sample-level crossfade
         if (bitDepth != 16) {
             return writeWithCorrectionSimple(track, pcmData)
@@ -2542,7 +2543,7 @@ class SyncAudioPlayer(
      * sample-level crossfade or interpolation. This avoids needing format-specific
      * sample blending code for 24-bit packed and 32-bit integer encodings.
      */
-    private fun writeWithCorrectionSimple(track: AudioTrack, pcmData: ByteArray): Int {
+    private fun writeWithCorrectionSimple(track: AudioSink, pcmData: ByteArray): Int {
         val inputFrameCount = pcmData.size / bytesPerFrame
         var totalWritten = 0
         var inputOffset = 0
@@ -2608,22 +2609,22 @@ class SyncAudioPlayer(
      *   Negative = DAC is behind expected (playing slow) -> need INSERT
      */
     private fun updateSyncError() {
-        val track = audioTrack ?: return
+        val track = audioSink ?: return
         if (playbackState != PlaybackState.PLAYING) return
 
         try {
             // Query AudioTimestamp on every update
-            val success = track.getTimestamp(audioTimestamp)
-            if (success) {
-                latencyEstimator.recordDacTimestamp(audioTimestamp.framePosition, audioTimestamp.nanoTime)
+            val ts = track.getTimestamp()
+            if (ts != null) {
+                latencyEstimator.recordDacTimestamp(ts.framePosition, ts.nanoTime)
             }
             latencyEstimator.tick()
-            if (!success) {
+            if (ts == null) {
                 return
             }
 
-            val dacTimeMicros = audioTimestamp.nanoTime / 1000
-            val framePosition = audioTimestamp.framePosition
+            val dacTimeMicros = ts.nanoTime / 1000
+            val framePosition = ts.framePosition
             val loopTimeUs = nowNs() / 1000
 
             // Sanity check - framePosition should be reasonable
@@ -2786,10 +2787,10 @@ class SyncAudioPlayer(
      * Compute microseconds between AudioTrack write cursor and DAC output position.
      * Returns 0 if AudioTimestamp is unavailable or invalid.
      */
-    private fun getPendingToDacUs(track: AudioTrack): Long {
-        if (!track.getTimestamp(audioTimestamp)) return 0L
-        if (audioTimestamp.framePosition <= 0) return 0L
-        val pendingFrames = (totalFramesWritten.get() - audioTimestamp.framePosition).coerceAtLeast(0)
+    private fun getPendingToDacUs(track: AudioSink): Long {
+        val ts = track.getTimestamp() ?: return 0L
+        if (ts.framePosition <= 0) return 0L
+        val pendingFrames = (totalFramesWritten.get() - ts.framePosition).coerceAtLeast(0)
         return (pendingFrames * 1_000_000L) / sampleRate
     }
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -199,6 +199,8 @@ class SyncAudioPlayer(
     private val bitDepth: Int = SendSpinProtocol.AudioFormat.BIT_DEPTH,
     private val maxQueueSamples: Long = 0,  // 0 = unlimited; >0 caps queue to this many samples
     private val requestClientStateSnapshot: () -> Unit = {},
+    // Injectable monotonic clock for testability; production default is System.nanoTime().
+    private val nowNs: () -> Long = { System.nanoTime() },
 ) {
     companion object {
         // Sync correction thresholds (microseconds)
@@ -331,7 +333,7 @@ class SyncAudioPlayer(
     // Output latency estimator: measures hardware write-to-DAC delay during
     // the pre-playback window and writes the result to timeFilter before PLAYING.
     private val latencyEstimator = com.sendspindroid.sendspin.latency.OutputLatencyEstimator(
-        nowNs = { System.nanoTime() },
+        nowNs = nowNs,
     )
 
     // Audio output
@@ -678,7 +680,7 @@ class SyncAudioPlayer(
     fun pause() {
         stateLock.withLock {
             isPaused.set(true)
-            pausedAtUs = System.nanoTime() / 1000
+            pausedAtUs = nowNs() / 1000
             audioTrack?.pause()
             audioTrack?.flush()
             AppLog.Audio.d("Playback paused")
@@ -711,7 +713,7 @@ class SyncAudioPlayer(
                 return@withLock
             }
 
-            val nowUs = System.nanoTime() / 1000
+            val nowUs = nowNs() / 1000
             val pauseDurationUs = nowUs - pausedAtUs
             val LONG_PAUSE_THRESHOLD_US = 5_000_000L  // 5 seconds
 
@@ -841,7 +843,7 @@ class SyncAudioPlayer(
             // run, leaving stale audio in the pipeline after stream/end.
             streamGeneration++
 
-            AppLog.Audio.i("[cmd-trace] T4 enterIdle ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name} gen=$streamGeneration")
+            AppLog.Audio.i("[cmd-trace] T4 enterIdle ts=${nowNs() / 1_000_000} thread=${Thread.currentThread().name} gen=$streamGeneration")
 
             // Clear all audio buffers
             chunkQueue.clear()
@@ -1066,7 +1068,7 @@ class SyncAudioPlayer(
         stateLock.withLock {
             streamGeneration++
 
-            AppLog.Audio.i("[cmd-trace] T4 clearBuffer ts=${System.nanoTime() / 1_000_000} thread=${Thread.currentThread().name} gen=$streamGeneration")
+            AppLog.Audio.i("[cmd-trace] T4 clearBuffer ts=${nowNs() / 1_000_000} thread=${Thread.currentThread().name} gen=$streamGeneration")
 
             // Reset paused state - we're starting a fresh stream (e.g., after seek)
             // This ensures playback loop will process new chunks even if we were paused
@@ -1499,7 +1501,7 @@ class SyncAudioPlayer(
             return true  // keep waiting
         }
 
-        val nowMicros = System.nanoTime() / 1000
+        val nowMicros = nowNs() / 1000
         val pendingToDacUs = getPendingToDacUs(track)
 
         if (pendingToDacUs <= 0) {
@@ -1593,7 +1595,7 @@ class SyncAudioPlayer(
      */
     private fun handleStartGatingKalman(): Boolean {
         val scheduledStart = scheduledStartLoopTimeUs ?: return false
-        val nowMicros = System.nanoTime() / 1000
+        val nowMicros = nowNs() / 1000
         val deltaUs = scheduledStart - nowMicros
 
         when {
@@ -1630,7 +1632,7 @@ class SyncAudioPlayer(
                     scheduledStartLoopTimeUs = timeFilter.serverToClient(firstPlayableChunk.serverTimeMicros)
                 }
 
-                resetSyncBaselines(System.nanoTime() / 1000)
+                resetSyncBaselines(nowNs() / 1000)
 
                 framesDropped += droppedFrames.toLong()
 
@@ -1658,7 +1660,7 @@ class SyncAudioPlayer(
                     AppLog.Sync.d("Realigned timing anchor: serverTs ${oldServerTs}->${firstServerTimestampUs}")
                 }
 
-                resetSyncBaselines(System.nanoTime() / 1000)
+                resetSyncBaselines(nowNs() / 1000)
 
                 // Diagnostic logging
                 val bufferedMs = (totalQueuedSamples.get() * 1000) / sampleRate
@@ -1694,7 +1696,7 @@ class SyncAudioPlayer(
 
         // Write pre-allocated silence (10ms = 480 frames at 48kHz)
         val silenceBytes = silenceBuffer.size
-        val silenceWriteTimeNs = System.nanoTime()
+        val silenceWriteTimeNs = nowNs()
         val written = track.write(silenceBuffer, 0, silenceBytes)
         if (written <= 0) return
 
@@ -1712,7 +1714,7 @@ class SyncAudioPlayer(
         val dacTimestampSuccess = track.getTimestamp(audioTimestamp)
         if (dacTimestampSuccess) {
             val dacTimeUs = audioTimestamp.nanoTime / 1000
-            val loopTimeUs = System.nanoTime() / 1000
+            val loopTimeUs = nowNs() / 1000
 
             // Sanity check - only store valid timestamps (framePosition > 0 means DAC has started)
             if (audioTimestamp.framePosition > 0) {
@@ -1750,7 +1752,7 @@ class SyncAudioPlayer(
         if (pendingUs > SILENCE_KEEPALIVE_THRESHOLD_US) return
 
         // Write pre-allocated silence (10ms) to top up the buffer
-        val keepAliveWriteTimeNs = System.nanoTime()
+        val keepAliveWriteTimeNs = nowNs()
         val written = track.write(silenceBuffer, 0, silenceBuffer.size)
         if (written > 0) {
             totalFramesWritten.addAndGet((written / bytesPerFrame).toLong())
@@ -1770,7 +1772,7 @@ class SyncAudioPlayer(
      * @return true if reanchor was triggered, false if still in cooldown or lock unavailable
      */
     private fun triggerReanchor(): Boolean {
-        val nowMicros = System.nanoTime() / 1000
+        val nowMicros = nowNs() / 1000
         val timeSinceLastReanchor = nowMicros - lastReanchorTimeUs
 
         if (timeSinceLastReanchor < REANCHOR_COOLDOWN_US) {
@@ -1966,7 +1968,7 @@ class SyncAudioPlayer(
 
                         // Rate-limited buffer warnings
                         if (bufferedMs < BUFFER_WARNING_MS) {
-                            val nowUs = System.nanoTime() / 1000
+                            val nowUs = nowNs() / 1000
                             if (nowUs - lastBufferWarningTimeUs > BUFFER_WARNING_INTERVAL_US) {
                                 lastBufferWarningTimeUs = nowUs
                                 stateCallback?.onBufferLow(bufferedMs)
@@ -2006,7 +2008,7 @@ class SyncAudioPlayer(
                     getPendingToDacUs(audioTrack!!) else 0L
 
                 // Rate-limited DAC pacing diagnostics
-                val nowMicros = System.nanoTime() / 1000
+                val nowMicros = nowNs() / 1000
                 if (dacTimestampsStable && nowMicros - lastDacPacingLogTimeUs > DAC_PACING_LOG_INTERVAL_US) {
                     lastDacPacingLogTimeUs = nowMicros
                     AppLog.Sync.d("DAC pacing: pending=${pendingToDacUs/1000}ms, syncErr=${syncErrorUs/1000}ms")
@@ -2136,7 +2138,7 @@ class SyncAudioPlayer(
         // Guard: Skip corrections during startup grace period (500ms)
         // AudioTimestamp needs time to stabilize after playback starts
         if (playingStateEnteredAtUs > 0) {
-            val nowUs = System.nanoTime() / 1000
+            val nowUs = nowNs() / 1000
             val timeSincePlayingUs = nowUs - playingStateEnteredAtUs
             if (timeSincePlayingUs < STARTUP_GRACE_PERIOD_US) {
                 insertEveryNFrames = 0
@@ -2148,7 +2150,7 @@ class SyncAudioPlayer(
         // Guard: Skip corrections during reconnection stabilization period (2s)
         // After reconnection, the Kalman filter needs time to re-converge with new measurements
         if (reconnectedAtUs > 0) {
-            val nowUs = System.nanoTime() / 1000
+            val nowUs = nowNs() / 1000
             val timeSinceReconnectUs = nowUs - reconnectedAtUs
             if (timeSinceReconnectUs < RECONNECT_STABILIZATION_US) {
                 insertEveryNFrames = 0
@@ -2232,7 +2234,7 @@ class SyncAudioPlayer(
         val needsCorrection = insertEveryNFrames > 0 || dropEveryNFrames > 0
                 || crossfadeState != CrossfadeState.IDLE
 
-        val writeTimeNs = System.nanoTime()
+        val writeTimeNs = nowNs()
         val written = if (needsCorrection) {
             writeWithCorrection(track, chunk.pcmData)
         } else {
@@ -2622,7 +2624,7 @@ class SyncAudioPlayer(
 
             val dacTimeMicros = audioTimestamp.nanoTime / 1000
             val framePosition = audioTimestamp.framePosition
-            val loopTimeUs = System.nanoTime() / 1000
+            val loopTimeUs = nowNs() / 1000
 
             // Sanity check - framePosition should be reasonable
             if (framePosition <= 0 || framePosition > totalFramesWritten.get() + sampleRate) {
@@ -2928,7 +2930,7 @@ class SyncAudioPlayer(
      */
     fun getGracePeriodRemainingUs(): Long {
         if (playingStateEnteredAtUs <= 0) return -1
-        val nowUs = System.nanoTime() / 1000
+        val nowUs = nowNs() / 1000
         val elapsed = nowUs - playingStateEnteredAtUs
         val remaining = STARTUP_GRACE_PERIOD_US - elapsed
         return if (remaining > 0) remaining else -1
@@ -2980,7 +2982,7 @@ class SyncAudioPlayer(
             }
 
             stateBeforeDraining = playbackState
-            drainingStartTimeUs = System.nanoTime() / 1000
+            drainingStartTimeUs = nowNs() / 1000
             lastBufferWarningTimeUs = 0L
             setPlaybackState(PlaybackState.DRAINING)
 
@@ -3007,11 +3009,11 @@ class SyncAudioPlayer(
                 return false
             }
 
-            val drainingDurationMs = (System.nanoTime() / 1000 - drainingStartTimeUs) / 1000
+            val drainingDurationMs = (nowNs() / 1000 - drainingStartTimeUs) / 1000
             AppLog.Audio.i("Exiting DRAINING state after ${drainingDurationMs}ms - resuming normal playback")
 
             // Mark reconnection time for stabilization period (skip sync corrections while Kalman re-converges)
-            reconnectedAtUs = System.nanoTime() / 1000
+            reconnectedAtUs = nowNs() / 1000
 
             // Transition back to PLAYING (the normal state for active playback)
             setPlaybackState(PlaybackState.PLAYING)
@@ -3036,7 +3038,7 @@ class SyncAudioPlayer(
             if (playbackState != newState) {
                 // Track when we enter PLAYING state for grace period calculation
                 if (newState == PlaybackState.PLAYING && playbackState != PlaybackState.PLAYING) {
-                    playingStateEnteredAtUs = System.nanoTime() / 1000
+                    playingStateEnteredAtUs = nowNs() / 1000
                     AppLog.Audio.d("Entered PLAYING state - grace period starts (${STARTUP_GRACE_PERIOD_US/1000}ms)")
                 }
                 playbackState = newState

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -129,6 +129,66 @@ import kotlin.math.abs
  * - onBufferExhausted() when buffer runs out
  * New chunks can still be queued (seamlessly spliced via gap/overlap handling).
  */
+/**
+ * Default production [AudioSink] factory for [SyncAudioPlayer].
+ *
+ * Builds an [AudioTrack] with the same configuration that SyncAudioPlayer previously
+ * constructed inline (USAGE_MEDIA / CONTENT_TYPE_MUSIC, MODE_STREAM,
+ * PERFORMANCE_MODE_LOW_LATENCY) and wraps it in an [AudioTrackSink]. The
+ * [bufferSize] is precomputed by the caller; this factory does not query
+ * [AudioTrack.getMinBufferSize].
+ *
+ * Tests inject a FakeAudioSink instead via SyncAudioPlayer's `sinkFactory`
+ * constructor parameter, allowing the player to run off-device without a real
+ * AudioTrack.
+ */
+private fun defaultSinkFactory(
+    sampleRate: Int,
+    channels: Int,
+    bitDepth: Int,
+    bufferSize: Int,
+): AudioSink {
+    val channelConfig = when (channels) {
+        1 -> AudioFormat.CHANNEL_OUT_MONO
+        2 -> AudioFormat.CHANNEL_OUT_STEREO
+        else -> throw IllegalArgumentException("Unsupported channel count: $channels")
+    }
+    val encoding = when (bitDepth) {
+        16 -> AudioFormat.ENCODING_PCM_16BIT
+        24 -> if (Build.VERSION.SDK_INT >= 31) {
+            AudioFormat.ENCODING_PCM_24BIT_PACKED
+        } else {
+            throw IllegalStateException("24-bit PCM requires API 31+, device is API ${Build.VERSION.SDK_INT}")
+        }
+        32 -> if (Build.VERSION.SDK_INT >= 31) {
+            AudioFormat.ENCODING_PCM_32BIT
+        } else {
+            throw IllegalStateException("32-bit PCM requires API 31+, device is API ${Build.VERSION.SDK_INT}")
+        }
+        else -> throw IllegalArgumentException("Unsupported bit depth: $bitDepth")
+    }
+    val bytesPerFrame = channels * (bitDepth / 8)
+    val track = AudioTrack.Builder()
+        .setAudioAttributes(
+            AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                .build()
+        )
+        .setAudioFormat(
+            AudioFormat.Builder()
+                .setSampleRate(sampleRate)
+                .setChannelMask(channelConfig)
+                .setEncoding(encoding)
+                .build()
+        )
+        .setBufferSizeInBytes(bufferSize)
+        .setTransferMode(AudioTrack.MODE_STREAM)
+        .setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
+        .build()
+    return AudioTrackSink(track, bytesPerFrame)
+}
+
 enum class PlaybackState {
     /** Waiting for first audio chunk and time sync to be ready. */
     INITIALIZING,
@@ -202,6 +262,11 @@ class SyncAudioPlayer(
     private val requestClientStateSnapshot: () -> Unit = {},
     // Injectable monotonic clock for testability; production default is System.nanoTime().
     private val nowNs: () -> Long = { System.nanoTime() },
+    // Injectable audio sink factory for testability; production default wraps AudioTrack.
+    // The bufferSize parameter is precomputed (via AudioTrack.getMinBufferSize + multiplier)
+    // and passed in rather than queried inside the factory.
+    private val sinkFactory: (sampleRate: Int, channels: Int, bitDepth: Int, bufferSize: Int) -> AudioSink =
+        ::defaultSinkFactory,
 ) {
     companion object {
         // Sync correction thresholds (microseconds)
@@ -542,25 +607,7 @@ class SyncAudioPlayer(
         val bufferSize = maxOf(minBufferSize * BUFFER_SIZE_MULTIPLIER, sampleRate * bytesPerFrame) // ~1 second
 
         try {
-            val track = AudioTrack.Builder()
-                .setAudioAttributes(
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_MEDIA)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-                        .build()
-                )
-                .setAudioFormat(
-                    AudioFormat.Builder()
-                        .setSampleRate(sampleRate)
-                        .setChannelMask(channelConfig)
-                        .setEncoding(encoding)
-                        .build()
-                )
-                .setBufferSizeInBytes(bufferSize)
-                .setTransferMode(AudioTrack.MODE_STREAM)
-                .setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
-                .build()
-            audioSink = AudioTrackSink(track, bytesPerFrame)
+            audioSink = sinkFactory(sampleRate, channels, bitDepth, bufferSize)
 
             // Pre-allocate frame buffers for sync correction (avoids GC in audio callback)
             lastOutputFrame = ByteArray(bytesPerFrame)

--- a/android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioSink.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioSink.kt
@@ -1,0 +1,56 @@
+package com.sendspindroid.sendspin.audio
+
+/**
+ * Abstraction over the audio output device. Production code wraps
+ * android.media.AudioTrack via AudioTrackSink; tests use FakeAudioSink.
+ *
+ * This interface mirrors the methods SyncAudioPlayer calls on AudioTrack --
+ * it is not a consolidation or redesign. Method semantics must match
+ * AudioTrack's exactly.
+ */
+interface AudioSink {
+    /** Begin playback. Mirrors AudioTrack.play(). */
+    fun play()
+
+    /** Pause playback. Mirrors AudioTrack.pause(). */
+    fun pause()
+
+    /** Stop playback. Mirrors AudioTrack.stop(). */
+    fun stop()
+
+    /** Discard queued audio. Mirrors AudioTrack.flush(). */
+    fun flush()
+
+    /** Release native resources. Mirrors AudioTrack.release(). */
+    fun release()
+
+    /**
+     * Write PCM data. Mirrors AudioTrack.write(buffer, offset, size) in
+     * blocking mode. Returns the number of bytes written, or a negative
+     * error code.
+     */
+    fun write(buffer: ByteArray, offset: Int, size: Int): Int
+
+    /**
+     * Query the DAC timestamp. Returns null if the hardware hasn't produced
+     * a valid timestamp yet (mirrors AudioTrack.getTimestamp() returning
+     * false).
+     */
+    fun getTimestamp(): SinkTimestamp?
+
+    /** Current playback head position in frames. Mirrors AudioTrack.getPlaybackHeadPosition(). */
+    val playbackHeadPosition: Int
+
+    /** Current state (matches AudioTrack.STATE_* constants). */
+    val state: Int
+
+    /** Buffer size in bytes. Mirrors AudioTrack.getBufferSizeInFrames() * bytesPerFrame. */
+    val bufferSizeInBytes: Int
+}
+
+/**
+ * DAC timestamp snapshot. Mirrors android.media.AudioTimestamp but is a
+ * plain data class so it can be constructed in JVM tests without the
+ * Android runtime.
+ */
+data class SinkTimestamp(val framePosition: Long, val nanoTime: Long)

--- a/android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioSink.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioSink.kt
@@ -44,6 +44,15 @@ interface AudioSink {
     /** Current state (matches AudioTrack.STATE_* constants). */
     val state: Int
 
+    /**
+     * Runtime playback state. Mirrors AudioTrack.getPlayState() -- values are
+     * AudioTrack.PLAYSTATE_STOPPED (1), PLAYSTATE_PAUSED (2), or
+     * PLAYSTATE_PLAYING (3).
+     *
+     * This is distinct from [state], which is STATE_INITIALIZED etc.
+     */
+    val playState: Int
+
     /** Buffer size in bytes. Mirrors AudioTrack.getBufferSizeInFrames() * bytesPerFrame. */
     val bufferSizeInBytes: Int
 }

--- a/android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioTrackSink.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioTrackSink.kt
@@ -1,0 +1,45 @@
+package com.sendspindroid.sendspin.audio
+
+import android.media.AudioTimestamp
+import android.media.AudioTrack
+
+/**
+ * AudioSink backed by a real android.media.AudioTrack.
+ *
+ * All methods delegate directly to the underlying track with identical
+ * semantics. Callers own AudioTrack construction (sample rate, channels,
+ * bit depth, buffer size, transfer mode) and hand the built track in.
+ *
+ * @param track the underlying AudioTrack to wrap
+ * @param bytesPerFrame used to expose bufferSizeInBytes; AudioTrack itself
+ *     reports a frame count, not a byte count
+ */
+class AudioTrackSink(
+    private val track: AudioTrack,
+    private val bytesPerFrame: Int,
+) : AudioSink {
+
+    private val ts = AudioTimestamp()
+
+    override fun play() = track.play()
+    override fun pause() = track.pause()
+    override fun stop() = track.stop()
+    override fun flush() = track.flush()
+    override fun release() = track.release()
+
+    override fun write(buffer: ByteArray, offset: Int, size: Int): Int =
+        track.write(buffer, offset, size)
+
+    override fun getTimestamp(): SinkTimestamp? =
+        if (track.getTimestamp(ts)) SinkTimestamp(ts.framePosition, ts.nanoTime)
+        else null
+
+    override val playbackHeadPosition: Int
+        get() = track.playbackHeadPosition
+
+    override val state: Int
+        get() = track.state
+
+    override val bufferSizeInBytes: Int
+        get() = track.bufferSizeInFrames * bytesPerFrame
+}

--- a/android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioTrackSink.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioTrackSink.kt
@@ -40,6 +40,9 @@ class AudioTrackSink(
     override val state: Int
         get() = track.state
 
+    override val playState: Int
+        get() = track.playState
+
     override val bufferSizeInBytes: Int
         get() = track.bufferSizeInFrames * bytesPerFrame
 }

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt
@@ -5,7 +5,9 @@ import com.sendspindroid.sendspin.audio.FakeAudioSink
 import com.sendspindroid.sendspin.latency.OutputLatencyEstimator
 import io.mockk.every
 import io.mockk.mockk
+import java.util.concurrent.atomic.AtomicLong
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -150,5 +152,77 @@ class SyncAudioPlayerIntegrationTest {
             OutputLatencyEstimator.Status.TimedOut,
             estimator.status,
         )
+    }
+
+    /**
+     * Build a SyncAudioPlayer wired to the shared `nowNs` clock and a
+     * relaxed time-filter mock. Used by the watchdog tests.
+     */
+    private fun newPlayerForWatchdog(): SyncAudioPlayer {
+        val timeFilter = mockk<SendspinTimeFilter>(relaxed = true)
+        every { timeFilter.isReady } returns true
+        every { timeFilter.serverToClient(any()) } answers { firstArg() }
+        every { timeFilter.clientToServer(any()) } answers { firstArg() }
+        every { timeFilter.offsetMicros } returns 0L
+        every { timeFilter.measurementCountValue } returns 10
+
+        val fakeSink = FakeAudioSink()
+        return SyncAudioPlayer(
+            timeFilter = timeFilter,
+            sampleRate = sampleRate,
+            channels = channels,
+            bitDepth = bitDepth,
+            nowNs = nowNs,
+            sinkFactory = { _, _, _, _ -> fakeSink },
+        )
+    }
+
+    /** Invoke the private parameterless checkStuckState() method. */
+    private fun invokeCheckStuckState(player: SyncAudioPlayer) {
+        val method = SyncAudioPlayer::class.java.getDeclaredMethod("checkStuckState")
+        method.isAccessible = true
+        method.invoke(player)
+    }
+
+    @Test
+    fun `watchdog warns when non-PLAYING state persists with chunks arriving`() {
+        now = 0L
+        val player = newPlayerForWatchdog()
+
+        setField(player, "playbackState", PlaybackState.WAITING_FOR_START)
+        // Simulate chunks arriving: set totalQueuedSamples > 0.
+        val totalQueuedSamples = getField<AtomicLong>(player, "totalQueuedSamples")
+        totalQueuedSamples.set(sampleRate.toLong() * 5)  // 5 seconds of audio
+
+        // First tick: establishes baseline, no warning yet.
+        invokeCheckStuckState(player)
+        val warn1: Long = getField(player, "lastStuckWarningAtUs")
+        assertEquals("no warning on first observation", 0L, warn1)
+
+        // Advance clock past the 5 s stuck threshold.
+        now = 6_000_000_000L
+        invokeCheckStuckState(player)
+        val warn2: Long = getField(player, "lastStuckWarningAtUs")
+        assertNotEquals("warning should have fired after 5s stuck", 0L, warn2)
+    }
+
+    @Test
+    fun `watchdog does not warn when non-PLAYING state has no buffered chunks`() {
+        now = 0L
+        val player = newPlayerForWatchdog()
+
+        setField(player, "playbackState", PlaybackState.WAITING_FOR_START)
+        // No buffered audio -- user paused / genuinely idle, not a deadlock.
+        val totalQueuedSamples = getField<AtomicLong>(player, "totalQueuedSamples")
+        totalQueuedSamples.set(0L)
+
+        // First tick: establishes baseline.
+        invokeCheckStuckState(player)
+
+        // Advance past the 5 s threshold; watchdog must STILL stay silent.
+        now = 6_000_000_000L
+        invokeCheckStuckState(player)
+        val warn: Long = getField(player, "lastStuckWarningAtUs")
+        assertEquals("no warning when buffer is empty", 0L, warn)
     }
 }

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt
@@ -1,0 +1,154 @@
+package com.sendspindroid.sendspin
+
+import com.sendspindroid.sendspin.audio.AudioSink
+import com.sendspindroid.sendspin.audio.FakeAudioSink
+import com.sendspindroid.sendspin.latency.OutputLatencyEstimator
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Integration-style regression test for the DAC-aware start-gating
+ * tick-starvation deadlock.
+ *
+ * Scenario covered:
+ *   Once `dacTimestampsStable` flips to true, the main playback loop stops
+ *   calling `preCalibrateDacTiming()` -- which was the only other path that
+ *   ticked [OutputLatencyEstimator]. If the estimator had not yet accepted
+ *   enough samples to converge, it could stay in `Status.Measuring`
+ *   indefinitely, holding the player in `WAITING_FOR_START` forever (surfaces
+ *   on-device as `MediaSession` BUFFERING with a growing chunk queue and no
+ *   audio).
+ *
+ * The fix is a single call to `latencyEstimator.tick()` at the top of
+ * `handleStartGatingDacAware()`. This test will fail (the assertion on
+ * `Status.TimedOut` after advancing the clock past 2 s) if that call is
+ * removed.
+ *
+ * Because `SyncAudioPlayer.initialize()` calls `AudioTrack.getMinBufferSize`
+ * (an Android-only API unavailable in JVM unit tests), we cannot use the
+ * normal init path to start the estimator. Instead we start the estimator
+ * directly via reflection -- that is fine for this test because we are
+ * exercising `handleStartGatingDacAware` in isolation, not the full
+ * initialisation sequence.
+ */
+class SyncAudioPlayerIntegrationTest {
+
+    // Controllable monotonic clock shared between the player and its estimator.
+    private var now: Long = 0L
+    private val nowNs: () -> Long = { now }
+
+    // Standard audio format: 48kHz, 2ch, 16-bit.
+    private val sampleRate = 48_000
+    private val channels = 2
+    private val bitDepth = 16
+
+    /** Get a private field value via reflection. */
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> getField(player: SyncAudioPlayer, name: String): T {
+        val field = SyncAudioPlayer::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(player) as T
+    }
+
+    /** Set a private field value via reflection. */
+    private fun setField(player: SyncAudioPlayer, name: String, value: Any?) {
+        val field = SyncAudioPlayer::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(player, value)
+    }
+
+    /** Invoke the private handleStartGatingDacAware(AudioSink) method. */
+    private fun invokeHandleStartGatingDacAware(
+        player: SyncAudioPlayer,
+        sink: AudioSink,
+    ): Boolean {
+        val method = SyncAudioPlayer::class.java.getDeclaredMethod(
+            "handleStartGatingDacAware",
+            AudioSink::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(player, sink) as Boolean
+    }
+
+    @Test
+    fun `handleStartGatingDacAware tick fires estimator timeout after 2s`() {
+        // Identity time-filter mock -- clientToServer/serverToClient are
+        // pass-throughs. We don't rely on any time-filter branch in this
+        // test because we expect the "Measuring" early-return to keep us
+        // from reaching the alignment math.
+        val timeFilter = mockk<SendspinTimeFilter>(relaxed = true)
+        every { timeFilter.isReady } returns true
+        every { timeFilter.serverToClient(any()) } answers { firstArg() }
+        every { timeFilter.clientToServer(any()) } answers { firstArg() }
+        every { timeFilter.offsetMicros } returns 0L
+        every { timeFilter.measurementCountValue } returns 10
+
+        val fakeSink = FakeAudioSink()
+
+        val player = SyncAudioPlayer(
+            timeFilter = timeFilter,
+            sampleRate = sampleRate,
+            channels = channels,
+            bitDepth = bitDepth,
+            nowNs = nowNs,
+            sinkFactory = { _, _, _, _ -> fakeSink },
+        )
+
+        // Reach into the player and put it into the on-device deadlock state:
+        //   - audioSink is our FakeAudioSink (handleStartGating's DAC-aware
+        //     branch checks audioSink != null && dacTimestampsStable)
+        //   - dacTimestampsStable = true
+        //   - playbackState = WAITING_FOR_START
+        setField(player, "audioSink", fakeSink)
+        setField(player, "dacTimestampsStable", true)
+        setField(player, "playbackState", PlaybackState.WAITING_FOR_START)
+
+        // The estimator is normally started inside SyncAudioPlayer.initialize()
+        // (which calls AudioTrack.getMinBufferSize, unavailable in JVM tests),
+        // so start it manually via reflection. It shares `nowNs` with the
+        // player by construction (see SyncAudioPlayer init), so advancing
+        // `now` advances the estimator's internal clock too.
+        val estimator: OutputLatencyEstimator = getField(player, "latencyEstimator")
+        estimator.start { /* no-op: we only care about status transitions */ }
+        assertEquals(
+            "estimator should be Measuring after start()",
+            OutputLatencyEstimator.Status.Measuring,
+            estimator.status,
+        )
+
+        // --- First call: estimator still Measuring, clock well before
+        // the 2 s timeout. handleStartGatingDacAware should tick() (harmless,
+        // no timeout yet), see Status.Measuring, and return true ("keep
+        // waiting"). Status must remain Measuring.
+        now = 0L
+        val first = invokeHandleStartGatingDacAware(player, fakeSink)
+        assertTrue(
+            "should keep waiting while estimator is Measuring",
+            first,
+        )
+        assertEquals(
+            "status should remain Measuring before timeout",
+            OutputLatencyEstimator.Status.Measuring,
+            estimator.status,
+        )
+
+        // --- Advance the clock past the 2 s estimator timeout.
+        // OutputLatencyEstimator.TIMEOUT_NS = 2_000_000_000L.
+        now = 2_100_000_000L
+
+        // --- Second call: the tick() at the top of handleStartGatingDacAware
+        // should observe the elapsed timeout and transition the estimator to
+        // TimedOut. If the tick() call is removed from production code, the
+        // estimator will still be Measuring here and the player will report
+        // "keep waiting" forever -- this assertion fails the regression test.
+        invokeHandleStartGatingDacAware(player, fakeSink)
+        assertEquals(
+            "tick() in handleStartGatingDacAware must fire estimator timeout",
+            OutputLatencyEstimator.Status.TimedOut,
+            estimator.status,
+        )
+    }
+}

--- a/android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSink.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSink.kt
@@ -1,0 +1,93 @@
+package com.sendspindroid.sendspin.audio
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Test-only AudioSink that records all calls and returns scripted values.
+ *
+ * Usage:
+ * ```
+ * val sink = FakeAudioSink()
+ * sink.scriptTimestamp(framePosition = 960, nanoTime = 1_000_000)
+ * // ... drive SyncAudioPlayer ...
+ * assertEquals(1, sink.playCallCount.get())
+ * assertEquals(960 * 4L, sink.totalBytesWritten.get())
+ * ```
+ */
+class FakeAudioSink(
+    override val bufferSizeInBytes: Int = DEFAULT_BUFFER_BYTES,
+) : AudioSink {
+
+    companion object {
+        // 1 second at 48kHz stereo 16-bit = 48000 * 2 * 2 = 192000 bytes.
+        const val DEFAULT_BUFFER_BYTES = 192_000
+        // AudioTrack.STATE_INITIALIZED = 1 (not 3 -- 3 is STATE_UNINITIALIZED).
+        // See android.media.AudioTrack source. We report INITIALIZED so callers
+        // that guard on state see a healthy sink.
+        const val STATE_INITIALIZED = 1
+    }
+
+    val playCallCount = AtomicInteger(0)
+    val pauseCallCount = AtomicInteger(0)
+    val stopCallCount = AtomicInteger(0)
+    val flushCallCount = AtomicInteger(0)
+    val releaseCallCount = AtomicInteger(0)
+
+    data class WriteRecord(val offset: Int, val size: Int, val snapshotFirstBytes: ByteArray) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is WriteRecord) return false
+            return offset == other.offset && size == other.size &&
+                snapshotFirstBytes.contentEquals(other.snapshotFirstBytes)
+        }
+        override fun hashCode(): Int {
+            var result = offset
+            result = 31 * result + size
+            result = 31 * result + snapshotFirstBytes.contentHashCode()
+            return result
+        }
+    }
+
+    private val _writes = ConcurrentLinkedQueue<WriteRecord>()
+    val writes: List<WriteRecord> get() = _writes.toList()
+    val totalBytesWritten = AtomicLong(0)
+
+    @Volatile private var nextTimestamp: SinkTimestamp? = null
+
+    /** Configure what getTimestamp() returns next. Null means "not ready." */
+    fun scriptTimestamp(ts: SinkTimestamp?) {
+        nextTimestamp = ts
+    }
+
+    fun scriptTimestamp(framePosition: Long, nanoTime: Long) {
+        nextTimestamp = SinkTimestamp(framePosition, nanoTime)
+    }
+
+    @Volatile var scriptedPlaybackHeadPosition: Int = 0
+
+    override fun play() { playCallCount.incrementAndGet() }
+    override fun pause() { pauseCallCount.incrementAndGet() }
+    override fun stop() { stopCallCount.incrementAndGet() }
+    override fun flush() { flushCallCount.incrementAndGet() }
+    override fun release() { releaseCallCount.incrementAndGet() }
+
+    override fun write(buffer: ByteArray, offset: Int, size: Int): Int {
+        val snapshotEnd = minOf(offset + 16, offset + size)
+        _writes.add(WriteRecord(
+            offset = offset,
+            size = size,
+            snapshotFirstBytes = buffer.copyOfRange(offset, snapshotEnd),
+        ))
+        totalBytesWritten.addAndGet(size.toLong())
+        return size
+    }
+
+    override fun getTimestamp(): SinkTimestamp? = nextTimestamp
+
+    override val playbackHeadPosition: Int
+        get() = scriptedPlaybackHeadPosition
+
+    override val state: Int = STATE_INITIALIZED
+}

--- a/android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSink.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSink.kt
@@ -27,6 +27,9 @@ class FakeAudioSink(
         // See android.media.AudioTrack source. We report INITIALIZED so callers
         // that guard on state see a healthy sink.
         const val STATE_INITIALIZED = 1
+        // AudioTrack.PLAYSTATE_PLAYING = 3. Default scripted playState so
+        // callers that guard on playState don't trigger unwanted branches.
+        const val PLAYSTATE_PLAYING = 3
     }
 
     val playCallCount = AtomicInteger(0)
@@ -90,4 +93,9 @@ class FakeAudioSink(
         get() = scriptedPlaybackHeadPosition
 
     override val state: Int = STATE_INITIALIZED
+
+    @Volatile var scriptedPlayState: Int = PLAYSTATE_PLAYING
+
+    override val playState: Int
+        get() = scriptedPlayState
 }

--- a/android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSinkTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSinkTest.kt
@@ -1,0 +1,74 @@
+package com.sendspindroid.sendspin.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FakeAudioSinkTest {
+
+    @Test
+    fun `records write calls with byte counts`() {
+        val sink = FakeAudioSink()
+        val buf = ByteArray(480 * 4)  // 10ms of stereo 16-bit at 48k
+        sink.write(buf, 0, buf.size)
+        sink.write(buf, 0, buf.size)
+        assertEquals(2, sink.writes.size)
+        assertEquals((480 * 4 * 2).toLong(), sink.totalBytesWritten.get())
+    }
+
+    @Test
+    fun `scriptTimestamp returns configured value, null by default`() {
+        val sink = FakeAudioSink()
+        assertNull(sink.getTimestamp())
+        sink.scriptTimestamp(framePosition = 960, nanoTime = 1_000_000)
+        val ts = sink.getTimestamp()!!
+        assertEquals(960L, ts.framePosition)
+        assertEquals(1_000_000L, ts.nanoTime)
+    }
+
+    @Test
+    fun `play pause stop flush release counted`() {
+        val sink = FakeAudioSink()
+        sink.play(); sink.pause(); sink.stop(); sink.flush(); sink.release()
+        assertEquals(1, sink.playCallCount.get())
+        assertEquals(1, sink.pauseCallCount.get())
+        assertEquals(1, sink.stopCallCount.get())
+        assertEquals(1, sink.flushCallCount.get())
+        assertEquals(1, sink.releaseCallCount.get())
+    }
+
+    @Test
+    fun `write captures snapshot of first bytes for inspection`() {
+        val sink = FakeAudioSink()
+        val buf = ByteArray(100) { i -> i.toByte() }
+        sink.write(buf, offset = 0, size = 100)
+        val record = sink.writes.first()
+        // First 16 bytes of 0..15 sequence.
+        for (i in 0 until 16) {
+            assertEquals(i.toByte(), record.snapshotFirstBytes[i])
+        }
+    }
+
+    @Test
+    fun `write returns size written`() {
+        val sink = FakeAudioSink()
+        val buf = ByteArray(1000)
+        val returned = sink.write(buf, offset = 100, size = 500)
+        assertEquals(500, returned)
+        assertEquals(500L, sink.totalBytesWritten.get())
+    }
+
+    @Test
+    fun `bufferSizeInBytes customisable`() {
+        val sink = FakeAudioSink(bufferSizeInBytes = 4096)
+        assertEquals(4096, sink.bufferSizeInBytes)
+    }
+
+    @Test
+    fun `playbackHeadPosition scriptable`() {
+        val sink = FakeAudioSink()
+        assertEquals(0, sink.playbackHeadPosition)
+        sink.scriptedPlaybackHeadPosition = 48000
+        assertEquals(48000, sink.playbackHeadPosition)
+    }
+}

--- a/android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSinkTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSinkTest.kt
@@ -71,4 +71,12 @@ class FakeAudioSinkTest {
         sink.scriptedPlaybackHeadPosition = 48000
         assertEquals(48000, sink.playbackHeadPosition)
     }
+
+    @Test
+    fun `playState defaults to PLAYSTATE_PLAYING and is scriptable`() {
+        val sink = FakeAudioSink()
+        assertEquals(FakeAudioSink.PLAYSTATE_PLAYING, sink.playState)
+        sink.scriptedPlayState = 2  // PLAYSTATE_PAUSED
+        assertEquals(2, sink.playState)
+    }
 }

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageParserTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageParserTest.kt
@@ -237,6 +237,51 @@ class MessageParserTest {
         assertEquals("paused", state)
     }
 
+    @Test
+    fun parseServerState_idleMetadataWithNullFields_doesNotThrow() {
+        // Reproduces the on-device exception observed 2026-04-23: server emits
+        // idle metadata with every field JsonNull ("progress": null in particular
+        // triggered IllegalArgumentException: ... is not a JsonObject).
+        // Parser must treat JsonNull the same as absent.
+        val payload = buildJsonObject {
+            put("metadata", buildJsonObject {
+                put("timestamp", 9730008767707L)
+                put("title", JsonPrimitive(null as String?))
+                put("artist", JsonPrimitive(null as String?))
+                put("album_artist", JsonPrimitive(null as String?))
+                put("album", JsonPrimitive(null as String?))
+                put("artwork_url", JsonPrimitive(null as String?))
+                put("year", JsonPrimitive(null as Int?))
+                put("track", JsonPrimitive(null as Int?))
+                put("progress", JsonPrimitive(null as String?))
+                put("repeat", JsonPrimitive(null as String?))
+                put("shuffle", JsonPrimitive(null as String?))
+            })
+        }
+
+        val (metadata, state) = MessageParser.parseServerState(payload)
+
+        assertNotNull("idle metadata should still yield a TrackMetadata", metadata)
+        assertEquals("", metadata!!.title)
+        assertEquals("", metadata.artist)
+        assertEquals(0L, metadata.progress.trackProgress)
+        assertEquals(0L, metadata.progress.trackDuration)
+        assertNull(state)
+    }
+
+    @Test
+    fun parseServerState_nullMetadataField_returnsNullMetadata() {
+        // Defensive: if the server ever sends `{"metadata": null}` instead of
+        // an object, we must treat it like missing rather than throwing.
+        val payload = buildJsonObject {
+            put("metadata", JsonPrimitive(null as String?))
+            put("state", "stopped")
+        }
+        val (metadata, state) = MessageParser.parseServerState(payload)
+        assertNull(metadata)
+        assertEquals("stopped", state)
+    }
+
     // --- parseServerCommand ---
 
     @Test

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageParser.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageParser.kt
@@ -67,7 +67,7 @@ object MessageParser {
     fun parseServerState(payload: JsonObject?): Pair<TrackMetadata?, String?> {
         if (payload == null) return Pair(null, null)
 
-        val metadata = payload["metadata"]?.jsonObject?.let { metadataObj ->
+        val metadata = (payload["metadata"] as? JsonObject)?.let { metadataObj ->
             fun optStringClean(key: String) =
                 metadataObj[key]?.jsonPrimitive?.contentOrNull?.takeUnless { it == "null" } ?: ""
 
@@ -80,7 +80,11 @@ object MessageParser {
             val year = metadataObj.intOrDefault("year", 0)
             val track = metadataObj.intOrDefault("track", 0)
 
-            val progress = metadataObj["progress"]?.jsonObject?.let { progressObj ->
+            // Use `as? JsonObject` rather than `?.jsonObject`: the latter throws
+            // IllegalArgumentException when the field is JsonNull (the server
+            // sometimes sends `"progress": null` in idle metadata). The cast
+            // form treats JsonNull the same as missing, which is what we want.
+            val progress = (metadataObj["progress"] as? JsonObject)?.let { progressObj ->
                 TrackProgress(
                     trackProgress = progressObj.longOrDefault("track_progress", 0),
                     trackDuration = progressObj.longOrDefault("track_duration", 0),

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -36,6 +36,35 @@ tick-starvation bug from PR #153 is an example).
 once. Do it after we have the integration harness + a few cycles of
 stable on-device use.
 
+## Reliability (observed, not yet tracked)
+
+### Rapid consecutive skip schedules first chunk ~12 s in the future
+
+**Symptom:** skip once (fine) -> skip again within a few seconds -> second track
+has a multi-second wait before audio starts, then resumes with sample-insert/drop
+glitches as the client catches up to server position.
+
+**Evidence (device log 2026-04-23, post-AudioSink-refactor + tick-starvation fix merged):**
+- First skip: first chunk `scheduled start` 336 ms in the future from `enterIdle`
+  timestamp. Transition to PLAYING within 365 ms total.
+- Second skip: first chunk `scheduled start` 12,052 ms in the future. State
+  machine correctly holds in WAITING_FOR_START and plays silence for 12 s until
+  `startErr` comes down to 42 ms, then transitions. 30 s of buffered audio
+  accumulated in the meantime.
+- Kalman offset drifted only 2 ms across both skips (measurements 296 -> 315),
+  so time sync is not the cause.
+
+**Likely location:** MA server, `music_assistant/providers/sendspin/player.py`.
+The server's first-chunk timestamp after `stream/end` -> `stream/start` appears
+to carry stale position from the previous track, or its `playback_start` offset
+accumulates rather than resets on rapid re-skip.
+
+**Client behaviour is correct:** holding for the scheduled start time preserves
+multi-room sync. Ignoring the startErr would desync groups. Fix must be
+server-side or protocol-level.
+
+**UX priority:** medium-high. Breaks user expectation that skip is instant.
+
 ## Protocol / Upstream
 
 ### File an MA upstream issue on three-image-source inconsistency

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,71 @@
+# SendSpinDroid Technical Backlog
+
+Items we've identified as worth doing but deliberately deferred. Not a roadmap
+commitment — a register so we don't lose them.
+
+## Architecture
+
+### Split SyncAudioPlayer into focused units
+
+**Size:** Large (week+ of work, not a side-quest).
+
+**Current state:** `SyncAudioPlayer.kt` is 3126 lines doing six jobs: the
+state machine, AudioTrack I/O, sync correction, latency-measurement wiring,
+pre-calibration/keep-alive silence, and stats logging. New gates added to the
+state machine have non-obvious interactions with existing gates (the
+tick-starvation bug from PR #153 is an example).
+
+**Target decomposition (sketch):**
+- A pure, testable `PlaybackStateMachine` — states, transitions, guards, no
+  I/O or timing.
+- An `AudioSink` layer (already introduced by the integration-harness work) —
+  AudioTrack adapter.
+- A `SyncCorrectionPolicy` — sample insert/drop rate decisions given sync
+  error.
+- A `LatencyCalibration` subsystem — owns the pre-cal silence pump, DAC
+  stability tracking, and `OutputLatencyEstimator` wiring.
+- An orchestrator that wires these together (`SyncAudioPlayer` becomes thin).
+
+**Prerequisites:**
+- The integration harness (see `docs/superpowers/plans/2026-04-23-audio-integration-harness-and-watchdog.md`).
+  That harness makes refactoring safe.
+- A few weeks of stability on the current code so we can tell regressions
+  apart from "this is how it's always behaved."
+
+**Why deferred:** it's the right call eventually but touches too much at
+once. Do it after we have the integration harness + a few cycles of
+stable on-device use.
+
+## Protocol / Upstream
+
+### File an MA upstream issue on three-image-source inconsistency
+
+`music_assistant/providers/sendspin/player.py` uses three different image
+sources for the same conceptual "current track image":
+- Line 730: `queue_item.image`
+- Line 736: `get_image_data_for_item(media_item)`
+- Line 842: `current_media.image_url`
+
+Captured in detail in `docs/architecture/sendspin-ma-metadata-flow.md` under
+"observed bugs." Needs a GitHub issue filed against
+`music-assistant/server`.
+
+## Reliability (tracked in task list)
+
+- **#16 L-5:** `isRecoverableError` default-true + no retry cap leads to
+  infinite reconnect. Fix needs a bounded retry strategy.
+- **#47 H-4 + M-8:** Codec-safe decoder redesign. PR #142's drop-oldest
+  rejection policy corrupted MediaCodec internal state. A clean redesign
+  needs to understand the decoder's state-machine contract better than the
+  previous attempt did.
+
+## Process
+
+### Before major plans, require an integration test that would fail today
+
+Several recent PRs passed unit tests and failed on-device (PR #142 FLAC
+corruption, PR #144 tick starvation, PR #146 wizard duplicate-key crash).
+The pattern: unit tests cover the pieces, nothing covers the composed
+system. When writing a new multi-task plan, make task 1 "add a failing
+integration test that motivates this plan" — forces the integration story
+up front.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -65,6 +65,18 @@ server-side or protocol-level.
 
 **UX priority:** medium-high. Breaks user expectation that skip is instant.
 
+### DAC-aware start-gating log spam at every track change
+
+`handleStartGatingDacAware` logs `DAC-aware start: waiting for alignment,
+startErr=...ms > 50ms` on every 10 ms poll of the playback loop while
+waiting for the DAC to catch up. For a normal ~2 s alignment wait that's
+~200 debug lines per track change; for the rapid-second-skip 12 s wait it's
+~1200. Harmless at INFO/WARN level (these are DEBUG) but noisy when debug
+logging is on. Rate-limit to once per 100 ms or once per second.
+
+Location: `SyncAudioPlayer.kt` around the `DAC-aware start: waiting for
+alignment` emission in `handleStartGatingDacAware`.
+
 ## Protocol / Upstream
 
 ### File an MA upstream issue on three-image-source inconsistency

--- a/docs/superpowers/plans/2026-04-23-audio-integration-harness-and-watchdog.md
+++ b/docs/superpowers/plans/2026-04-23-audio-integration-harness-and-watchdog.md
@@ -1,0 +1,926 @@
+# Audio Integration Harness + Stuck-State Watchdog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a fake-AudioTrack integration harness that lets us unit-test
+`SyncAudioPlayer` state transitions end-to-end, plus a stuck-state watchdog
+that surfaces playback-loop deadlocks in logcat. Together these convert a
+class of bugs (tick starvation, FLAC corruption, BUFFERING/PLAYING mismatch)
+from "caught by the user on spotty Wi-Fi" to "caught by CI in seconds" or
+"self-reports in logs within 5 s."
+
+**Architecture:**
+
+- **Harness:** introduce `AudioSink` interface wrapping the methods
+  `SyncAudioPlayer` calls on `android.media.AudioTrack`. Provide
+  `AudioTrackSink` (production) wrapping a real `AudioTrack`, and
+  `FakeAudioSink` (test-only) with scripted `getTimestamp()` and a write log.
+  Inject a `nowNs: () -> Long` clock provider to replace direct
+  `System.nanoTime()` calls. Use `kotlinx.coroutines.test` with virtual time
+  to drive the playback loop deterministically, or — if full virtual-time
+  driving is too invasive — test the extracted helpers (`handleStartGating`,
+  `playbackLoopIteration`) directly via reflection/visibility tweaks.
+- **Watchdog:** extend the existing stats logger (runs every 1 s in the
+  playback loop) with a check: if the state has been non-`PLAYING` for
+  longer than `STUCK_STATE_WARNING_S` while chunks are arriving, emit a
+  warning log with state, buffered-ms, and estimator status. No recovery
+  action — diagnostic only.
+
+**Design decisions (locked in here, not for further debate during execution):**
+
+1. **Interface-based abstraction over mocking.** Introduce `AudioSink`; do
+   not try to mock `android.media.AudioTrack` directly. AudioTrack is a
+   final Android class with native resources — mocking it is fragile and
+   requires Robolectric. A plain-Kotlin interface is cheaper to maintain
+   and doesn't add a test runtime dependency.
+2. **Thin wrapper, not a rewrite.** `AudioSink` mirrors the exact methods
+   currently called on `AudioTrack`. No method consolidation, no semantic
+   changes. This keeps the production-behavior diff minimal.
+3. **Introduce `SinkTimestamp` data class** so tests don't need
+   `android.media.AudioTimestamp` (also final, hard to construct in JVM
+   tests). Production sink translates between `AudioTimestamp` and
+   `SinkTimestamp`.
+4. **Inject clock now, not later.** All `System.nanoTime()` calls in
+   `SyncAudioPlayer` are replaced with a `nowNs: () -> Long` injected at
+   construction. The default `{ System.nanoTime() }` keeps production
+   behaviour identical. Tests inject a controllable clock.
+5. **Test-driver decision: start with reflection, graduate to virtual
+   time if needed.** Task 7 writes the tick-starvation regression test
+   using reflection on `handleStartGatingDacAware`. If that proves brittle
+   or insufficient for future tests, Task 10 (follow-up) introduces a
+   `TestDispatcher`-based full loop driver. Not committing to full
+   virtual-time driving up front — it's a bigger refactor than needed for
+   the immediate goal.
+6. **Watchdog logs only.** No auto-recovery (reset state, trigger
+   reanchor). Recovery changes behaviour and needs its own design. The
+   watchdog's only job is diagnostic visibility.
+
+**Tech Stack:** Kotlin, JUnit 4 (existing), mockk (existing), no new test
+dependencies.
+
+---
+
+## File Structure
+
+**Create:**
+- `android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioSink.kt`
+- `android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioTrackSink.kt`
+- `android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSink.kt`
+- `android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt`
+
+**Modify:**
+- `android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt`
+  - Accept `audioSink: AudioSink` (optional) and `nowNs: () -> Long` in constructor
+  - Replace direct `AudioTrack`/`AudioTimestamp` calls with sink calls
+  - Replace all `System.nanoTime()` with `nowNs()`
+  - Add stuck-state watchdog to the stats logger
+- `android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt`
+  - Wrap the constructed `AudioTrack` in `AudioTrackSink` when creating
+    `SyncAudioPlayer` (only if needed — preferred path is SyncAudioPlayer
+    keeps owning AudioTrack creation and wraps it internally)
+- `android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerTest.kt`
+  - Update existing tests to pass `nowNs` where construction changed
+
+---
+
+## Task 1: Technical backlog file committed
+
+**Files:**
+- Modify: `docs/BACKLOG.md` (already created in this branch's base commit)
+
+- [ ] **Step 1: Verify `docs/BACKLOG.md` contains the SyncAudioPlayer-split
+      entry and other deferred items**
+
+Read: `docs/BACKLOG.md`
+Expected: mentions "Split SyncAudioPlayer into focused units", MA upstream
+issue, and the deferred reliability tasks #16 and #47.
+
+- [ ] **Step 2: No commit needed if already committed in base**
+
+If the file is untracked, commit it:
+
+```bash
+git add docs/BACKLOG.md
+git commit -m "docs: add BACKLOG.md with deferred technical work"
+```
+
+---
+
+## Task 2: Introduce AudioSink interface
+
+**Files:**
+- Create: `android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioSink.kt`
+
+- [ ] **Step 1: Write the interface**
+
+```kotlin
+package com.sendspindroid.sendspin.audio
+
+/**
+ * Abstraction over the audio output device. Production code wraps
+ * android.media.AudioTrack via AudioTrackSink; tests use FakeAudioSink.
+ *
+ * This interface mirrors the methods SyncAudioPlayer calls on AudioTrack —
+ * it is not a consolidation or redesign. Method semantics must match
+ * AudioTrack's exactly.
+ */
+interface AudioSink {
+    /** Begin playback. Mirrors AudioTrack.play(). */
+    fun play()
+
+    /** Pause playback. Mirrors AudioTrack.pause(). */
+    fun pause()
+
+    /** Stop playback. Mirrors AudioTrack.stop(). */
+    fun stop()
+
+    /** Discard queued audio. Mirrors AudioTrack.flush(). */
+    fun flush()
+
+    /** Release native resources. Mirrors AudioTrack.release(). */
+    fun release()
+
+    /**
+     * Write PCM data. Mirrors AudioTrack.write(buffer, offset, size) in
+     * blocking mode. Returns the number of bytes written, or a negative
+     * error code.
+     */
+    fun write(buffer: ByteArray, offset: Int, size: Int): Int
+
+    /**
+     * Query the DAC timestamp. Returns null if the hardware hasn't
+     * produced a valid timestamp yet (mirrors AudioTrack.getTimestamp()
+     * returning false).
+     */
+    fun getTimestamp(): SinkTimestamp?
+
+    /** Current playback head position in frames. */
+    val playbackHeadPosition: Int
+
+    /** Current state (matches AudioTrack.STATE_* constants). */
+    val state: Int
+
+    /** Buffer size in bytes. */
+    val bufferSizeInBytes: Int
+}
+
+/**
+ * DAC timestamp snapshot. Mirrors android.media.AudioTimestamp but is a
+ * plain data class so it can be constructed in JVM tests without the
+ * Android runtime.
+ */
+data class SinkTimestamp(val framePosition: Long, val nanoTime: Long)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioSink.kt
+git commit -m "feat: introduce AudioSink interface for testable audio output"
+```
+
+---
+
+## Task 3: Implement AudioTrackSink (production wrapper)
+
+**Files:**
+- Create: `android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioTrackSink.kt`
+- Test: `android/app/src/test/java/com/sendspindroid/sendspin/audio/AudioTrackSinkTest.kt`
+  (optional — smoke test only, construction requires real AudioTrack)
+
+- [ ] **Step 1: Write the wrapper**
+
+```kotlin
+package com.sendspindroid.sendspin.audio
+
+import android.media.AudioTimestamp
+import android.media.AudioTrack
+
+/**
+ * AudioSink backed by a real android.media.AudioTrack.
+ *
+ * All methods delegate directly to the underlying track with identical
+ * semantics. Callers must construct the AudioTrack (with the desired
+ * sample rate, channels, bit depth, buffer size) and hand it in.
+ */
+class AudioTrackSink(private val track: AudioTrack) : AudioSink {
+
+    private val ts = AudioTimestamp()
+
+    override fun play() = track.play()
+    override fun pause() = track.pause()
+    override fun stop() = track.stop()
+    override fun flush() = track.flush()
+    override fun release() = track.release()
+
+    override fun write(buffer: ByteArray, offset: Int, size: Int): Int =
+        track.write(buffer, offset, size)
+
+    override fun getTimestamp(): SinkTimestamp? =
+        if (track.getTimestamp(ts)) SinkTimestamp(ts.framePosition, ts.nanoTime)
+        else null
+
+    override val playbackHeadPosition: Int
+        get() = track.playbackHeadPosition
+
+    override val state: Int
+        get() = track.state
+
+    override val bufferSizeInBytes: Int
+        get() = track.bufferSizeInFrames * 4  // caller-known bytesPerFrame; see note
+}
+```
+
+**Note on `bufferSizeInBytes`:** `AudioTrack.bufferSizeInFrames` is an Int;
+bytes-per-frame depends on format. Either pass `bytesPerFrame` into the
+constructor (preferred — the production caller already knows it) or expose
+`bufferSizeInFrames` directly and let callers compute. Pick whichever makes
+the downstream refactor (Task 4) cleanest.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add android/app/src/main/java/com/sendspindroid/sendspin/audio/AudioTrackSink.kt
+git commit -m "feat: add AudioTrackSink wrapping real AudioTrack"
+```
+
+---
+
+## Task 4: Implement FakeAudioSink (test-only)
+
+**Files:**
+- Create: `android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSink.kt`
+- Test: `android/app/src/test/java/com/sendspindroid/sendspin/audio/FakeAudioSinkTest.kt`
+
+- [ ] **Step 1: Write the fake**
+
+```kotlin
+package com.sendspindroid.sendspin.audio
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Test-only AudioSink that records all calls and returns scripted values.
+ *
+ * Usage:
+ * ```
+ * val sink = FakeAudioSink()
+ * sink.scriptTimestamp(framePosition = 960, nanoTime = 1_000_000_000)
+ * // ... drive SyncAudioPlayer ...
+ * assertEquals(1, sink.playCallCount)
+ * assertEquals(960 * 4, sink.totalBytesWritten)
+ * ```
+ */
+class FakeAudioSink(
+    override val bufferSizeInBytes: Int = 192_000,  // 1s at 48kHz stereo 16-bit
+) : AudioSink {
+
+    // --- call counters ---
+    val playCallCount = AtomicInteger(0)
+    val pauseCallCount = AtomicInteger(0)
+    val stopCallCount = AtomicInteger(0)
+    val flushCallCount = AtomicInteger(0)
+    val releaseCallCount = AtomicInteger(0)
+
+    // --- write log ---
+    private val _writes = ConcurrentLinkedQueue<WriteRecord>()
+    val writes: List<WriteRecord> get() = _writes.toList()
+    val totalBytesWritten = AtomicLong(0)
+
+    data class WriteRecord(val offset: Int, val size: Int, val snapshotFirstBytes: ByteArray)
+
+    // --- timestamp script ---
+    @Volatile private var nextTimestamp: SinkTimestamp? = null
+
+    /** Configure what getTimestamp() returns next. Null means "not ready." */
+    fun scriptTimestamp(ts: SinkTimestamp?) {
+        nextTimestamp = ts
+    }
+
+    fun scriptTimestamp(framePosition: Long, nanoTime: Long) {
+        nextTimestamp = SinkTimestamp(framePosition, nanoTime)
+    }
+
+    // --- AudioSink impl ---
+    override fun play() { playCallCount.incrementAndGet() }
+    override fun pause() { pauseCallCount.incrementAndGet() }
+    override fun stop() { stopCallCount.incrementAndGet() }
+    override fun flush() { flushCallCount.incrementAndGet() }
+    override fun release() { releaseCallCount.incrementAndGet() }
+
+    override fun write(buffer: ByteArray, offset: Int, size: Int): Int {
+        _writes.add(WriteRecord(
+            offset = offset,
+            size = size,
+            snapshotFirstBytes = buffer.copyOfRange(offset, minOf(offset + 16, offset + size)),
+        ))
+        totalBytesWritten.addAndGet(size.toLong())
+        return size
+    }
+
+    override fun getTimestamp(): SinkTimestamp? = nextTimestamp
+
+    override val playbackHeadPosition: Int = 0  // extend if needed
+    override val state: Int = 3  // AudioTrack.STATE_INITIALIZED = 3
+}
+```
+
+- [ ] **Step 2: Write failing test for the fake**
+
+```kotlin
+package com.sendspindroid.sendspin.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FakeAudioSinkTest {
+
+    @Test
+    fun `records write calls with byte counts`() {
+        val sink = FakeAudioSink()
+        val buf = ByteArray(480 * 4)  // 10ms of stereo 16-bit at 48k
+        sink.write(buf, 0, buf.size)
+        sink.write(buf, 0, buf.size)
+        assertEquals(2, sink.writes.size)
+        assertEquals((480 * 4 * 2).toLong(), sink.totalBytesWritten.get())
+    }
+
+    @Test
+    fun `scriptTimestamp returns configured value, null by default`() {
+        val sink = FakeAudioSink()
+        assertNull(sink.getTimestamp())
+        sink.scriptTimestamp(framePosition = 960, nanoTime = 1_000_000)
+        val ts = sink.getTimestamp()!!
+        assertEquals(960L, ts.framePosition)
+        assertEquals(1_000_000L, ts.nanoTime)
+    }
+
+    @Test
+    fun `play pause stop flush release counted`() {
+        val sink = FakeAudioSink()
+        sink.play(); sink.pause(); sink.stop(); sink.flush(); sink.release()
+        assertEquals(1, sink.playCallCount.get())
+        assertEquals(1, sink.pauseCallCount.get())
+        assertEquals(1, sink.stopCallCount.get())
+        assertEquals(1, sink.flushCallCount.get())
+        assertEquals(1, sink.releaseCallCount.get())
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.sendspindroid.sendspin.audio.FakeAudioSinkTest"
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add android/app/src/test/java/com/sendspindroid/sendspin/audio/
+git commit -m "test: add FakeAudioSink for integration-level SyncAudioPlayer tests"
+```
+
+---
+
+## Task 5: Inject nowNs clock into SyncAudioPlayer
+
+**Files:**
+- Modify: `android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt`
+- Modify: `android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerTest.kt` (if any existing tests construct the player)
+
+- [ ] **Step 1: Add nowNs parameter to SyncAudioPlayer constructor**
+
+Change the primary constructor signature:
+
+```kotlin
+class SyncAudioPlayer(
+    private val timeFilter: SendspinTimeFilter,
+    private val sampleRate: Int,
+    private val channels: Int,
+    private val bitDepth: Int,
+    private val nowNs: () -> Long = { System.nanoTime() },  // NEW
+) { ... }
+```
+
+- [ ] **Step 2: Replace all `System.nanoTime()` inside SyncAudioPlayer with `nowNs()`**
+
+```bash
+# Count before:
+grep -c "System\.nanoTime()" android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+# Expected: 28
+
+# Apply replacements — but do this by reading each call site, not blind sed,
+# because some may be inside string interpolations or comments.
+```
+
+Use the Edit tool to replace each occurrence. The typical pattern is:
+
+```kotlin
+// Before:
+val nowMicros = System.nanoTime() / 1000
+
+// After:
+val nowMicros = nowNs() / 1000
+```
+
+- [ ] **Step 3: Update OutputLatencyEstimator construction to share the clock**
+
+```kotlin
+// In SyncAudioPlayer (~line 333):
+private val latencyEstimator = com.sendspindroid.sendspin.latency.OutputLatencyEstimator(
+    nowNs = nowNs,  // was: { System.nanoTime() }
+)
+```
+
+- [ ] **Step 4: Run existing tests to verify no regressions**
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.sendspindroid.sendspin.SyncAudioPlayerTest"
+```
+
+Expected: all existing tests pass (default `nowNs` = `System.nanoTime()` preserves prod behaviour).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+git commit -m "refactor: inject nowNs clock into SyncAudioPlayer for testability"
+```
+
+---
+
+## Task 6: Route SyncAudioPlayer's AudioTrack calls through AudioSink
+
+**Files:**
+- Modify: `android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt`
+
+- [ ] **Step 1: Replace the internal `audioTrack: AudioTrack?` field with `audioSink: AudioSink?`**
+
+Keep `AudioTrack` creation inside SyncAudioPlayer for now (Task 6 is about the
+internal seam, not external construction). Wrap the created track in
+`AudioTrackSink` right after `.build()`:
+
+```kotlin
+// Where AudioTrack is currently built (~line 543):
+val track = AudioTrack.Builder()
+    .setAudioAttributes(...)
+    .setAudioFormat(...)
+    .setBufferSizeInBytes(bufferSize)
+    .setTransferMode(AudioTrack.MODE_STREAM)
+    .build()
+audioSink = AudioTrackSink(track)
+```
+
+- [ ] **Step 2: Replace every `audioTrack?.foo()` and `audioTrack!!.foo()` with
+       `audioSink?.foo()` / `audioSink!!.foo()`**
+
+Find-and-replace each usage. Pay attention to:
+- `audioTrack.write(...)` -> `audioSink.write(...)`
+- `audioTrack.getTimestamp(audioTimestamp)` -> `audioSink.getTimestamp()?.let { ts -> ... }` (signature changed — no shared AudioTimestamp buffer any more)
+- `audioTrack.play() / pause() / stop() / flush() / release()` -> `audioSink.foo()`
+- `audioTrack.playbackHeadPosition` -> `audioSink.playbackHeadPosition`
+- `audioTrack.state` -> `audioSink.state`
+
+- [ ] **Step 3: Delete the now-unused `audioTimestamp: AudioTimestamp` field
+       (line 377) and the `AudioTimestamp` import (line 6)**
+
+- [ ] **Step 4: Remove `AudioTrack` import** if no longer used in the file.
+
+- [ ] **Step 5: Run build to catch missed references**
+
+```bash
+./gradlew :app:compileDebugKotlin 2>&1 | tail -30
+```
+
+Expected: compiles clean.
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+./gradlew :app:testDebugUnitTest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Install on device and verify normal-path playback still works**
+
+```bash
+./gradlew :app:installDebug
+# Play a track, confirm audio comes out, check logcat for any new errors.
+```
+
+This is the big "did I break prod" checkpoint. Do not proceed until audio
+plays normally.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+git commit -m "refactor: route SyncAudioPlayer AudioTrack calls through AudioSink"
+```
+
+---
+
+## Task 7: Add SyncAudioPlayer constructor overload accepting an AudioSink directly
+
+**Files:**
+- Modify: `android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt`
+
+The goal: tests need to inject `FakeAudioSink` without SyncAudioPlayer
+constructing an `AudioTrack` internally.
+
+- [ ] **Step 1: Extract AudioTrack creation into a factory parameter**
+
+Change the primary constructor:
+
+```kotlin
+class SyncAudioPlayer(
+    private val timeFilter: SendspinTimeFilter,
+    private val sampleRate: Int,
+    private val channels: Int,
+    private val bitDepth: Int,
+    private val nowNs: () -> Long = { System.nanoTime() },
+    private val sinkFactory: (sampleRate: Int, channels: Int, bitDepth: Int, bufferSize: Int) -> AudioSink = ::defaultSinkFactory,
+) {
+    private fun defaultSinkFactory(
+        sampleRate: Int, channels: Int, bitDepth: Int, bufferSize: Int,
+    ): AudioSink {
+        val track = AudioTrack.Builder()
+            .setAudioAttributes(...)
+            .setAudioFormat(...)
+            .setBufferSizeInBytes(bufferSize)
+            .setTransferMode(AudioTrack.MODE_STREAM)
+            .build()
+        return AudioTrackSink(track)
+    }
+    // ...
+}
+```
+
+Note: the `companion object` is a common location for `defaultSinkFactory`
+if top-level or member-function form is awkward given the AudioAttributes
+code already in the file. Pick whichever matches existing patterns — check
+how SyncAudioPlayer currently organises helper methods.
+
+- [ ] **Step 2: Update the AudioTrack creation path to use `sinkFactory(...)`**
+
+```kotlin
+// In the existing init method:
+val bufferSize = AudioTrack.getMinBufferSize(...)
+audioSink = sinkFactory(sampleRate, channels, bitDepth, bufferSize)
+```
+
+- [ ] **Step 3: Run existing tests**
+
+```bash
+./gradlew :app:testDebugUnitTest
+```
+
+Expected: pass (default factory preserves prod behaviour).
+
+- [ ] **Step 4: Smoke-test on device**
+
+Normal playback must still work.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+git commit -m "refactor: accept sinkFactory in SyncAudioPlayer for test injection"
+```
+
+---
+
+## Task 8: Write the tick-starvation regression test
+
+**Files:**
+- Create: `android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+The test must fail if we revert the tick-starvation fix from PR #153.
+
+```kotlin
+package com.sendspindroid.sendspin
+
+import com.sendspindroid.sendspin.audio.FakeAudioSink
+import com.sendspindroid.sendspin.audio.SinkTimestamp
+import com.sendspindroid.sendspin.latency.OutputLatencyEstimator
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Integration tests for SyncAudioPlayer driven through the AudioSink
+ * abstraction with a controlled clock. Exercises real state-machine
+ * behaviour without a real AudioTrack.
+ */
+class SyncAudioPlayerIntegrationTest {
+
+    private val sampleRate = 48000
+    private val channels = 2
+    private val bitDepth = 16
+
+    @Test
+    fun `tick starvation: estimator times out and state machine progresses`() {
+        // Controlled clock; tests advance it explicitly.
+        var now = 0L
+        val nowNs = { now }
+
+        val timeFilter = mockk<SendspinTimeFilter>(relaxed = true)
+        every { timeFilter.isReady } returns true
+        every { timeFilter.serverToClient(any()) } answers { firstArg() }
+        every { timeFilter.clientToServer(any()) } answers { firstArg() }
+
+        val fakeSink = FakeAudioSink()
+        val player = SyncAudioPlayer(
+            timeFilter = timeFilter,
+            sampleRate = sampleRate, channels = channels, bitDepth = bitDepth,
+            nowNs = nowNs,
+            sinkFactory = { _, _, _, _ -> fakeSink },
+        )
+
+        // Reach into private state: put the player into WAITING_FOR_START with
+        // dacTimestampsStable = true (mimics the on-device deadlock scenario).
+        setPrivate(player, "playbackState", PlaybackState.WAITING_FOR_START)
+        setPrivate(player, "dacTimestampsStable", true)
+
+        // The latency estimator is started when AudioTrack/sink is created.
+        // Grab the estimator and advance the clock past the 2s timeout.
+        val est: OutputLatencyEstimator = getPrivate(player, "latencyEstimator")
+        assertEquals(OutputLatencyEstimator.Status.Measuring, est.status)
+
+        // Simulate arrival at WAITING_FOR_START with stable DAC and no DAC
+        // samples — invoke handleStartGatingDacAware directly via reflection.
+        fakeSink.scriptTimestamp(SinkTimestamp(framePosition = 960, nanoTime = now))
+
+        val method = SyncAudioPlayer::class.java.getDeclaredMethod(
+            "handleStartGatingDacAware",
+            com.sendspindroid.sendspin.audio.AudioSink::class.java,  // update param type as refactored
+        )
+        method.isAccessible = true
+
+        // First call: estimator still Measuring, should keep waiting.
+        method.invoke(player, fakeSink)
+        assertEquals(OutputLatencyEstimator.Status.Measuring, est.status)
+
+        // Advance the clock past the 2s timeout.
+        now = 2_100_000_000L
+
+        // Second call: tick() at top of handleStartGatingDacAware must fire the
+        // timeout. If the fix is reverted, status stays Measuring.
+        method.invoke(player, fakeSink)
+        assertNotEquals(
+            "estimator must leave Measuring once 2s has elapsed",
+            OutputLatencyEstimator.Status.Measuring, est.status,
+        )
+    }
+
+    // --- reflection helpers ---
+
+    private fun <T> getPrivate(target: Any, name: String): T {
+        val f = target.javaClass.getDeclaredField(name)
+        f.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return f.get(target) as T
+    }
+
+    private fun setPrivate(target: Any, name: String, value: Any?) {
+        val f = target.javaClass.getDeclaredField(name)
+        f.isAccessible = true
+        f.set(target, value)
+    }
+}
+```
+
+**Note:** the second parameter type of `handleStartGatingDacAware` was
+`AudioTrack` before the refactor; after Task 6 it should be `AudioSink`. Adjust
+the `getDeclaredMethod` call to match the refactored signature.
+
+- [ ] **Step 2: Verify the test passes with the current fix in place**
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.sendspindroid.sendspin.SyncAudioPlayerIntegrationTest.tick starvation*"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify the test fails if the fix is reverted**
+
+Temporarily remove the `latencyEstimator.tick()` call from
+`handleStartGatingDacAware` and rerun. Expected: FAIL. Revert the
+temporary change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt
+git commit -m "test: regression test for tick-starvation deadlock"
+```
+
+---
+
+## Task 9: Stuck-state watchdog
+
+**Files:**
+- Modify: `android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt`
+
+- [ ] **Step 1: Add watchdog state fields**
+
+Near the other stats-related fields, add:
+
+```kotlin
+// Stuck-state watchdog: tracks when a non-PLAYING state was first entered.
+// Used by the stats logger to surface state-machine deadlocks.
+private var stuckStateEnteredAtUs: Long = 0L
+private var lastObservedState: PlaybackState = PlaybackState.INITIALIZING
+
+companion object {
+    // ... existing constants ...
+    private const val STUCK_STATE_WARNING_US = 5_000_000L       // 5s
+    private const val STUCK_STATE_WARNING_INTERVAL_US = 10_000_000L  // 10s between warnings
+}
+
+private var lastStuckWarningAtUs: Long = 0L
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Test file: reuse `SyncAudioPlayerIntegrationTest.kt`.
+
+```kotlin
+@Test
+fun `watchdog warns when non-PLAYING state persists with chunks arriving`() {
+    var now = 0L
+    val nowNs = { now }
+
+    val timeFilter = mockk<SendspinTimeFilter>(relaxed = true)
+    every { timeFilter.isReady } returns true
+    every { timeFilter.serverToClient(any()) } answers { firstArg() }
+    every { timeFilter.clientToServer(any()) } answers { firstArg() }
+
+    val fakeSink = FakeAudioSink()
+    val player = SyncAudioPlayer(
+        timeFilter, sampleRate, channels, bitDepth, nowNs,
+        sinkFactory = { _, _, _, _ -> fakeSink },
+    )
+
+    setPrivate(player, "playbackState", PlaybackState.WAITING_FOR_START)
+
+    // Put some chunks in the queue so the watchdog has reason to warn.
+    val chunkQueue: ConcurrentLinkedQueue<*> = getPrivate(player, "chunkQueue")
+    // ... push a chunk; see existing tests for the helper ...
+
+    // Invoke stats-log / watchdog path via reflection.
+    val method = SyncAudioPlayer::class.java.getDeclaredMethod("checkStuckState")
+    method.isAccessible = true
+
+    // First tick: establishes baseline, no warning yet.
+    method.invoke(player)
+    val warn1 = getPrivate<Long>(player, "lastStuckWarningAtUs")
+    assertEquals("no warning on first observation", 0L, warn1)
+
+    // Advance clock past the 5s threshold.
+    now = 5_500_000_000L
+    method.invoke(player)
+    val warn2 = getPrivate<Long>(player, "lastStuckWarningAtUs")
+    assertNotEquals("warning should have fired after 5s stuck", 0L, warn2)
+}
+```
+
+Expected: FAIL (`checkStuckState` doesn't exist yet).
+
+- [ ] **Step 3: Implement checkStuckState**
+
+```kotlin
+/**
+ * Watchdog invoked once per stats-log cycle. Warns if the state machine has
+ * been in a non-PLAYING state for more than STUCK_STATE_WARNING_US while
+ * chunks are arriving (indicating the pipeline is wedged, not just idle).
+ *
+ * Diagnostic only — no recovery action.
+ */
+private fun checkStuckState() {
+    val nowUs = nowNs() / 1000
+    val state = playbackState
+
+    if (state != lastObservedState) {
+        lastObservedState = state
+        stuckStateEnteredAtUs = nowUs
+        return
+    }
+
+    if (state == PlaybackState.PLAYING) return
+
+    val stuckUs = nowUs - stuckStateEnteredAtUs
+    if (stuckUs < STUCK_STATE_WARNING_US) return
+
+    // Only warn if there's actual audio backlog — don't spam when the user
+    // just paused playback.
+    if (totalQueuedSamples.get() == 0L) return
+
+    if (nowUs - lastStuckWarningAtUs < STUCK_STATE_WARNING_INTERVAL_US) return
+    lastStuckWarningAtUs = nowUs
+
+    val bufferedMs = (totalQueuedSamples.get() * 1000) / sampleRate
+    AppLog.Audio.w(
+        "WATCHDOG: state=$state stuck for ${stuckUs / 1000}ms, " +
+            "buffered=${bufferedMs}ms, chunks=${chunkQueue.size}, " +
+            "estimatorStatus=${latencyEstimator.status}, " +
+            "dacTimestampsStable=$dacTimestampsStable"
+    )
+}
+```
+
+- [ ] **Step 4: Call checkStuckState from the existing stats logger**
+
+Find the existing 1-second stats log site (search for `"Stats: state="`).
+Add a call to `checkStuckState()` immediately before or after the stats
+log line.
+
+- [ ] **Step 5: Run the watchdog test**
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.sendspindroid.sendspin.SyncAudioPlayerIntegrationTest.watchdog*"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Full test suite**
+
+```bash
+./gradlew :app:testDebugUnitTest
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Install on device and confirm no spurious warnings in
+       normal playback**
+
+Watch logcat during a normal track. `WATCHDOG:` lines must not appear
+under healthy playback.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt \
+        android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt
+git commit -m "feat: stuck-state watchdog logs when playback loop deadlocks"
+```
+
+---
+
+## Task 10: Build, full-suite test, open PR
+
+**Files:** all touched in Tasks 1-9.
+
+- [ ] **Step 1: Full build**
+
+```bash
+./gradlew :app:assembleDebug :shared:testAndroidHostTest :app:testDebugUnitTest
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Install on device, verify healthy playback**
+
+```bash
+./gradlew :app:installDebug
+```
+
+Play a track. Confirm:
+- Audio plays immediately (no `WATCHDOG:` lines in logcat).
+- Track changes work.
+- Pausing / unpausing works.
+- Seeking works.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat: audio integration harness + stuck-state watchdog" --body "..."
+```
+
+PR body should include:
+- Motivation (the "we've had three integration bugs slip through unit tests" story)
+- Summary of what this adds
+- Explicit callout that `SyncAudioPlayer` still owns AudioTrack creation (no prod behaviour change)
+- Link to `docs/BACKLOG.md` for the deferred `SyncAudioPlayer` split
+
+- [ ] **Step 4: Note follow-up work**
+
+After merge:
+- Consider whether the harness is sufficient or if a `TestDispatcher`-based
+  full loop driver is worth adding next.
+- Revisit `docs/BACKLOG.md` to decide if any of the deferred items are now
+  ripe to pick up.


### PR DESCRIPTION
## Summary

Three things land in this branch:
1. **AudioSink integration harness** — introduces an `AudioSink` interface, a `FakeAudioSink` test double, an injected `nowNs` clock, and a `sinkFactory` constructor parameter so `SyncAudioPlayer`'s state transitions can be exercised end-to-end in JVM unit tests without a real `AudioTrack`.
2. **Stuck-state watchdog** — logs a `WATCHDOG:` warning when the playback loop sits in a non-`PLAYING` state with chunks arriving for more than 5 s. Diagnostic only; no recovery action.
3. **JsonNull protocol-parse fix** — observed on-device: Music Assistant sends idle metadata with `"progress": null` (and other null fields). `MessageParser.kt:83` was using `?.jsonObject`, which throws `IllegalArgumentException` on `JsonNull`. Switched to `as? JsonObject` so null is treated like absent.

## Motivation

Several recent PRs passed unit tests and broke on-device (PR #142 FLAC corruption, PR #144 tick-starvation deadlock, PR #146 wizard duplicate-key crash). All three were *wiring* bugs — the individual components were tested, but nothing exercised the composed state machine under realistic timing.

This PR is the harness those bugs needed: new code paths can be covered by tests that drive a real `SyncAudioPlayer` with a scripted DAC and a controllable clock. First regression test using the harness: the tick-starvation bug from PR #153 (included in the test suite here, committed with a verified pass-with-fix / fail-without-fix).

## What's in it

| File | Role |
|------|------|
| `audio/AudioSink.kt` | Thin interface over `AudioTrack`'s surface (`play`/`pause`/`stop`/`flush`/`release`/`write`/`getTimestamp`/`playbackHeadPosition`/`state`/`playState`/`bufferSizeInBytes`) |
| `audio/AudioTrackSink.kt` | Production wrapper delegating to a real `AudioTrack` |
| `audio/FakeAudioSink.kt` | Test-only sink that records calls and scripts `getTimestamp()` returns |
| `SyncAudioPlayer.kt` | Now accepts `nowNs: () -> Long` and `sinkFactory` in the constructor. Internal AudioTrack interactions routed through `AudioSink`. Added stuck-state watchdog (`checkStuckState`) called from the playback loop. |
| `SyncAudioPlayerIntegrationTest.kt` | Tick-starvation regression + two watchdog tests |
| `MessageParser.kt` | Defensive `as? JsonObject` casts replace `?.jsonObject` on nullable fields |
| `docs/superpowers/plans/2026-04-23-audio-integration-harness-and-watchdog.md` | Implementation plan |
| `docs/BACKLOG.md` | Deferred items — `SyncAudioPlayer` split, rapid-skip 12 s future-scheduling bug, DAC-alignment log spam, process-level integration-test requirement |

## Production behaviour

- `nowNs` defaults to `System.nanoTime()` — no behaviour change.
- `sinkFactory` defaults to a top-level function that constructs the same `AudioTrack` with identical `AudioAttributes` / `AudioFormat` / buffer size / performance mode — no behaviour change.
- Watchdog is diagnostic-only: log line on stuck state, no reanchor / reset.
- Parse fix changes behaviour only when the server sends `JsonNull` for `progress` or `metadata` — was throwing before, now treated as absent (matches handling of missing fields).

## Dependency on #153

This branch includes a local merge of `task/tick-starvation-fix` so the AudioSink refactor could be smoke-tested against a playable baseline. When **#153 lands on `main` first**, this branch rebases cleanly and the merge commit becomes redundant. If this PR lands before #153, GitHub will pull #153's commit in too.

## Test plan

- [x] `:app:testDebugUnitTest` green (including 1 new integration test + 2 new watchdog tests + 7 new FakeAudioSink tests + existing suite)
- [x] `:shared:testAndroidHostTest` — 3 failures (`parseServerTime_zeroTimestamps_returnsResult`, `MaCommandMultiplexerTest.*empty array*`, `SendspinTimeFilterTest.stabilityScore_consistentMeasurements_convergesToOne`) verified pre-existing on `origin/main` (baseline check at `b699238` reproduces them). My 2 new `MessageParserTest` regression tests pass.
- [x] `assembleDebug` succeeds
- [x] Device smoke: audio plays, pause/resume works, track change works, no WATCHDOG lines during healthy playback, no JsonNull exceptions
- [x] Verified `latencyEstimator.tick()` fix from PR #153 locks in place: test passes with the line, fails without it

## Follow-ups (in BACKLOG)

- `SyncAudioPlayer` split (week+ refactor; harness is the prerequisite)
- Rapid-skip 12 s future-scheduling bug (server-side)
- DAC-alignment log-spam rate-limit
- MA upstream three-image-source inconsistency issue