### PR TITLE
fix: bound reconnect retries + default unknown errors to unrecoverable (L-5)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpinClient.kt
@@ -89,6 +89,13 @@ class SendSpinClient(
         private const val MAX_RECONNECT_DELAY_MS = 10000L // 10 seconds (was 30s)
         private const val HIGH_POWER_RECONNECT_DELAY_MS = 30_000L // 30s steady-state for high power mode
 
+        // Hard ceiling on reconnect attempts per cycle. At the current schedule
+        // (exp backoff for 5, then 30s each) this caps the total try-window at
+        // about 7m45s. Beyond that we surface the failure to the UI via
+        // onDisconnected(wasReconnectExhausted=true) and stop scheduling attempts.
+        // Reset to 0 on every successful handshake.
+        private const val MAX_TOTAL_RECONNECT_ATTEMPTS = 20
+
         // Stall watchdog: while connected+handshake-complete, if no bytes arrive for
         // this long, force-close the transport so the existing reconnect path kicks in.
         // Shorter than Ktor's 30s ping-timeout to beat buffer drain.
@@ -1034,6 +1041,26 @@ class SendSpinClient(
             return
         }
 
+        // Hard cap (L-5 fix): after MAX_TOTAL_RECONNECT_ATTEMPTS, stop scheduling
+        // attempts and surface failure to the UI. The user can manually reconnect
+        // (which clears reconnectAttempts and restarts the cycle).
+        val prior = reconnectAttempts.get()
+        if (prior >= MAX_TOTAL_RECONNECT_ATTEMPTS) {
+            Log.w(TAG, "Reconnect cap reached ($prior >= $MAX_TOTAL_RECONNECT_ATTEMPTS) - giving up")
+            AppLog.Network.w(
+                "[reconnect-exhausted] cap=$MAX_TOTAL_RECONNECT_ATTEMPTS " +
+                    "attempts_total=${reconnectAttemptsTotal.get()} mode=$connectionMode"
+            )
+            reconnecting.set(false)
+            reconnectJob?.cancel()
+            reconnectJob = null
+            _connectionState.value = ConnectionState.Error(
+                "Couldn't reconnect to $savedServerName after $MAX_TOTAL_RECONNECT_ATTEMPTS attempts"
+            )
+            callback.onDisconnected(wasUserInitiated = false, wasReconnectExhausted = true)
+            return
+        }
+
         val attempts = reconnectAttempts.incrementAndGet()
         // Lifetime counter survives across reconnect cycles. Issue #128.
         reconnectAttemptsTotal.incrementAndGet()
@@ -1163,7 +1190,12 @@ class SendSpinClient(
             cause is UnknownHostException -> false
             cause is SSLHandshakeException -> false
             message.contains("refused") -> false
-            else -> true
+            else -> {
+                // Default to NOT recoverable. A leaked programming bug (NPE, parser
+                // RuntimeException, etc.) must not trigger endless reconnect loops.
+                Log.d(TAG, "isRecoverableError: unrecognized throwable ${cause::class.simpleName} msg='$message' -> unrecoverable")
+                false
+            }
         }
     }
 

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientReconnectBackoffTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientReconnectBackoffTest.kt
@@ -26,10 +26,12 @@ import org.junit.Test
 
 /**
  * Tests that reconnection uses exponential backoff with the correct delays
- * and that both normal and high-power modes retry indefinitely.
+ * and that the total attempt count is bounded by MAX_TOTAL_RECONNECT_ATTEMPTS.
  *
- * Expected delay sequence: 500ms, 1s, 2s, 4s, 8s.
- * Both normal and high-power mode: infinite retries, 30s steady-state after the 5th attempt.
+ * Expected delay sequence: 500ms, 1s, 2s, 4s, 8s (first five), then 30s
+ * steady-state. Retries stop after MAX_TOTAL_RECONNECT_ATTEMPTS (20), at which
+ * point onDisconnected(wasReconnectExhausted=true) fires and the connection
+ * state transitions to Error.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class SendSpinClientReconnectBackoffTest {
@@ -139,33 +141,96 @@ class SendSpinClientReconnectBackoffTest {
     }
 
     @Test
-    fun `normal mode retries forever without triggering exhausted error`() {
+    fun `attempts below cap do not trigger exhausted disconnect`() {
         setupForReconnection()
         every { UserSettings.highPowerMode } returns false
 
         val attemptReconnect = SendSpinClient::class.java.getDeclaredMethod("attemptReconnect")
         attemptReconnect.isAccessible = true
 
-        // Perform 10 attempts - all should succeed in normal mode now
+        // Ten attempts is well under the MAX_TOTAL_RECONNECT_ATTEMPTS (20) cap.
         for (i in 1..10) {
             attemptReconnect.invoke(client)
         }
 
-        // Should NOT have called onDisconnected with wasReconnectExhausted=true
+        verify(exactly = 0) {
+            mockCallback.onDisconnected(wasUserInitiated = false, wasReconnectExhausted = true)
+        }
+        verify(exactly = 10) {
+            mockCallback.onReconnecting(any(), any())
+        }
+        assertTrue(
+            "State should remain Connecting below cap, was: ${client.connectionState.value}",
+            client.connectionState.value is SendSpinClient.ConnectionState.Connecting
+        )
+    }
+
+    @Test
+    fun `reaching MAX_TOTAL_RECONNECT_ATTEMPTS triggers exhausted disconnect`() {
+        setupForReconnection()
+        every { UserSettings.highPowerMode } returns false
+
+        val attemptReconnect = SendSpinClient::class.java.getDeclaredMethod("attemptReconnect")
+        attemptReconnect.isAccessible = true
+
+        // Drive attempts up to the cap. At MAX_TOTAL_RECONNECT_ATTEMPTS (20) we
+        // should still be reconnecting; the cap-exceeded check fires on the 21st
+        // entry into attemptReconnect (when reconnectAttempts.get() is already 20).
+        for (i in 1..20) {
+            attemptReconnect.invoke(client)
+        }
+        assertEquals(20, client.getReconnectAttempts())
         verify(exactly = 0) {
             mockCallback.onDisconnected(wasUserInitiated = false, wasReconnectExhausted = true)
         }
 
-        // All 10 should have been onReconnecting calls
-        verify(exactly = 10) {
-            mockCallback.onReconnecting(any(), any())
-        }
+        // The 21st call is the one that should detect the cap and fire exhausted.
+        attemptReconnect.invoke(client)
 
-        // State should remain Connecting (not Error)
+        verify(exactly = 1) {
+            mockCallback.onDisconnected(wasUserInitiated = false, wasReconnectExhausted = true)
+        }
         assertTrue(
-            "State should remain Connecting in normal mode with no cap, was: ${client.connectionState.value}",
-            client.connectionState.value is SendSpinClient.ConnectionState.Connecting
+            "State should transition to Error after cap, was: ${client.connectionState.value}",
+            client.connectionState.value is SendSpinClient.ConnectionState.Error
         )
+    }
+
+    @Test
+    fun `isRecoverableError returns false for unknown throwables`() {
+        val method = SendSpinClient::class.java.getDeclaredMethod("isRecoverableError", Throwable::class.java)
+        method.isAccessible = true
+
+        // A totally generic RuntimeException (the shape a parser bug or NPE takes)
+        // must not be treated as recoverable, to avoid infinite reconnect on
+        // programmer errors.
+        val unknown = RuntimeException("something strange nobody has matched")
+        assertEquals(false, method.invoke(client, unknown))
+    }
+
+    @Test
+    fun `isRecoverableError returns true for known network glitches`() {
+        val method = SendSpinClient::class.java.getDeclaredMethod("isRecoverableError", Throwable::class.java)
+        method.isAccessible = true
+
+        // Sanity: known-recoverable errors still resolve to recoverable.
+        val socketErr = java.net.SocketException("Connection reset by peer")
+        val eofErr = java.io.EOFException("unexpected eof")
+        val timeoutErr = java.net.SocketTimeoutException("read timed out")
+        assertEquals(true, method.invoke(client, socketErr))
+        assertEquals(true, method.invoke(client, eofErr))
+        assertEquals(true, method.invoke(client, timeoutErr))
+    }
+
+    @Test
+    fun `isRecoverableError returns false for known permanent errors`() {
+        val method = SendSpinClient::class.java.getDeclaredMethod("isRecoverableError", Throwable::class.java)
+        method.isAccessible = true
+
+        val unknownHost = java.net.UnknownHostException("no such host")
+        val refused = java.io.IOException("connection refused")
+        assertEquals(false, method.invoke(client, unknownHost))
+        assertEquals(false, method.invoke(client, refused))
     }
 
     @Test

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/BaseWebSocketTransport.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/BaseWebSocketTransport.kt
@@ -89,8 +89,15 @@ abstract class BaseWebSocketTransport(
     }
 
     /**
-     * Check if an error is likely temporary (network glitch) vs. permanent (config error).
-     * Subclasses may override to add transport-specific checks (e.g., auth errors).
+     * Check if an error is likely temporary (network glitch) vs. permanent (config error
+     * or a leaked programming bug). Subclasses may override to add transport-specific
+     * checks (e.g., auth errors).
+     *
+     * Defaults to NOT recoverable for unknown errors. Historically this defaulted to
+     * true, which meant a `RuntimeException` leaking through (NPE, parser bug, etc.)
+     * would trigger infinite reconnect loops against a server that was already fine.
+     * Erring on "give up" for unknowns lets the UI surface the failure and keeps a
+     * misbehaving client from pinging forever.
      */
     protected open fun isRecoverableError(t: Throwable): Boolean {
         val cause = t.cause ?: t
@@ -118,8 +125,10 @@ abstract class BaseWebSocketTransport(
             message.contains("unknown host") -> false
             message.contains("no route") -> false
 
-            // Default to recoverable (optimistic)
-            else -> true
+            else -> {
+                Log.d(tag, "isRecoverableError: unrecognized throwable $causeName msg='$message' -> treating as unrecoverable")
+                false
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses audit finding **L-5**: `isRecoverableError` defaulted to `true` and the reconnect loop had no hard cap. Net effect was that a leaked programming bug (parser `RuntimeException`, NPE) or a permanently-dead server would cause the client to ping forever — draining battery and masking the real failure.

## Changes

### 1. `isRecoverableError` defaults flipped (both call sites)

`BaseWebSocketTransport.isRecoverableError` (shared) and `SendSpinClient.isRecoverableError` (app) now default **unknown errors to `false`**. Known-recoverable errors (SocketException, EOF, SocketTimeout, "reset"/"abort"/"broken pipe"/"connection closed") stay recoverable. Known-permanent (UnknownHostException, SSL, ConnectException, "refused", "no route") stay permanent. Unknown now logs a debug line with the class name + message and returns `false`.

### 2. Hard cap on reconnect attempts

`SendSpinClient` gets `MAX_TOTAL_RECONNECT_ATTEMPTS = 20`. At the current backoff schedule (500ms → 1s → 2s → 4s → 8s, then 30s steady-state) this caps a single reconnect cycle at **~7m45s** of trying. Generous enough for "walked to the edge of Wi-Fi" scenarios; bounded enough that "server is never coming back" isn't pinged indefinitely.

On the 21st entry into `attemptReconnect` (i.e. when `reconnectAttempts.get()` is already 20), we:
- emit `AppLog.Network.w("[reconnect-exhausted] cap=20 attempts_total=N mode=X")`
- cancel any pending `reconnectJob` and clear `reconnecting`
- transition `_connectionState` → `ConnectionState.Error("Couldn't reconnect to <server> after 20 attempts")`
- fire `callback.onDisconnected(wasUserInitiated=false, wasReconnectExhausted=true)`

The downstream pipeline was **already fully wired** end-to-end: `PlaybackService.onDisconnected` → `EXTRA_WAS_RECONNECT_EXHAUSTED` intent extra → `MainActivity` which already correctly skips UI-level auto-reconnect when `wasReconnectExhausted=true` and shows the server list. The flag was just never being set to `true` — this PR connects that last wire.

### 3. Counter reset preserved

`reconnectAttempts.set(0)` on every successful handshake was already in place (SendSpinClient:353). A successful reconnect still restarts the cap cycle cleanly. User-initiated "reconnect" also resets via the existing `destroy()` / re-init flow.

## Not changing

- Exponential backoff schedule (500ms → 1s → 2s → 4s → 8s → 30s...)
- `networkAvailable` pause semantics — Wi-Fi loss still pauses without consuming attempts
- `userInitiatedDisconnect` short-circuit
- LOCAL → PROXY internal fallback logic
- The lifetime `reconnectAttemptsTotal` telemetry counter (survives across cycles)

## Tests

New:
- `isRecoverableError_returnsFalse_forUnknownThrowables`
- `isRecoverableError_returnsTrue_forKnownNetworkGlitches` (sanity)
- `isRecoverableError_returnsFalse_forKnownPermanentErrors` (sanity)
- `attempts below cap do not trigger exhausted disconnect`
- `reaching MAX_TOTAL_RECONNECT_ATTEMPTS triggers exhausted disconnect`

Updated:
- Existing test `normal mode retries forever` renamed to `attempts below cap do not trigger exhausted disconnect` — the "forever" claim is no longer accurate but below-cap behavior is preserved.
- File-header doc comment updated to reflect the cap.

Existing suite:
- All existing `:app:testDebugUnitTest` pass
- `:shared:testAndroidHostTest` has 3 pre-existing failures on `origin/main` — not related to this change

## Test plan

- [x] Unit tests pass
- [x] `assembleDebug` clean
- [x] Installed on device; normal-play / pause / skip still work (connection-good path unaffected)
- [ ] (Field validation) With server unreachable, confirm that after ~7-8 minutes the UI transitions to server list with no further network traffic in logcat

## Follow-ups (not this PR)

- Surface the `Error` state in the UI as a "Couldn't reconnect — try again" banner with a retry button. Right now the existing flow sends the user back to the server list, which works but is a bit blunt. Tracked in BACKLOG alongside the other connection-UX items.