### PR TITLE
fix: throttle DAC-aware alignment-wait log spam

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SyncAudioPlayer.kt
@@ -430,6 +430,14 @@ class SyncAudioPlayer(
     private var consecutiveValidTimestamps = 0       // counts consecutive valid getTimestamp() reads
     private var dacTimestampsStable = false           // true once TIMESTAMP_STABLE_READS reached
 
+    // DAC-aware alignment wait: rate-limit the per-iteration "waiting for alignment"
+    // log so a 2-12s wait emits ~3-13 lines instead of 200-1200. Entry log fires once
+    // when we first enter alignment wait; progress logs fire at 1s intervals while
+    // still waiting; exit log fires when alignment completes. Both fields reset to 0L
+    // on successful transition to PLAYING so the next alignment wait emits fresh logs.
+    @Volatile private var alignmentWaitStartedAtUs: Long = 0L
+    @Volatile private var alignmentWaitLastLoggedUs: Long = 0L
+
     // DRAINING state tracking - for seamless reconnection
     private var drainingStartTimeUs: Long = 0            // When we entered DRAINING state
     private var lastBufferWarningTimeUs: Long = 0        // Rate limiting for buffer warnings
@@ -1601,7 +1609,19 @@ class SyncAudioPlayer(
             // Queue head is too far ahead of where the DAC needs it -- wait for
             // the DAC to catch up by playing through existing silence. Without
             // this gate, starting with startErr=200ms bakes in a permanent offset.
-            AppLog.Sync.d("DAC-aware start: waiting for alignment, startErr=${startErrUs/1000}ms > ${START_ALIGN_TOL_US/1000}ms")
+            //
+            // This branch runs every playback-loop iteration (~10ms) while we wait.
+            // Rate-limit the log: first-time entry, then once per second progress,
+            // then an exit log on transition to PLAYING. See alignmentWait* fields.
+            if (alignmentWaitStartedAtUs == 0L) {
+                alignmentWaitStartedAtUs = nowMicros
+                alignmentWaitLastLoggedUs = nowMicros
+                AppLog.Sync.d("DAC-aware start: waiting for alignment, startErr=${startErrUs/1000}ms > ${START_ALIGN_TOL_US/1000}ms")
+            } else if (nowMicros - alignmentWaitLastLoggedUs > 1_000_000L) {
+                alignmentWaitLastLoggedUs = nowMicros
+                val elapsedMs = (nowMicros - alignmentWaitStartedAtUs) / 1000
+                AppLog.Sync.d("DAC-aware start: still waiting, startErr=${startErrUs/1000}ms, elapsed=${elapsedMs}ms")
+            }
             return true
         }
 
@@ -1649,6 +1669,16 @@ class SyncAudioPlayer(
             "kalmanOffset=${timeFilter.offsetMicros/1000}ms, " +
             "kalmanMeasurements=${timeFilter.measurementCountValue}, " +
             "bufferedChunks=${chunkQueue.size}, bufferedMs=$bufferedMs")
+
+        // Exit log for the rate-limited alignment-wait path: emit total elapsed
+        // so ops can see how long the DAC took to catch up. Reset both fields
+        // so the next alignment cycle (e.g. after a track change) starts fresh.
+        if (alignmentWaitStartedAtUs != 0L) {
+            val waitElapsedMs = (nowMicros - alignmentWaitStartedAtUs) / 1000
+            AppLog.Sync.i("DAC-aware start: alignment complete after ${waitElapsedMs}ms wait")
+            alignmentWaitStartedAtUs = 0L
+            alignmentWaitLastLoggedUs = 0L
+        }
 
         setPlaybackState(PlaybackState.PLAYING)
         AppLog.Sync.i("DAC-aware start gating complete: now PLAYING")

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SyncAudioPlayerIntegrationTest.kt
@@ -206,6 +206,120 @@ class SyncAudioPlayerIntegrationTest {
         assertNotEquals("warning should have fired after 5s stuck", 0L, warn2)
     }
 
+    /**
+     * Put a player into the "waiting for alignment" state. Returns the
+     * FakeAudioSink so the caller can script timestamps.
+     *
+     * To reach the startErr > tolerance branch of handleStartGatingDacAware
+     * we need:
+     *   - audioSink non-null and dacTimestampsStable
+     *   - estimator not Measuring (so the status check doesn't early-return)
+     *   - pendingToDacUs > 0 (non-zero fakeSink.getTimestamp().framePosition
+     *     and totalFramesWritten > framePosition)
+     *   - chunkQueue has a head chunk whose serverTimeMicros is far in the
+     *     future relative to nowMicros, so startErrUs computes positive
+     *     and exceeds START_ALIGN_TOL_US (50 ms)
+     */
+    private fun setupAlignmentWaitState(player: SyncAudioPlayer): FakeAudioSink {
+        // Like the tick-starvation test, SyncAudioPlayer.initialize() is
+        // unavailable in JVM tests (AudioTrack.getMinBufferSize is Android-only),
+        // so we inject the audioSink via reflection instead of going through
+        // the sinkFactory init path.
+        val fakeSink = FakeAudioSink()
+        setField(player, "audioSink", fakeSink)
+        setField(player, "dacTimestampsStable", true)
+        setField(player, "playbackState", PlaybackState.WAITING_FOR_START)
+
+        // Estimator: cancel it so status != Measuring. (Same as TimedOut/Converged
+        // for the purposes of the status check.)
+        val estimator: OutputLatencyEstimator = getField(player, "latencyEstimator")
+        estimator.start { }
+        estimator.cancel()
+
+        // DAC timestamp: framePosition=1 means DAC has produced 1 frame.
+        // totalFramesWritten > 1 so pendingFrames > 0 and pendingToDacUs > 0.
+        fakeSink.scriptTimestamp(framePosition = 1L, nanoTime = 0L)
+        val totalFramesWritten = getField<AtomicLong>(player, "totalFramesWritten")
+        totalFramesWritten.set(sampleRate.toLong())  // 1 s worth so pendingToDacUs > 0
+
+        // Queue a single AudioChunk whose serverTime is 5 s ahead of nowMicros,
+        // so startErrUs will be ~5 s (way above the 50 ms tolerance).
+        val audioChunkClass = SyncAudioPlayer::class.java.declaredClasses
+            .find { it.simpleName == "AudioChunk" }!!
+        val ctor = audioChunkClass.getDeclaredConstructor(
+            Long::class.javaPrimitiveType, Long::class.javaPrimitiveType,
+            ByteArray::class.java, Int::class.javaPrimitiveType,
+        )
+        ctor.isAccessible = true
+        val futureServerTime = (now / 1000) + 5_000_000L
+        val chunk = ctor.newInstance(futureServerTime, 0L, ByteArray(0), 0)
+        @Suppress("UNCHECKED_CAST")
+        val chunkQueue = getField<java.util.Queue<Any>>(player, "chunkQueue")
+        chunkQueue.add(chunk)
+
+        return fakeSink
+    }
+
+    @Test
+    fun `alignment wait log emits entry on first call and not on immediate follow-up`() {
+        now = 0L
+        val player = newPlayerForWatchdog()
+        val sink = setupAlignmentWaitState(player)
+
+        // Initial state: alignment tracking fields are 0.
+        assertEquals(0L, getField<Long>(player, "alignmentWaitStartedAtUs"))
+        assertEquals(0L, getField<Long>(player, "alignmentWaitLastLoggedUs"))
+
+        // First call: entry log fires; fields take the current clock value.
+        now = 100_000_000L  // 100 ms
+        invokeHandleStartGatingDacAware(player, sink)
+        val startedAfterFirst = getField<Long>(player, "alignmentWaitStartedAtUs")
+        val loggedAfterFirst = getField<Long>(player, "alignmentWaitLastLoggedUs")
+        assertNotEquals("entry log must set alignmentWaitStartedAtUs", 0L, startedAfterFirst)
+        assertEquals("on entry the two fields match", startedAfterFirst, loggedAfterFirst)
+
+        // Immediate follow-up (no clock advance): no new log; fields unchanged.
+        invokeHandleStartGatingDacAware(player, sink)
+        invokeHandleStartGatingDacAware(player, sink)
+        invokeHandleStartGatingDacAware(player, sink)
+        assertEquals(
+            "follow-up calls within 1 s must not change alignmentWaitStartedAtUs",
+            startedAfterFirst, getField<Long>(player, "alignmentWaitStartedAtUs"),
+        )
+        assertEquals(
+            "follow-up calls within 1 s must not change alignmentWaitLastLoggedUs",
+            loggedAfterFirst, getField<Long>(player, "alignmentWaitLastLoggedUs"),
+        )
+    }
+
+    @Test
+    fun `alignment wait progress log fires after 1 second while still waiting`() {
+        now = 0L
+        val player = newPlayerForWatchdog()
+        val sink = setupAlignmentWaitState(player)
+
+        // Enter alignment wait at t=0.
+        now = 100_000_000L  // 100 ms clock
+        invokeHandleStartGatingDacAware(player, sink)
+        val startedAt = getField<Long>(player, "alignmentWaitStartedAtUs")
+        val loggedAtEntry = getField<Long>(player, "alignmentWaitLastLoggedUs")
+
+        // Advance clock by 1.1 s so the progress-log gate (1 s interval) fires.
+        // Re-script chunk so it's still in the future relative to the new clock.
+        now = 1_200_000_000L  // 1.2 s
+        invokeHandleStartGatingDacAware(player, sink)
+
+        val loggedAfterProgress = getField<Long>(player, "alignmentWaitLastLoggedUs")
+        assertNotEquals(
+            "progress log must advance alignmentWaitLastLoggedUs after 1 s",
+            loggedAtEntry, loggedAfterProgress,
+        )
+        assertEquals(
+            "alignmentWaitStartedAtUs must not change during progress",
+            startedAt, getField<Long>(player, "alignmentWaitStartedAtUs"),
+        )
+    }
+
     @Test
     fun `watchdog does not warn when non-PLAYING state has no buffered chunks`() {
         now = 0L


### PR DESCRIPTION
## Summary

BACKLOG item. `handleStartGatingDacAware` runs on the 10 ms state-poll loop, and the "waiting for alignment" debug line at the `startErr > tolerance` branch was emitting every iteration until the DAC caught up.

- A typical 2 s track-change alignment: **~200 log lines**
- The rapid-second-skip 12 s future-schedule pathology: **~1200 log lines**

DEBUG level so invisible by default, but during our recent triage sessions (logging flipped to DEBUG) it was ~15 % of log volume and rolled the on-device log buffer faster than useful.

## Fix

Mirrors the existing rate-limit pattern used by `DAC_PACING_LOG` (line 2086) and Sync-err logs in the same file.

- Two `@Volatile` fields track when the alignment wait started and when we last logged.
- Entry log fires once on the first `startErr > tol` iteration.
- Progress log fires every 1 s while still waiting.
- Exit log (at INFO) fires on transition to PLAYING and reports total elapsed.
- Fields reset to `0L` so the next alignment cycle starts fresh.

## Output volume

| Wait | Before | After |
|------|--------|-------|
| 2 s (normal track change) | 200 lines | 3 lines (entry + 1 progress + exit) |
| 12 s (rapid-skip pathology) | 1200 lines | 13 lines (entry + 11 progress + exit) |

## Tests

Two new tests in `SyncAudioPlayerIntegrationTest` using the existing reflection-based harness:
- `alignment wait log emits entry on first call and not on immediate follow-up` — verifies entry-log-once
- `alignment wait progress log fires after 1 second while still waiting` — verifies 1 s progress throttle

Plus a `setupAlignmentWaitState` helper that reflects an `AudioChunk` into the queue with a `serverTime` far in the future, so `startErr > tolerance` is reliably reached in tests.

## No behavior change

Pure log-volume reduction. No transitions changed, no correctness semantics touched, no new timing dependency. The alignment-wait logic itself (wait for DAC to catch up by playing silence) is byte-identical.

## Test plan

- [x] `:app:testDebugUnitTest` — all pass (new + existing)
- [x] `assembleDebug` clean
- [x] Installed on device; normal-play / skip / pause-resume all work
- [ ] (Optional field validation) Check logcat during a normal track change: expect 1 entry + 1 progress + 1 exit log instead of ~200 lines