### PR TITLE
fix(remote): normalize Remote ID to wire form; match MA's 8-5-5-8 display

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/remote/RemoteConnection.kt
+++ b/android/app/src/main/java/com/sendspindroid/remote/RemoteConnection.kt
@@ -46,12 +46,24 @@ class RemoteConnection(private val context: Context) {
         /**
          * Format a Remote ID for display (add dashes for readability).
          *
+         * Matches Music Assistant's settings UI grouping (8-5-5-8) so the ID
+         * we show is identical to the hyphenated form the user copied from MA.
+         * See music-assistant/frontend RemoteAccessSettings.vue
+         * (`remoteIdLengths = [8, 5, 5, 8]`).
+         *
          * @param remoteId The raw 26-character ID
-         * @return Formatted ID like "VVPN3-TLP34-YMGIZ-DINCE-KQKSI-R"
+         * @return Formatted ID like "4OPRUGEE-37BPK-SURPJ-BTU5N6SM"
          */
         fun formatRemoteId(remoteId: String): String {
             if (remoteId.length != 26) return remoteId
-            return remoteId.chunked(5).joinToString("-")
+            val groupLengths = intArrayOf(8, 5, 5, 8)
+            val parts = mutableListOf<String>()
+            var offset = 0
+            for (len in groupLengths) {
+                parts.add(remoteId.substring(offset, offset + len))
+                offset += len
+            }
+            return parts.joinToString("-")
         }
 
         /**

--- a/android/app/src/test/java/com/sendspindroid/e2e/RemoteConnectWebRTCTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/e2e/RemoteConnectWebRTCTest.kt
@@ -116,9 +116,25 @@ class RemoteConnectWebRTCTest : E2ETestBase() {
     }
 
     @Test
-    fun `formatRemoteId adds dashes for readability`() {
-        val formatted = RemoteConnection.formatRemoteId("VVPN3TLP34YMGIZDINCEKQKSIR")
-        assertEquals("VVPN3-TLP34-YMGIZ-DINCE-KQKSI-R", formatted)
+    fun `formatRemoteId matches Music Assistant 8-5-5-8 grouping`() {
+        // The 26-char wire form regrouped exactly as MA's settings UI displays
+        // it, so what we show equals what the user copied from MA.
+        assertEquals(
+            "4OPRUGEE-37BPK-SURPJ-BTU5N6SM",
+            RemoteConnection.formatRemoteId("4OPRUGEE37BPKSURPJBTU5N6SM")
+        )
+        assertEquals(
+            "VVPN3TLP-34YMG-IZDIN-CEKQKSIR",
+            RemoteConnection.formatRemoteId("VVPN3TLP34YMGIZDINCEKQKSIR")
+        )
+    }
+
+    @Test
+    fun `formatRemoteId round-trips through parseRemoteId`() {
+        // A displayed (hyphenated) ID parses back to the same 26-char wire form.
+        val wire = "4OPRUGEE37BPKSURPJBTU5N6SM"
+        val displayed = RemoteConnection.formatRemoteId(wire)
+        assertEquals(wire, RemoteConnection.parseRemoteId(displayed))
     }
 
     // ========== Remote Connection Flow Tests ==========

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/remote/SignalingClientRemoteIdTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/remote/SignalingClientRemoteIdTest.kt
@@ -1,0 +1,117 @@
+package com.sendspindroid.remote
+
+import com.sendspindroid.shared.log.Log
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.WebSockets
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for Remote ID normalization in [SignalingClient].
+ *
+ * MA registers the 26-char base32 wire form (no hyphens); the 8-5-5-8
+ * hyphenated form a user copies from the MA UI (e.g.
+ * "4OPRUGEE-37BPK-SURPJ-BTU5N6SM") is display-only. The client must normalize
+ * to the wire form before validating and sending, so a pasted/stored display
+ * ID — from any path — connects rather than being rejected as malformed.
+ */
+class SignalingClientRemoteIdTest {
+
+    // Real MA Remote ID in display form (8-5-5-8 hyphen grouping).
+    private val displayId = "4OPRUGEE-37BPK-SURPJ-BTU5N6SM"
+    private val wireId = "4OPRUGEE37BPKSURPJBTU5N6SM" // 26 chars, hyphens stripped
+
+    private lateinit var httpClient: HttpClient
+
+    @Before
+    fun setUp() {
+        mockkObject(Log)
+        every { Log.v(any(), any()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.w(any(), any()) } returns 0
+        every { Log.e(any(), any()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+        every { Log.w(any(), any(), any()) } returns 0
+        httpClient = HttpClient { install(WebSockets) }
+    }
+
+    @After
+    fun tearDown() {
+        httpClient.close()
+        unmockkAll()
+    }
+
+    // --- normalizeRemoteId (pure) ---
+
+    @Test
+    fun `strips hyphens from display id`() {
+        assertEquals(wireId, SignalingClient.normalizeRemoteId(displayId))
+    }
+
+    @Test
+    fun `display id normalizes to exactly 26 chars`() {
+        assertEquals(26, SignalingClient.normalizeRemoteId(displayId).length)
+    }
+
+    @Test
+    fun `uppercases lowercase input`() {
+        assertEquals("ABC123", SignalingClient.normalizeRemoteId("abc123"))
+    }
+
+    @Test
+    fun `strips surrounding and internal whitespace`() {
+        assertEquals("ABCDEF", SignalingClient.normalizeRemoteId("  ab cd ef "))
+    }
+
+    @Test
+    fun `leaves an already-canonical id unchanged`() {
+        assertEquals(wireId, SignalingClient.normalizeRemoteId(wireId))
+    }
+
+    // --- validation through the constructor/connect path ---
+
+    @Test
+    fun `hyphenated display id is not rejected as invalid format`() {
+        val client = SignalingClient(
+            remoteId = displayId,
+            signalingUrl = "wss://localhost:0/ws", // unreachable; connection will fail later, that's fine
+            httpClient = httpClient,
+            ownsHttpClient = false
+        )
+        client.connect()
+        val state = client.state.value
+        // The only synchronous failure in connect() is the malformed-ID check.
+        // A later async connection failure carries a different message, so this
+        // assertion is race-free.
+        assertFalse(
+            "Hyphenated Remote ID must pass validation after normalization",
+            state is SignalingClient.State.Error &&
+                (state as SignalingClient.State.Error).message.contains("Invalid Remote ID")
+        )
+        client.destroy()
+    }
+
+    @Test
+    fun `genuinely malformed id is still rejected`() {
+        val client = SignalingClient(
+            remoteId = "TOO-SHORT",
+            signalingUrl = "wss://localhost:0/ws",
+            httpClient = httpClient,
+            ownsHttpClient = false
+        )
+        client.connect()
+        val state = client.state.value
+        assertTrue(
+            "A short/malformed ID must be rejected as invalid format",
+            state is SignalingClient.State.Error &&
+                (state as SignalingClient.State.Error).message.contains("Invalid Remote ID")
+        )
+        client.destroy()
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/remote/SignalingClient.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/remote/SignalingClient.kt
@@ -72,11 +72,20 @@ import kotlinx.serialization.json.put
  *   when injecting a shared HttpClient that is managed externally.
  */
 class SignalingClient(
-    private val remoteId: String,
+    remoteId: String,
     private val signalingUrl: String = DEFAULT_SIGNALING_URL,
     private val httpClient: HttpClient = createDefaultClient(),
     private val ownsHttpClient: Boolean = true
 ) {
+
+    /**
+     * Canonical Remote ID used on the wire. MA registers the 26-char base32
+     * form with NO hyphens (derived from the WebRTC certificate fingerprint);
+     * the 8-5-5-8 hyphenated form users copy from the MA UI is display-only.
+     * Normalizing at construction makes every caller robust regardless of how
+     * the stored value was captured (paste, QR, migration, manual entry).
+     */
+    private val remoteId: String = normalizeRemoteId(remoteId)
 
     companion object {
         private const val TAG = "SignalingClient"
@@ -95,6 +104,15 @@ class SignalingClient(
                 pingIntervalSeconds = 30,
                 connectTimeoutMs = 10_000,
             )
+
+        /**
+         * Strip display formatting (hyphens, whitespace) and uppercase a Remote
+         * ID to its canonical wire form. The MA UI shows the ID grouped with
+         * hyphens (e.g. "4OPRUGEE-37BPK-SURPJ-BTU5N6SM"); the value registered
+         * on the signaling server is the ungrouped 26-char string.
+         */
+        fun normalizeRemoteId(raw: String): String =
+            raw.filter { it.isLetterOrDigit() }.uppercase()
     }
 
     /**


### PR DESCRIPTION
## Context

Investigated how MA's Remote ID flows through our WebRTC/signaling path against the upstream sources (`music-assistant/server` `webrtc_certificate.py`, the PWA `app.music-assistant.io` `broker.ts`, and `music-assistant/frontend` `RemoteAccessSettings.vue`).

**Ground truth:** MA derives the Remote ID from the WebRTC certificate fingerprint as a **26-char base32 string with no hyphens** (`b32encode(fingerprint[:16]).rstrip("=").replace("2","9")`) and registers *that* on the signaling server. The MA settings UI displays and copies it grouped **8-5-5-8** (e.g. `4OPRUGEE-37BPK-SURPJ-BTU5N6SM`), so that's the form users paste.

## Changes

- **`SignalingClient` normalizes its Remote ID at construction** (strip non-alphanumeric, uppercase). The user-facing entry paths already normalized via `RemoteConnection.parseRemoteId`, but `DefaultServerPinger.pingRemote` and `WebRTCTransport` passed the stored value straight into `SignalingClient(remoteId)`, whose validator rejects hyphens. A non-normalized stored ID (migration/import/manual) would have silently reported the server **offline**. Normalizing once at the lowest layer makes every path bulletproof.
- **`formatRemoteId` now groups 8-5-5-8** to match MA's frontend exactly (was chunked-by-5: `4OPRU-GEE37-…`), so the ID we display equals what the user copied from MA — removing "did I paste it right?" confusion.

## Tests

- `normalizeRemoteId`: real display ID → 26-char wire form, case-folding, whitespace, canonical-unchanged.
- Hyphenated display ID passes validation; genuinely malformed still rejected.
- `formatRemoteId` matches MA's 8-5-5-8 for two IDs; `format`↔`parse` round-trip.

Full app + shared suites pass (one unrelated pre-existing flaky test, `CurrentDetailDerivationTest`, passes on isolation/re-run).