### PR TITLE
feat(remote): verify SDP DTLS fingerprint against Remote ID (cert pinning)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/remote/WebRTCTransport.kt
+++ b/android/app/src/main/java/com/sendspindroid/remote/WebRTCTransport.kt
@@ -304,10 +304,24 @@ class WebRTCTransport(
     }
 
     override fun onAnswer(sdp: String) {
-        Log.d(TAG, "Setting remote description (answer)")
         val pc = peerConnection ?: return
 
-        val sessionDescription = SessionDescription(SessionDescription.Type.ANSWER, sdp)
+        // DTLS certificate pinning: the Remote ID is the server cert's SHA-256
+        // fingerprint (truncated, base32). Verify the answer's fingerprint(s)
+        // against it before accepting, so a malicious/compromised signaling
+        // server can't redirect us to an impostor peer. Fail closed.
+        val verification = RemoteCertificateVerifier.verify(remoteId, sdp)
+        val verifiedSdp = when (verification) {
+            is RemoteCertificateVerifier.Result.Verified -> verification.sanitizedSdp
+            is RemoteCertificateVerifier.Result.Rejected -> {
+                Log.e(TAG, "Rejecting answer: certificate verification failed (${verification.reason})")
+                handleError("Certificate verification failed: ${verification.reason}", isRecoverable = false)
+                return
+            }
+        }
+
+        Log.d(TAG, "Answer certificate verified; setting remote description")
+        val sessionDescription = SessionDescription(SessionDescription.Type.ANSWER, verifiedSdp)
         pc.setRemoteDescription(object : SdpObserver {
             override fun onCreateSuccess(p0: SessionDescription?) {}
             override fun onCreateFailure(p0: String?) {}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/remote/RemoteCertificateVerifierTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/remote/RemoteCertificateVerifierTest.kt
@@ -1,0 +1,146 @@
+package com.sendspindroid.remote
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Tests for [RemoteCertificateVerifier] DTLS certificate pinning.
+ *
+ * A Remote ID is `base32(certFingerprintSha256[:16])` with `2` rendered as `9`.
+ * These tests synthesize a 16-byte prefix, derive the matching Remote ID, build
+ * an SDP carrying a SHA-256 fingerprint with that prefix, and check the verifier
+ * accepts matches and rejects everything else.
+ */
+class RemoteCertificateVerifierTest {
+
+    private val base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+    /** RFC 4648 base32 encode (no padding) — inverse of the verifier's decode. */
+    private fun base32Encode(data: ByteArray): String {
+        val sb = StringBuilder()
+        var buffer = 0
+        var bits = 0
+        for (b in data) {
+            buffer = (buffer shl 8) or (b.toInt() and 0xFF)
+            bits += 8
+            while (bits >= 5) {
+                bits -= 5
+                sb.append(base32Alphabet[(buffer shr bits) and 0x1F])
+            }
+        }
+        if (bits > 0) sb.append(base32Alphabet[(buffer shl (5 - bits)) and 0x1F])
+        return sb.toString()
+    }
+
+    /** Remote ID for a 16-byte fingerprint prefix (base32, MA's 2->9). */
+    private fun remoteIdFor(prefix: ByteArray): String =
+        base32Encode(prefix).replace('2', '9')
+
+    /** Colon-separated hex SHA-256 fingerprint (32 bytes) with the given prefix. */
+    private fun fingerprintHex(prefix: ByteArray, fill: Int = 0xAB): String {
+        val full = ByteArray(32) { if (it < 16) prefix[it] else fill.toByte() }
+        return full.joinToString(":") { "%02X".format(it.toInt() and 0xFF) }
+    }
+
+    private fun sdp(vararg fingerprintLines: String): String = buildString {
+        appendLine("v=0")
+        appendLine("o=- 0 0 IN IP4 0.0.0.0")
+        appendLine("a=setup:active")
+        fingerprintLines.forEach { appendLine(it) }
+    }
+
+    // 16-byte prefix. First byte 0xD0 = 11010000 -> leading base32 group 11010
+    // = index 26 = '2', which becomes '9' in the Remote ID, so the substitution
+    // path is always exercised.
+    private val prefix = ByteArray(16) { i -> if (i == 0) 0xD0.toByte() else (i * 17 + 0x17).toByte() }
+
+    @Test
+    fun `matching fingerprint is verified`() {
+        val id = remoteIdFor(prefix)
+        val result = RemoteCertificateVerifier.verify(id, sdp("a=fingerprint:sha-256 ${fingerprintHex(prefix)}"))
+        assertTrue("expected Verified but was $result", result is RemoteCertificateVerifier.Result.Verified)
+    }
+
+    @Test
+    fun `remote id uses 9 not 2 and still verifies`() {
+        val id = remoteIdFor(prefix)
+        assertFalse("Remote ID must not contain base32 '2'", id.contains('2'))
+        assertTrue(id.contains('9')) // sanity: this prefix does produce a 9
+        assertTrue(
+            RemoteCertificateVerifier.verify(id, sdp("a=fingerprint:sha-256 ${fingerprintHex(prefix)}"))
+                is RemoteCertificateVerifier.Result.Verified
+        )
+    }
+
+    @Test
+    fun `mismatched fingerprint is rejected`() {
+        val id = remoteIdFor(prefix)
+        val tampered = prefix.copyOf().also { it[0] = (it[0] + 1).toByte() }
+        val result = RemoteCertificateVerifier.verify(id, sdp("a=fingerprint:sha-256 ${fingerprintHex(tampered)}"))
+        assertTrue(result is RemoteCertificateVerifier.Result.Rejected)
+        assertEquals("Fingerprint mismatch", (result as RemoteCertificateVerifier.Result.Rejected).reason)
+    }
+
+    @Test
+    fun `sdp without sha256 fingerprint is rejected`() {
+        val id = remoteIdFor(prefix)
+        val result = RemoteCertificateVerifier.verify(id, sdp("a=setup:active"))
+        assertTrue(result is RemoteCertificateVerifier.Result.Rejected)
+    }
+
+    @Test
+    fun `non-sha256 fingerprint is stripped and matching sha256 verifies`() {
+        val id = remoteIdFor(prefix)
+        val result = RemoteCertificateVerifier.verify(
+            id,
+            sdp(
+                "a=fingerprint:sha-1 AA:BB:CC:DD:EE:FF",
+                "a=fingerprint:sha-256 ${fingerprintHex(prefix)}"
+            )
+        )
+        assertTrue(result is RemoteCertificateVerifier.Result.Verified)
+        val sanitized = (result as RemoteCertificateVerifier.Result.Verified).sanitizedSdp
+        assertFalse("sha-1 fingerprint must be stripped", sanitized.contains("sha-1"))
+        assertTrue(sanitized.contains("sha-256"))
+    }
+
+    @Test
+    fun `any mismatched sha256 fingerprint rejects the whole sdp`() {
+        val id = remoteIdFor(prefix)
+        val other = prefix.copyOf().also { it[15] = (it[15] + 1).toByte() }
+        val result = RemoteCertificateVerifier.verify(
+            id,
+            sdp(
+                "a=fingerprint:sha-256 ${fingerprintHex(prefix)}",
+                "a=fingerprint:sha-256 ${fingerprintHex(other)}"
+            )
+        )
+        assertTrue(result is RemoteCertificateVerifier.Result.Rejected)
+    }
+
+    @Test
+    fun `empty or null sdp is rejected`() {
+        val id = remoteIdFor(prefix)
+        assertTrue(RemoteCertificateVerifier.verify(id, null) is RemoteCertificateVerifier.Result.Rejected)
+        assertTrue(RemoteCertificateVerifier.verify(id, "") is RemoteCertificateVerifier.Result.Rejected)
+    }
+
+    @Test
+    fun `malformed remote id is rejected`() {
+        // Lowercase 'l'/'0'/'1'/'8' are not in the base32 alphabet -> decode fails.
+        assertTrue(
+            RemoteCertificateVerifier.verify("0118", sdp("a=fingerprint:sha-256 ${fingerprintHex(prefix)}"))
+                is RemoteCertificateVerifier.Result.Rejected
+        )
+    }
+
+    @Test
+    fun `case-insensitive fingerprint hex still matches`() {
+        val id = remoteIdFor(prefix)
+        val lower = fingerprintHex(prefix).lowercase()
+        assertTrue(
+            RemoteCertificateVerifier.verify(id, sdp("a=fingerprint:sha-256 $lower"))
+                is RemoteCertificateVerifier.Result.Verified
+        )
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/remote/RemoteCertificateVerifier.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/remote/RemoteCertificateVerifier.kt
@@ -1,0 +1,100 @@
+package com.sendspindroid.remote
+
+/**
+ * WebRTC DTLS certificate pinning for the Remote (WebRTC) connection.
+ *
+ * A Music Assistant Remote ID *is* a custom base32 encoding (RFC 4648 alphabet
+ * with `2` rendered as `9`) of the first 16 bytes of the server certificate's
+ * SHA-256 fingerprint. Verifying the SDP answer's `a=fingerprint` line(s)
+ * against the Remote ID before accepting the connection authenticates the peer
+ * end-to-end: a malicious or compromised signaling server cannot redirect the
+ * client to an impostor, because it cannot produce a certificate whose
+ * fingerprint matches the Remote ID.
+ *
+ * Mirrors the official PWA's `crypto-utils.ts#verifyAndSanitizeSdp`
+ * (music-assistant/app.music-assistant.io).
+ */
+object RemoteCertificateVerifier {
+
+    private const val BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+    private const val FINGERPRINT_PREFIX_BYTES = 16
+
+    sealed class Result {
+        /**
+         * The peer certificate matches the Remote ID. [sanitizedSdp] is the SDP
+         * with any non-SHA-256 `a=fingerprint` lines removed and must be used
+         * for `setRemoteDescription` (algorithm-substitution defense).
+         */
+        data class Verified(val sanitizedSdp: String) : Result()
+
+        /** The SDP was rejected; [reason] explains why. Do NOT connect. */
+        data class Rejected(val reason: String) : Result()
+    }
+
+    /**
+     * Verify every SHA-256 fingerprint in [sdp] against [remoteId].
+     *
+     * @param remoteId canonical Remote ID (26-char custom base32, uppercase)
+     * @param sdp the SDP answer received from the peer via signaling
+     */
+    fun verify(remoteId: String, sdp: String?): Result {
+        if (sdp.isNullOrEmpty()) return Result.Rejected("No SDP provided")
+
+        // Remote ID uses "9" in place of base32 "2"; reverse before decoding.
+        val expected = base32DecodeOrNull(remoteId.uppercase().replace('9', '2'))
+            ?: return Result.Rejected("Invalid Remote ID encoding")
+        if (expected.size != FINGERPRINT_PREFIX_BYTES) {
+            return Result.Rejected("Invalid Remote ID length")
+        }
+
+        // Strip any non-SHA-256 fingerprint lines so a weaker advertised
+        // algorithm can't be substituted for the verified one.
+        val sanitized = sdp.replace(
+            Regex("""(?im)^a=fingerprint:(?!sha-256).*\r?\n?"""), ""
+        )
+
+        val matches = Regex(
+            """a=fingerprint:sha-256\s+([A-Fa-f0-9:]+)""",
+            RegexOption.IGNORE_CASE
+        ).findAll(sanitized).toList()
+        if (matches.isEmpty()) return Result.Rejected("No SHA-256 fingerprint in SDP")
+
+        for (match in matches) {
+            val hex = match.groupValues[1].replace(":", "")
+            if (hex.length < FINGERPRINT_PREFIX_BYTES * 2) {
+                return Result.Rejected("Malformed fingerprint")
+            }
+            for (i in 0 until FINGERPRINT_PREFIX_BYTES) {
+                val b = hex.substring(i * 2, i * 2 + 2).toIntOrNull(16)
+                    ?: return Result.Rejected("Malformed fingerprint")
+                if (b != (expected[i].toInt() and 0xFF)) {
+                    return Result.Rejected("Fingerprint mismatch")
+                }
+            }
+        }
+        return Result.Verified(sanitized)
+    }
+
+    /**
+     * Decode an RFC 4648 base32 string (no padding) to bytes, or null on an
+     * invalid character. Trailing '=' padding is tolerated.
+     */
+    private fun base32DecodeOrNull(input: String): ByteArray? {
+        val clean = input.trimEnd('=')
+        val out = ByteArray((clean.length * 5) / 8)
+        var bits = 0
+        var value = 0
+        var idx = 0
+        for (c in clean) {
+            val v = BASE32_ALPHABET.indexOf(c)
+            if (v < 0) return null
+            value = (value shl 5) or v
+            bits += 5
+            if (bits >= 8) {
+                bits -= 8
+                out[idx++] = ((value shr bits) and 0xFF).toByte()
+            }
+        }
+        return out.copyOf(idx)
+    }
+}


### PR DESCRIPTION
## Why

The MA Remote ID *is* `base32(serverCertSha256Fingerprint[:16])` (with `2` rendered as `9`). The official PWA verifies the WebRTC answer's DTLS `a=fingerprint` against the Remote ID before accepting the connection (`crypto-utils.ts#verifyAndSanitizeSdp`). Our Android client did **not** — so a malicious or compromised signaling server could redirect us to an impostor peer. This closes that gap.

A server cannot forge this: it can't present a certificate whose SHA-256 fingerprint matches the Remote ID without the corresponding private key.

## What

New `RemoteCertificateVerifier` (pure Kotlin, shared module), wired into `WebRTCTransport.onAnswer` before `setRemoteDescription`. It mirrors the PWA exactly:

- Decode the Remote ID (`9`→`2`, base32) to the expected **16-byte** fingerprint prefix; reject if it doesn't decode to 16 bytes.
- **Strip non-SHA-256** `a=fingerprint` lines (algorithm-substitution defense).
- Require ≥1 SHA-256 fingerprint and verify **every** one matches the prefix.
- Set the remote description from the **sanitized** SDP.
- **Fail closed** on any mismatch (non-recoverable — don't retry against an impostor).

## Tests

9 unit tests: match, mismatch, multi-fingerprint (any bad → reject), sanitization of sha-1, the `2`↔`9` substitution path, empty/null SDP, malformed Remote ID, case-insensitive hex.

Full app + shared suites pass.

## Notes

- Independent of #165 (different files); `WebRTCTransport` already receives the normalized Remote ID via `RemoteConnection.parseRemoteId`.
- Matches the official PWA's security posture (hard gate). Any server the PWA can reach, we can too.

Verified against `app.music-assistant.io` `crypto-utils.ts` and `music-assistant/server` `webrtc_certificate.py`.