### PR TITLE
feat(playback): pause on audio output disconnect; notes on #4a/#4b already covered

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -407,6 +407,12 @@ class PlaybackService : MediaLibraryService() {
     private var audioFocusRequest: AudioFocusRequest? = null
     private var hasAudioFocus: Boolean = false
 
+    // Receiver for ACTION_AUDIO_BECOMING_NOISY: fired when the audio output is
+    // rerouting to the built-in speaker because an external output disconnected
+    // (wired headphones unplugged, Bluetooth/Android Auto disconnected). We pause
+    // local playback so we don't abruptly blast the phone speaker.
+    private var becomingNoisyReceiver: BroadcastReceiver? = null
+
     companion object {
         private const val TAG = "PlaybackService"
 
@@ -975,6 +981,9 @@ class PlaybackService : MediaLibraryService() {
 
         // Initialize AudioManager for device volume control
         initializeVolumeControl()
+
+        // Pause local playback when the audio output device disconnects.
+        registerBecomingNoisyReceiver()
     }
 
     /**
@@ -2526,6 +2535,48 @@ class PlaybackService : MediaLibraryService() {
                 // since ducking would desync volume with other clients
             }
         }
+    }
+
+    /**
+     * Register a receiver for ACTION_AUDIO_BECOMING_NOISY so we pause when the
+     * audio output device disconnects. Idempotent.
+     */
+    private fun registerBecomingNoisyReceiver() {
+        if (becomingNoisyReceiver != null) return
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                if (intent.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+                    handleBecomingNoisy()
+                }
+            }
+        }
+        becomingNoisyReceiver = receiver
+        // System-protected broadcast; not exported (constant value is inert on
+        // API < 33, the 3-arg overload exists since API 26).
+        registerReceiver(
+            receiver,
+            IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY),
+            Context.RECEIVER_NOT_EXPORTED
+        )
+        Log.d(TAG, "Registered ACTION_AUDIO_BECOMING_NOISY receiver")
+    }
+
+    /**
+     * Handles ACTION_AUDIO_BECOMING_NOISY: the audio output is rerouting to the
+     * built-in speaker because an external output disconnected (wired headphones
+     * unplugged, Bluetooth/Android Auto disconnected). Pause local playback so we
+     * don't abruptly blast the phone speaker, matching standard media-app
+     * behavior. Pausing is local-only (we do not pause the MA group) so other
+     * grouped speakers keep playing.
+     *
+     * ACTION_AUDIO_BECOMING_NOISY is fired once by the system per transition, so
+     * it is inherently single-fire -- unlike AudioDeviceCallback.onAudioDevicesRemoved,
+     * which can fire several times for one Bluetooth device (A2DP + SCO) and
+     * would need debouncing.
+     */
+    private fun handleBecomingNoisy() {
+        Log.i(TAG, "Audio becoming noisy (output disconnected) - pausing local playback")
+        syncAudioPlayer?.pause()
     }
 
     /**
@@ -4095,6 +4146,12 @@ class PlaybackService : MediaLibraryService() {
         LocalBroadcastManager.getInstance(this).unregisterReceiver(highPowerModeReceiver)
         LocalBroadcastManager.getInstance(this).unregisterReceiver(preferredCodecReceiver)
         releaseHighPowerLocks()
+
+        // Unregister the becoming-noisy receiver (system broadcast)
+        becomingNoisyReceiver?.let {
+            runCatching { unregisterReceiver(it) }
+            becomingNoisyReceiver = null
+        }
 
         // Unregister volume observer (only if it was registered)
         if (volumeObserverRegistered) {

--- a/android/app/src/test/java/com/sendspindroid/playback/BecomingNoisyHandlingTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/playback/BecomingNoisyHandlingTest.kt
@@ -1,0 +1,45 @@
+package com.sendspindroid.playback
+
+import android.media.AudioManager
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Unit test for PlaybackService's ACTION_AUDIO_BECOMING_NOISY handling.
+ *
+ * Reproduces the receiver/handler logic (the service itself is not unit-testable
+ * on the JVM). The system fires ACTION_AUDIO_BECOMING_NOISY once when audio is
+ * about to reroute to the built-in speaker (headphones unplugged, Bluetooth or
+ * Android Auto disconnected). We pause local playback so we don't blast the
+ * phone speaker. Only that action should trigger a pause.
+ */
+class BecomingNoisyHandlingTest {
+
+    private var playerPaused = false
+
+    /** Reproduces the BroadcastReceiver.onReceive + handleBecomingNoisy logic. */
+    private fun onReceive(action: String?) {
+        if (action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+            // syncAudioPlayer?.pause()
+            playerPaused = true
+        }
+    }
+
+    @Test
+    fun `becoming noisy pauses local playback`() {
+        onReceive(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+        assertTrue("Output disconnect should pause local playback", playerPaused)
+    }
+
+    @Test
+    fun `unrelated broadcast action does not pause`() {
+        onReceive("android.intent.action.SOMETHING_ELSE")
+        assertFalse("Only ACTION_AUDIO_BECOMING_NOISY should pause", playerPaused)
+    }
+
+    @Test
+    fun `null action does not pause`() {
+        onReceive(null)
+        assertFalse(playerPaused)
+    }
+}


### PR DESCRIPTION
Follow-up to the official MA mobile-app review (the "#4" smaller patterns). Issues for the larger items: #167 (adaptive buffering), #168 (voice search), #169 (DataChannel ordering).

## What this implements — #4c: pause on output disconnect

When an external output disconnects (wired headphones unplugged, Bluetooth/Android Auto disconnected), Android reroutes audio to the built-in speaker. We had **no handling** for this — audio focus loss does *not* fire on a headphone unplug — so audio would suddenly blast the phone speaker.

Added a receiver for `ACTION_AUDIO_BECOMING_NOISY` → `syncAudioPlayer.pause()`:
- **Local-only pause** (we don't pause the MA group, so other grouped speakers keep playing).
- Registered in `onCreate`, unregistered in `onDestroy`, `RECEIVER_NOT_EXPORTED`.
- `ACTION_AUDIO_BECOMING_NOISY` is fired **once** per transition, so it's inherently single-fire — this sidesteps the multi-fire (A2DP + SCO) double-pause that the official app's `AudioDeviceCallback` approach had to debounce. Simpler and more idiomatic than copying their debounce.
- 3 unit tests (mirrors the existing `AudioFocusHandlingTest` reproduced-logic style).

## The other two #4 items were already covered

**#4b (error categorization):** We already have `FailureReason` (`TransientNetwork`, `HandshakeFailed`, `AuthRejected`, `ProtocolError`, `Exhausted`) in `coordinator/TransportState.kt`, consumed by `SendSpin.classifyFailureReason`. That's *more* granular than the official app's Transient/Permanent/Degraded for failures. No change made.

**#4a (silent re-auth):** `MusicAssistant.handleConnectionFailure` already does the core of it — `AuthenticationException` → `AuthRejected` (clears the token, emits `loginRequired`); everything else → `TransientNetwork` (preserves the token), token cleared **only** on confirmed rejection. The official app's bounded-budget-escalation is a narrow refinement, and for us escalating to "show login" after repeated *transient* (network) failures would be wrong — the token is still valid; we should keep retrying when the network returns. No change made.

So this PR is just #4c; #4a/#4b are documented as already-handled rather than reimplemented.