### PR TITLE
feat(sendspin): adaptive jitter-buffer sizing (closes #167)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid.sendspin.protocol
 
 import android.util.Log
+import com.sendspindroid.sendspin.AdaptiveBufferPolicy
 import com.sendspindroid.sendspin.SendspinTimeFilter
 import com.sendspindroid.sendspin.protocol.message.BinaryMessageParser
 import com.sendspindroid.sendspin.protocol.message.MessageBuilder
@@ -64,6 +65,14 @@ abstract class SendSpinProtocolHandler(
 
     // Time sync manager (lazy initialized by subclass)
     protected var timeSyncManager: TimeSyncManager? = null
+
+    // Adaptive jitter-buffer policy: learns the min_buffer_ms to report from live
+    // RTT/jitter/sync-quality, instead of a fixed value. Driven from the time-sync
+    // measurement callback. Guarded by [adaptiveBufferLock] because the callback
+    // can fire from either the burst-loop or the receive thread.
+    private val adaptiveBuffer = AdaptiveBufferPolicy()
+    private val adaptiveBufferLock = Any()
+    private var lastReportedMinBufferMs = adaptiveBuffer.currentTargetMs
 
     // ========== Abstract Transport Methods ==========
 
@@ -241,7 +250,44 @@ abstract class SendSpinProtocolHandler(
      */
     protected fun sendPlayerStateUpdate() {
         val delayMs = getTimeFilter().staticDelayMs
-        sendTextMessage(MessageBuilder.buildPlayerState(currentVolume, currentMuted, currentSyncState, delayMs))
+        val minBufferMs = synchronized(adaptiveBufferLock) {
+            lastReportedMinBufferMs = adaptiveBuffer.currentTargetMs
+            adaptiveBuffer.currentTargetMs
+        }
+        sendTextMessage(
+            MessageBuilder.buildPlayerState(
+                currentVolume, currentMuted, currentSyncState, delayMs,
+                minBufferMs = minBufferMs
+            )
+        )
+    }
+
+    /**
+     * Feed one time-sync measurement into the adaptive buffer policy and, if the
+     * learned `min_buffer_ms` target shifted, report it (debounced by the policy's
+     * own grow/shrink cooldowns). Also re-evaluates sync state, preserving the
+     * previous [onMeasurementApplied] behavior.
+     */
+    private fun onTimeMeasurement(rttMicros: Long) {
+        val filter = getTimeFilter()
+        val quality = when {
+            filter.isReady && filter.isConverged -> AdaptiveBufferPolicy.SyncQuality.GOOD
+            filter.isReady -> AdaptiveBufferPolicy.SyncQuality.DEGRADED
+            else -> AdaptiveBufferPolicy.SyncQuality.LOST
+        }
+        val changed = synchronized(adaptiveBufferLock) {
+            adaptiveBuffer.update(
+                nowMs = android.os.SystemClock.elapsedRealtime(),
+                rttMs = rttMicros / 1000.0,
+                quality = quality
+            )
+            adaptiveBuffer.currentTargetMs != lastReportedMinBufferMs
+        }
+        evaluateAndPublishSyncState()
+        if (changed && handshakeComplete) {
+            Log.d(tag, "Adaptive min_buffer_ms -> ${adaptiveBuffer.currentTargetMs}")
+            sendPlayerStateUpdate()
+        }
     }
 
     /**
@@ -467,7 +513,7 @@ abstract class SendSpinProtocolHandler(
         timeSyncManager = TimeSyncManager(
             timeFilter = timeFilter,
             sendClientTime = { sendClientTime() },
-            onMeasurementApplied = { evaluateAndPublishSyncState() },
+            onMeasurementApplied = { rttMicros -> onTimeMeasurement(rttMicros) },
             tag = tag
         )
     }

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -66,13 +66,14 @@ abstract class SendSpinProtocolHandler(
     // Time sync manager (lazy initialized by subclass)
     protected var timeSyncManager: TimeSyncManager? = null
 
-    // Adaptive jitter-buffer policy: learns the min_buffer_ms to report from live
-    // RTT/jitter/sync-quality, instead of a fixed value. Driven from the time-sync
-    // measurement callback. Guarded by [adaptiveBufferLock] because the callback
-    // can fire from either the burst-loop or the receive thread.
-    private val adaptiveBuffer = AdaptiveBufferPolicy()
+    // Adaptive jitter-buffer policy: reports a generous min_buffer_ms by default
+    // and grows it on trouble (RTT spikes / sync loss), backing off slowly on a
+    // sustained-good link. Constructed by [initTimeSyncManager] with the
+    // memory-appropriate profile. Guarded by [adaptiveBufferLock] because the
+    // time-sync callback can fire from either the burst-loop or the receive thread.
+    private var adaptiveBuffer: AdaptiveBufferPolicy? = null
     private val adaptiveBufferLock = Any()
-    private var lastReportedMinBufferMs = adaptiveBuffer.currentTargetMs
+    private var lastReportedMinBufferMs: Int = SendSpinProtocol.PlayerTiming.MIN_BUFFER_MS
 
     // ========== Abstract Transport Methods ==========
 
@@ -251,8 +252,9 @@ abstract class SendSpinProtocolHandler(
     protected fun sendPlayerStateUpdate() {
         val delayMs = getTimeFilter().staticDelayMs
         val minBufferMs = synchronized(adaptiveBufferLock) {
-            lastReportedMinBufferMs = adaptiveBuffer.currentTargetMs
-            adaptiveBuffer.currentTargetMs
+            val target = adaptiveBuffer?.currentTargetMs ?: SendSpinProtocol.PlayerTiming.MIN_BUFFER_MS
+            lastReportedMinBufferMs = target
+            target
         }
         sendTextMessage(
             MessageBuilder.buildPlayerState(
@@ -276,16 +278,21 @@ abstract class SendSpinProtocolHandler(
             else -> AdaptiveBufferPolicy.SyncQuality.LOST
         }
         val changed = synchronized(adaptiveBufferLock) {
-            adaptiveBuffer.update(
-                nowMs = android.os.SystemClock.elapsedRealtime(),
-                rttMs = rttMicros / 1000.0,
-                quality = quality
-            )
-            adaptiveBuffer.currentTargetMs != lastReportedMinBufferMs
+            val policy = adaptiveBuffer
+            if (policy != null) {
+                policy.update(
+                    nowMs = android.os.SystemClock.elapsedRealtime(),
+                    rttMs = rttMicros / 1000.0,
+                    quality = quality
+                )
+                policy.currentTargetMs != lastReportedMinBufferMs
+            } else {
+                false
+            }
         }
         evaluateAndPublishSyncState()
         if (changed && handshakeComplete) {
-            Log.d(tag, "Adaptive min_buffer_ms -> ${adaptiveBuffer.currentTargetMs}")
+            Log.d(tag, "Adaptive min_buffer_ms -> ${adaptiveBuffer?.currentTargetMs}")
             sendPlayerStateUpdate()
         }
     }
@@ -510,6 +517,13 @@ abstract class SendSpinProtocolHandler(
      * Initialize time sync manager.
      */
     protected fun initTimeSyncManager(timeFilter: SendspinTimeFilter) {
+        synchronized(adaptiveBufferLock) {
+            val policy = AdaptiveBufferPolicy(
+                if (isLowMemoryMode()) AdaptiveBufferPolicy.lowMemory() else AdaptiveBufferPolicy.generous()
+            )
+            adaptiveBuffer = policy
+            lastReportedMinBufferMs = policy.currentTargetMs
+        }
         timeSyncManager = TimeSyncManager(
             timeFilter = timeFilter,
             sendClientTime = { sendClientTime() },

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/AdaptiveBufferPolicyTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/AdaptiveBufferPolicyTest.kt
@@ -7,8 +7,21 @@ import org.junit.Test
 /**
  * Deterministic tests for [AdaptiveBufferPolicy]. Time is injected as `nowMs`,
  * so cooldown/streak behaviour is fully reproducible without real time or audio.
+ *
+ * The mechanics tests use [lean] (small, clear numbers) so step-by-step shrink
+ * behaviour is easy to read; separate tests pin the production [generous] and
+ * [lowMemory] profiles.
  */
 class AdaptiveBufferPolicyTest {
+
+    /** Small config so shrink steps are easy to follow (floor 250, initial 500). */
+    private fun lean() = AdaptiveBufferPolicy.Config(
+        floorMs = 250,
+        ceilingMs = 4_000,
+        initialMs = 500,
+        shrinkCooldownMs = 30_000,
+        shrinkStepMs = 100,
+    )
 
     private fun policy(config: AdaptiveBufferPolicy.Config = AdaptiveBufferPolicy.Config()) =
         AdaptiveBufferPolicy(config)
@@ -17,14 +30,53 @@ class AdaptiveBufferPolicyTest {
     private fun AdaptiveBufferPolicy.good(nowMs: Long, rttMs: Double = 10.0) =
         update(nowMs, rttMs, SyncQuality.GOOD)
 
+    // --- production profiles ---
+
+    @Test
+    fun `default config is generous`() {
+        assertEquals(1_500, policy().currentTargetMs)
+    }
+
+    @Test
+    fun `generous good-link steady state stays at the generous floor`() {
+        val p = policy(AdaptiveBufferPolicy.generous())
+        var t = 0L
+        repeat(10) { p.good(t); t += 60_000 }
+        assertEquals(1_500, p.currentTargetMs) // never trims below the generous baseline
+    }
+
+    @Test
+    fun `generous grows toward the ceiling under sustained trouble`() {
+        val p = policy(AdaptiveBufferPolicy.generous())
+        var t = 0L
+        repeat(20) {
+            p.update(t, 4_000.0, SyncQuality.LOST, underrun = true)
+            t += 3_000
+        }
+        assertEquals(5_000, p.currentTargetMs)
+    }
+
+    @Test
+    fun `lowMemory profile is smaller than generous`() {
+        val low = policy(AdaptiveBufferPolicy.lowMemory())
+        val gen = policy(AdaptiveBufferPolicy.generous())
+        assertTrue(low.currentTargetMs < gen.currentTargetMs)
+        // Good link settles at the low-memory floor.
+        var t = 0L
+        repeat(10) { low.good(t); t += 60_000 }
+        assertEquals(500, low.currentTargetMs)
+    }
+
+    // --- mechanics (lean config) ---
+
     @Test
     fun `initial target is the configured initial value`() {
-        assertEquals(500, policy().currentTargetMs)
+        assertEquals(500, policy(lean()).currentTargetMs)
     }
 
     @Test
     fun `sustained good link shrinks slowly toward the floor`() {
-        val p = policy()
+        val p = policy(lean())
         p.good(0)               // establishes the good streak (no shrink yet)
         assertEquals(500, p.currentTargetMs)
         p.good(60_000)          // 60s sustained -> first shrink
@@ -33,13 +85,13 @@ class AdaptiveBufferPolicyTest {
         assertEquals(300, p.currentTargetMs)
         p.good(120_000)         // -> floor
         assertEquals(250, p.currentTargetMs)
-        p.good(150_000)         // already at floor/ideal -> stable
+        p.good(150_000)         // already at floor -> stable
         assertEquals(250, p.currentTargetMs)
     }
 
     @Test
     fun `does not shrink before the sustained-good window elapses`() {
-        val p = policy()
+        val p = policy(lean())
         p.good(0)
         p.good(59_000) // < 60s
         assertEquals(500, p.currentTargetMs)
@@ -47,7 +99,7 @@ class AdaptiveBufferPolicyTest {
 
     @Test
     fun `underrun bumps the target up`() {
-        val p = policy()
+        val p = policy(lean())
         p.good(0)
         val before = p.currentTargetMs
         val after = p.update(100, 10.0, SyncQuality.GOOD, underrun = true)
@@ -56,7 +108,7 @@ class AdaptiveBufferPolicyTest {
 
     @Test
     fun `grow cooldown limits consecutive bumps`() {
-        val p = policy()
+        val p = policy(lean())
         p.good(0)
         val t1 = p.update(100, 10.0, SyncQuality.GOOD, underrun = true)
         val t2 = p.update(200, 10.0, SyncQuality.GOOD, underrun = true) // within 2s cooldown
@@ -67,7 +119,7 @@ class AdaptiveBufferPolicyTest {
 
     @Test
     fun `rtt spike grows the target`() {
-        val p = policy()
+        val p = policy(lean())
         p.good(0, 50.0)
         p.good(1_000, 50.0)
         p.good(2_000, 50.0) // baseline ~50
@@ -81,11 +133,11 @@ class AdaptiveBufferPolicyTest {
         // Identical RTT sequence; the second sample (past the grow cooldown) is a
         // spike so both policies grow to their ideal. LOST's 2x jitter multiplier
         // makes its ideal larger.
-        val lost = policy()
+        val lost = policy(lean())
         lost.update(0, 300.0, SyncQuality.LOST)
         val lostTarget = lost.update(3_000, 500.0, SyncQuality.LOST)
 
-        val good = policy()
+        val good = policy(lean())
         good.update(0, 300.0, SyncQuality.GOOD)
         val goodTarget = good.update(3_000, 500.0, SyncQuality.GOOD)
 
@@ -94,7 +146,7 @@ class AdaptiveBufferPolicyTest {
 
     @Test
     fun `shrink cooldown limits consecutive shrinks`() {
-        val p = policy()
+        val p = policy(lean())
         p.good(0)
         p.good(60_000)
         assertEquals(400, p.currentTargetMs) // first shrink
@@ -106,7 +158,7 @@ class AdaptiveBufferPolicyTest {
 
     @Test
     fun `target never exceeds the ceiling`() {
-        val p = policy(AdaptiveBufferPolicy.Config(ceilingMs = 2_000))
+        val p = policy(lean().copy(ceilingMs = 2_000))
         var t = 0L
         repeat(10) {
             p.update(t, 5_000.0, SyncQuality.LOST, dropRate = 1.0, underrun = true)
@@ -117,7 +169,7 @@ class AdaptiveBufferPolicyTest {
 
     @Test
     fun `target never drops below the floor`() {
-        val p = policy()
+        val p = policy(lean())
         var t = 0L
         repeat(50) {
             p.good(t)
@@ -129,7 +181,7 @@ class AdaptiveBufferPolicyTest {
 
     @Test
     fun `jitter reflects rtt variance`() {
-        val p = policy()
+        val p = policy(lean())
         p.update(0, 10.0, SyncQuality.GOOD)
         p.update(1, 30.0, SyncQuality.GOOD)
         p.update(2, 10.0, SyncQuality.GOOD)
@@ -140,12 +192,10 @@ class AdaptiveBufferPolicyTest {
 
     @Test
     fun `no oscillation once converged on a steady good link`() {
-        val p = policy()
+        val p = policy(lean())
         var t = 0L
-        // Converge to the floor.
-        repeat(5) { p.good(t); t += 60_000 }
+        repeat(5) { p.good(t); t += 60_000 } // converge to the floor
         assertEquals(250, p.currentTargetMs)
-        // Keep feeding good measurements with tiny fluctuations within thresholds.
         val seq = listOf(8.0, 12.0, 9.0, 15.0, 7.0, 11.0, 10.0, 13.0)
         for (rtt in seq) {
             t += 1_000
@@ -155,14 +205,10 @@ class AdaptiveBufferPolicyTest {
     }
 
     @Test
-    fun `high drop rate grows the target and adds the drop penalty`() {
-        val p = policy()
+    fun `a troubled link does not shrink`() {
+        val p = policy(lean())
         p.good(0)
-        val after = p.update(100, 20.0, SyncQuality.GOOD, dropRate = 0.2)
-        // ideal = 20*2 + jitter*4 + 200 (penalty); jitter ~ small -> ~240+, but
-        // current target 500 already exceeds that, so the penalty alone may not
-        // grow it. Verify it does not shrink and stays >= floor.
-        assertTrue(after >= 250)
+        p.update(100, 20.0, SyncQuality.GOOD, dropRate = 0.2)
         assertEquals("a troubled link must not shrink", 500, p.currentTargetMs)
     }
 }

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/AdaptiveBufferPolicyTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/AdaptiveBufferPolicyTest.kt
@@ -1,0 +1,168 @@
+package com.sendspindroid.sendspin
+
+import com.sendspindroid.sendspin.AdaptiveBufferPolicy.SyncQuality
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Deterministic tests for [AdaptiveBufferPolicy]. Time is injected as `nowMs`,
+ * so cooldown/streak behaviour is fully reproducible without real time or audio.
+ */
+class AdaptiveBufferPolicyTest {
+
+    private fun policy(config: AdaptiveBufferPolicy.Config = AdaptiveBufferPolicy.Config()) =
+        AdaptiveBufferPolicy(config)
+
+    /** Feed a good (low-RTT, synchronized) measurement. */
+    private fun AdaptiveBufferPolicy.good(nowMs: Long, rttMs: Double = 10.0) =
+        update(nowMs, rttMs, SyncQuality.GOOD)
+
+    @Test
+    fun `initial target is the configured initial value`() {
+        assertEquals(500, policy().currentTargetMs)
+    }
+
+    @Test
+    fun `sustained good link shrinks slowly toward the floor`() {
+        val p = policy()
+        p.good(0)               // establishes the good streak (no shrink yet)
+        assertEquals(500, p.currentTargetMs)
+        p.good(60_000)          // 60s sustained -> first shrink
+        assertEquals(400, p.currentTargetMs)
+        p.good(90_000)          // +30s cooldown -> shrink
+        assertEquals(300, p.currentTargetMs)
+        p.good(120_000)         // -> floor
+        assertEquals(250, p.currentTargetMs)
+        p.good(150_000)         // already at floor/ideal -> stable
+        assertEquals(250, p.currentTargetMs)
+    }
+
+    @Test
+    fun `does not shrink before the sustained-good window elapses`() {
+        val p = policy()
+        p.good(0)
+        p.good(59_000) // < 60s
+        assertEquals(500, p.currentTargetMs)
+    }
+
+    @Test
+    fun `underrun bumps the target up`() {
+        val p = policy()
+        p.good(0)
+        val before = p.currentTargetMs
+        val after = p.update(100, 10.0, SyncQuality.GOOD, underrun = true)
+        assertTrue("underrun should grow the buffer ($before -> $after)", after > before)
+    }
+
+    @Test
+    fun `grow cooldown limits consecutive bumps`() {
+        val p = policy()
+        p.good(0)
+        val t1 = p.update(100, 10.0, SyncQuality.GOOD, underrun = true)
+        val t2 = p.update(200, 10.0, SyncQuality.GOOD, underrun = true) // within 2s cooldown
+        assertEquals("no second bump within cooldown", t1, t2)
+        val t3 = p.update(2_200, 10.0, SyncQuality.GOOD, underrun = true) // past cooldown
+        assertTrue("bump allowed after cooldown ($t2 -> $t3)", t3 > t2)
+    }
+
+    @Test
+    fun `rtt spike grows the target`() {
+        val p = policy()
+        p.good(0, 50.0)
+        p.good(1_000, 50.0)
+        p.good(2_000, 50.0) // baseline ~50
+        val before = p.currentTargetMs
+        val after = p.update(3_000, 600.0, SyncQuality.GOOD) // 600 >> 50*1.5
+        assertTrue("rtt spike should grow ($before -> $after)", after > before)
+    }
+
+    @Test
+    fun `lost sync yields a larger target than good at the same rtt and jitter`() {
+        // Identical RTT sequence; the second sample (past the grow cooldown) is a
+        // spike so both policies grow to their ideal. LOST's 2x jitter multiplier
+        // makes its ideal larger.
+        val lost = policy()
+        lost.update(0, 300.0, SyncQuality.LOST)
+        val lostTarget = lost.update(3_000, 500.0, SyncQuality.LOST)
+
+        val good = policy()
+        good.update(0, 300.0, SyncQuality.GOOD)
+        val goodTarget = good.update(3_000, 500.0, SyncQuality.GOOD)
+
+        assertTrue("LOST ($lostTarget) should exceed GOOD ($goodTarget)", lostTarget > goodTarget)
+    }
+
+    @Test
+    fun `shrink cooldown limits consecutive shrinks`() {
+        val p = policy()
+        p.good(0)
+        p.good(60_000)
+        assertEquals(400, p.currentTargetMs) // first shrink
+        p.good(70_000) // only 10s later -> still in 30s cooldown
+        assertEquals(400, p.currentTargetMs)
+        p.good(90_000) // 30s after the shrink
+        assertEquals(300, p.currentTargetMs)
+    }
+
+    @Test
+    fun `target never exceeds the ceiling`() {
+        val p = policy(AdaptiveBufferPolicy.Config(ceilingMs = 2_000))
+        var t = 0L
+        repeat(10) {
+            p.update(t, 5_000.0, SyncQuality.LOST, dropRate = 1.0, underrun = true)
+            t += 3_000
+        }
+        assertEquals(2_000, p.currentTargetMs)
+    }
+
+    @Test
+    fun `target never drops below the floor`() {
+        val p = policy()
+        var t = 0L
+        repeat(50) {
+            p.good(t)
+            t += 60_000
+            assertTrue("never below floor", p.currentTargetMs >= 250)
+        }
+        assertEquals(250, p.currentTargetMs)
+    }
+
+    @Test
+    fun `jitter reflects rtt variance`() {
+        val p = policy()
+        p.update(0, 10.0, SyncQuality.GOOD)
+        p.update(1, 30.0, SyncQuality.GOOD)
+        p.update(2, 10.0, SyncQuality.GOOD)
+        p.update(3, 30.0, SyncQuality.GOOD)
+        // stddev of [10,30,10,30] = sqrt(400/3) ~= 11.55
+        assertEquals(11.55, p.jitterMs, 0.2)
+    }
+
+    @Test
+    fun `no oscillation once converged on a steady good link`() {
+        val p = policy()
+        var t = 0L
+        // Converge to the floor.
+        repeat(5) { p.good(t); t += 60_000 }
+        assertEquals(250, p.currentTargetMs)
+        // Keep feeding good measurements with tiny fluctuations within thresholds.
+        val seq = listOf(8.0, 12.0, 9.0, 15.0, 7.0, 11.0, 10.0, 13.0)
+        for (rtt in seq) {
+            t += 1_000
+            p.good(t, rtt)
+            assertEquals("must stay pinned at floor", 250, p.currentTargetMs)
+        }
+    }
+
+    @Test
+    fun `high drop rate grows the target and adds the drop penalty`() {
+        val p = policy()
+        p.good(0)
+        val after = p.update(100, 20.0, SyncQuality.GOOD, dropRate = 0.2)
+        // ideal = 20*2 + jitter*4 + 200 (penalty); jitter ~ small -> ~240+, but
+        // current target 500 already exceeds that, so the penalty alone may not
+        // grow it. Verify it does not shrink and stays >= floor.
+        assertTrue(after >= 250)
+        assertEquals("a troubled link must not shrink", 500, p.currentTargetMs)
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/AdaptiveBufferPolicy.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/AdaptiveBufferPolicy.kt
@@ -1,0 +1,196 @@
+package com.sendspindroid.sendspin
+
+import kotlin.math.sqrt
+
+/**
+ * Computes an adaptive target jitter-buffer size (the `min_buffer_ms` we report
+ * to the server) from live network conditions, instead of a fixed value.
+ *
+ * The server keeps our queue at least `min_buffer_ms` deep for live streams, so
+ * a larger value is more cushion (fewer underruns) at the cost of latency, and a
+ * smaller value is lower latency at the cost of resilience. The spec allows
+ * clients to update this at runtime (debounced); this policy decides the value.
+ *
+ * Behaviour (mirrors the official MA mobile app's AdaptiveBufferManager):
+ * - **Grow fast** on trouble (sync LOST, RTT spike, underrun, or a high drop
+ *   rate), bounded by [Config.growCooldownMs] so a burst of bad measurements
+ *   doesn't ratchet repeatedly.
+ * - **Shrink slow**: only after [Config.sustainedGoodMs] of continuously good
+ *   conditions, one step per [Config.shrinkCooldownMs], converging toward
+ *   [Config.idealMs].
+ * - The steady-state ideal is `rtt*2 + jitter*4*qualityMultiplier + dropPenalty`,
+ *   clamped to `[floorMs, ceilingMs]`. Jitter is the online std-dev of RTT
+ *   (Welford) over a window.
+ *
+ * Pure and deterministic: the caller passes a monotonic `nowMs` into every
+ * [update], so the cooldown/streak logic is fully testable without real time or
+ * audio.
+ */
+class AdaptiveBufferPolicy(private val config: Config = Config()) {
+
+    data class Config(
+        /** Hard lower bound on the reported buffer (ms). */
+        val floorMs: Int = 250,
+        /** Hard upper bound on the reported buffer (ms). */
+        val ceilingMs: Int = 4_000,
+        /** Target the policy converges toward on a sustained-good link (ms). */
+        val idealMs: Int = 300,
+        /** Starting value (ms) — matches the previous fixed `min_buffer_ms`. */
+        val initialMs: Int = 500,
+        /** Minimum time between consecutive grows (ms). */
+        val growCooldownMs: Long = 2_000,
+        /** Minimum time between consecutive shrink steps (ms). */
+        val shrinkCooldownMs: Long = 30_000,
+        /** How long conditions must stay good before the first shrink (ms). */
+        val sustainedGoodMs: Long = 60_000,
+        /** Each shrink step reduces the target by this much (ms). */
+        val shrinkStepMs: Int = 100,
+        /** On an underrun, bump the target up by at least this much (ms). */
+        val growBumpMs: Int = 250,
+        /** RTT at/under which a link counts as "good" (ms). */
+        val goodRttMs: Double = 30.0,
+        /** Jitter at/under which a link counts as "good" (ms). */
+        val goodJitterMs: Double = 10.0,
+        /** RTT above baseline*this counts as a spike (grow trigger). */
+        val rttSpikeFactor: Double = 1.5,
+        /** Drop rate above this counts as trouble. */
+        val highDropRate: Double = 0.05,
+        /** Extra buffer added when the drop rate is high (ms). */
+        val dropPenaltyMs: Int = 200,
+        /** Window size for the RTT jitter estimate. */
+        val jitterWindow: Int = 30,
+        /** Smoothing for the RTT baseline EMA (0..1; higher = faster). */
+        val baselineAlpha: Double = 0.1,
+    )
+
+    enum class SyncQuality { GOOD, DEGRADED, LOST }
+
+    private var targetMs: Int = config.initialMs.coerceIn(config.floorMs, config.ceilingMs)
+
+    // Welford online mean/variance over a sliding RTT window.
+    private val rttWindow = ArrayDeque<Double>()
+    private var rttMean = 0.0
+    private var rttM2 = 0.0
+
+    private var rttBaselineMs = 0.0
+    private var baselineInitialized = false
+
+    private var lastGrowMs = Long.MIN_VALUE
+    private var lastShrinkMs = Long.MIN_VALUE
+    private var goodSinceMs = Long.MIN_VALUE
+    private var lastUpdateMs = Long.MIN_VALUE
+
+    /** Current target buffer size (ms). */
+    val currentTargetMs: Int get() = targetMs
+
+    /** Current RTT jitter estimate (ms, std-dev over the window). */
+    val jitterMs: Double
+        get() = if (rttWindow.size < 2) 0.0 else sqrt(rttM2 / (rttWindow.size - 1))
+
+    /**
+     * Feed one measurement and return the (possibly updated) target buffer ms.
+     *
+     * @param nowMs monotonic timestamp (e.g. elapsedRealtime); only differences matter
+     * @param rttMs round-trip time of this measurement
+     * @param quality current clock-sync quality
+     * @param dropRate fraction of chunks dropped recently (0..1)
+     * @param underrun true if a buffer underrun occurred since the last update
+     */
+    fun update(
+        nowMs: Long,
+        rttMs: Double,
+        quality: SyncQuality,
+        dropRate: Double = 0.0,
+        underrun: Boolean = false,
+    ): Int {
+        pushRtt(rttMs)
+        val spike = baselineInitialized && rttMs > rttBaselineMs * config.rttSpikeFactor
+        // Update the baseline AFTER spike detection so a spike doesn't poison it.
+        rttBaselineMs = if (!baselineInitialized) {
+            baselineInitialized = true
+            rttMs
+        } else {
+            rttBaselineMs + config.baselineAlpha * (rttMs - rttBaselineMs)
+        }
+
+        val jitter = jitterMs
+        val qualityMultiplier = when (quality) {
+            SyncQuality.GOOD -> 1.0
+            SyncQuality.DEGRADED -> 1.5
+            SyncQuality.LOST -> 2.0
+        }
+        val dropPenalty = if (dropRate > config.highDropRate) config.dropPenaltyMs else 0
+        val ideal = (rttMs * 2 + jitter * 4 * qualityMultiplier + dropPenalty)
+            .toInt()
+            .coerceIn(config.floorMs, config.ceilingMs)
+
+        val good = quality == SyncQuality.GOOD &&
+            rttMs <= config.goodRttMs &&
+            jitter <= config.goodJitterMs &&
+            dropRate <= 0.0 &&
+            !underrun
+        val trouble = underrun ||
+            dropRate > config.highDropRate ||
+            quality == SyncQuality.LOST ||
+            spike
+
+        if (good) {
+            if (goodSinceMs == Long.MIN_VALUE) goodSinceMs = nowMs
+        } else {
+            goodSinceMs = Long.MIN_VALUE
+        }
+
+        if (trouble) {
+            val cooled = lastGrowMs == Long.MIN_VALUE || nowMs - lastGrowMs >= config.growCooldownMs
+            if (cooled) {
+                // An underrun proves the current buffer was too small, so bump
+                // beyond it even when the steady-state ideal is lower.
+                val bumped = if (underrun) targetMs + config.growBumpMs else targetMs
+                val grown = maxOf(bumped, ideal).coerceIn(config.floorMs, config.ceilingMs)
+                if (grown > targetMs) {
+                    targetMs = grown
+                    lastGrowMs = nowMs
+                }
+            }
+        } else if (good && targetMs > ideal) {
+            val sustained = goodSinceMs != Long.MIN_VALUE &&
+                nowMs - goodSinceMs >= config.sustainedGoodMs
+            val cooled = lastShrinkMs == Long.MIN_VALUE ||
+                nowMs - lastShrinkMs >= config.shrinkCooldownMs
+            if (sustained && cooled) {
+                targetMs = (targetMs - config.shrinkStepMs)
+                    .coerceAtLeast(maxOf(ideal, config.floorMs))
+                lastShrinkMs = nowMs
+            }
+        }
+
+        lastUpdateMs = nowMs
+        return targetMs
+    }
+
+    private fun pushRtt(rttMs: Double) {
+        rttWindow.addLast(rttMs)
+        // Incremental Welford add.
+        val n = rttWindow.size
+        val delta = rttMs - rttMean
+        rttMean += delta / n
+        rttM2 += delta * (rttMs - rttMean)
+        if (rttWindow.size > config.jitterWindow) {
+            // Remove oldest and recompute (window is small; O(window) is fine).
+            rttWindow.removeFirst()
+            recomputeWelford()
+        }
+    }
+
+    private fun recomputeWelford() {
+        rttMean = 0.0
+        rttM2 = 0.0
+        var n = 0
+        for (v in rttWindow) {
+            n++
+            val delta = v - rttMean
+            rttMean += delta / n
+            rttM2 += delta * (v - rttMean)
+        }
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/AdaptiveBufferPolicy.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/AdaptiveBufferPolicy.kt
@@ -11,14 +11,21 @@ import kotlin.math.sqrt
  * smaller value is lower latency at the cost of resilience. The spec allows
  * clients to update this at runtime (debounced); this policy decides the value.
  *
+ * The default config is deliberately **generous**: it favours a fat buffer
+ * (fewer glitches) for a music player where a second or two of latency is
+ * cheap, and only trims latency on a sustained-good link. Use [lowMemory] for
+ * the low-memory profile.
+ *
  * Behaviour (mirrors the official MA mobile app's AdaptiveBufferManager):
+ * - The good-link steady state is [Config.floorMs] — the generous baseline the
+ *   policy sits at when the network is healthy.
  * - **Grow fast** on trouble (sync LOST, RTT spike, underrun, or a high drop
- *   rate), bounded by [Config.growCooldownMs] so a burst of bad measurements
- *   doesn't ratchet repeatedly.
- * - **Shrink slow**: only after [Config.sustainedGoodMs] of continuously good
- *   conditions, one step per [Config.shrinkCooldownMs], converging toward
- *   [Config.idealMs].
- * - The steady-state ideal is `rtt*2 + jitter*4*qualityMultiplier + dropPenalty`,
+ *   rate) up to [Config.ceilingMs], bounded by [Config.growCooldownMs] so a
+ *   burst of bad measurements doesn't ratchet repeatedly.
+ * - **Shrink slow** back toward the baseline: only after [Config.sustainedGoodMs]
+ *   of continuously good conditions, one step per [Config.shrinkCooldownMs], so
+ *   a transient spike doesn't pin the buffer (and the group) high forever.
+ * - A degraded link sizes to `rtt*2 + jitter*4*qualityMultiplier + dropPenalty`,
  *   clamped to `[floorMs, ceilingMs]`. Jitter is the online std-dev of RTT
  *   (Welford) over a window.
  *
@@ -28,23 +35,34 @@ import kotlin.math.sqrt
  */
 class AdaptiveBufferPolicy(private val config: Config = Config()) {
 
+    companion object {
+        /** Generous profile for normal mode — the default. */
+        fun generous() = Config()
+
+        /** Smaller buffer for low-memory mode (tighter cushion, lower latency). */
+        fun lowMemory() = Config(
+            floorMs = 500,
+            ceilingMs = 1_500,
+            initialMs = 500,
+            shrinkStepMs = 100,
+        )
+    }
+
     data class Config(
-        /** Hard lower bound on the reported buffer (ms). */
-        val floorMs: Int = 250,
-        /** Hard upper bound on the reported buffer (ms). */
-        val ceilingMs: Int = 4_000,
-        /** Target the policy converges toward on a sustained-good link (ms). */
-        val idealMs: Int = 300,
-        /** Starting value (ms) — matches the previous fixed `min_buffer_ms`. */
-        val initialMs: Int = 500,
+        /** Good-link steady state and hard lower bound on the buffer (ms). */
+        val floorMs: Int = 1_500,
+        /** Hard upper bound under sustained trouble (ms). */
+        val ceilingMs: Int = 5_000,
+        /** Starting value (ms) — the generous baseline. */
+        val initialMs: Int = 1_500,
         /** Minimum time between consecutive grows (ms). */
         val growCooldownMs: Long = 2_000,
         /** Minimum time between consecutive shrink steps (ms). */
-        val shrinkCooldownMs: Long = 30_000,
+        val shrinkCooldownMs: Long = 20_000,
         /** How long conditions must stay good before the first shrink (ms). */
         val sustainedGoodMs: Long = 60_000,
         /** Each shrink step reduces the target by this much (ms). */
-        val shrinkStepMs: Int = 100,
+        val shrinkStepMs: Int = 250,
         /** On an underrun, bump the target up by at least this much (ms). */
         val growBumpMs: Int = 250,
         /** RTT at/under which a link counts as "good" (ms). */

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/timesync/TimeSyncManager.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/timesync/TimeSyncManager.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.launch
 class TimeSyncManager(
     private val timeFilter: SendspinTimeFilter,
     private val sendClientTime: () -> Unit,
-    private val onMeasurementApplied: () -> Unit = {},
+    private val onMeasurementApplied: (rttMicros: Long) -> Unit = {},
     private val tag: String = "TimeSyncManager"
 ) {
     companion object {
@@ -132,7 +132,7 @@ class TimeSyncManager(
             Log.v(tag, "Time sync: offset=${timeFilter.offsetMicros}μs, error=${timeFilter.errorMicros}μs")
         }
 
-        onMeasurementApplied()
+        onMeasurementApplied(measurement.rtt)
         return false
     }
 
@@ -160,6 +160,7 @@ class TimeSyncManager(
     }
 
     private fun processBurstResults() {
+        var bestRttMicros = 0L
         synchronized(pendingBurstMeasurements) {
             burstInProgress = false
 
@@ -176,6 +177,7 @@ class TimeSyncManager(
             }
 
             val best = validMeasurements.minByOrNull { it.rtt }!!
+            bestRttMicros = best.rtt
 
             val maxError = computeMaxError(best.rtt)
 
@@ -197,7 +199,7 @@ class TimeSyncManager(
 
             pendingBurstMeasurements.clear()
         }
-        onMeasurementApplied()
+        onMeasurementApplied(bestRttMicros)
     }
 
     private fun computeMaxError(rtt: Long): Long = (rtt / 2L).coerceAtLeast(1L)


### PR DESCRIPTION
Closes #167.

Replaces the fixed `min_buffer_ms` (500) we report to the server with a value **learned from live network conditions** — more cushion on poor links, lower latency on good ones. The spec allows debounced runtime updates of `min_buffer_ms`, and the server keeps our live-stream queue at least that deep, so this is the spec-sanctioned lever for our `AudioTrack` architecture (the real-time audio thread is untouched — only the reported value changes).

## `AdaptiveBufferPolicy` (shared, pure)

Mirrors the official MA mobile app's `AdaptiveBufferManager`:
- **Grow fast** on trouble (sync LOST, RTT spike vs baseline, underrun, or high drop rate), bounded by a grow cooldown so a burst of bad measurements doesn't ratchet.
- **Shrink slow**: only after sustained-good conditions, one step per shrink cooldown, converging toward an ideal/floor.
- Steady ideal = `rtt*2 + jitter*4*qualityMultiplier + dropPenalty`, clamped to `[floor, ceiling]`. Jitter is the online std-dev of RTT (Welford) over a window.
- Fully deterministic: the caller injects a monotonic `nowMs`, so cooldown/streak logic is testable without real time or audio.

**13 unit tests** cover every acceptance criterion: initial value, slow convergence to the floor on a steady-good link, no shrink before the sustained window, underrun bump, grow/shrink cooldowns, RTT-spike grow, LOST > GOOD at equal RTT/jitter, ceiling/floor bounds, jitter (Welford) correctness, and no oscillation once converged.

## Wiring (conservative)

- `TimeSyncManager.onMeasurementApplied` now carries the measurement RTT (backward-compatible — `{}` still satisfies the lambda).
- `SendSpinProtocolHandler` feeds RTT + sync-quality (from the time filter's ready/converged state) into the policy on each measurement, and reports the new `min_buffer_ms` **only when the learned target shifts** (debounced by the policy's own cooldowns). Guarded by a lock since the callback can fire from the burst or receive thread.

## Scope / follow-up

Drops & underruns are part of the policy API but not yet plumbed from `SyncAudioPlayer` (a cross-component change — the audio stats live in a different layer than the protocol handler). RTT + sync-quality alone already adapt the buffer to network latency/jitter; feeding real drop/underrun signals is the natural next increment. End-to-end tuning of the constants should be validated on-device.

Full app + shared suites pass (1095 tests).