### PR TITLE
fix(connect): re-resolve saved local server address via mDNS (#158)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/UnifiedServerRepository.kt
+++ b/android/app/src/main/java/com/sendspindroid/UnifiedServerRepository.kt
@@ -280,28 +280,43 @@ object UnifiedServerRepository {
 
     /**
      * Keep a saved server's stored local address current when the server is seen
-     * via mDNS at a different address (e.g. after a DHCP lease change). Matches a
-     * saved server by [name] and updates its local address only if it differs.
+     * via mDNS at a different address (e.g. after a DHCP lease change). Updates the
+     * first saved server whose [name] matches (and whose [local] address differs),
+     * only if it differs.
      *
      * This keeps auto-connect resilient to the server's IP changing: the reported
      * bug (#158) was auto-connect dialing a stale stored address while the server
      * was reachable, and discoverable, at a new one.
      *
+     * Matching is by name: it depends on the saved server's name still equaling
+     * the server's advertised mDNS friendly name. A renamed saved server, or two
+     * saved servers sharing a name (only the first is updated), won't fully match.
+     *
+     * Uses an atomic [MutableStateFlow.update] because this is reached from mDNS
+     * discovery callbacks on a background thread (see [removeDiscoveredServer]).
+     *
      * @return true if a saved server's address was updated.
      */
     fun refreshSavedServerAddress(name: String, address: String): Boolean {
         ensurePersistedDataLoaded()
-        val current = _savedServers.value.toMutableList()
-        val index = current.indexOfFirst {
-            it.name == name && it.local != null && it.local!!.address != address
+        var oldAddress: String? = null
+        _savedServers.update { current ->
+            val index = current.indexOfFirst {
+                it.name == name && it.local != null && it.local!!.address != address
+            }
+            if (index < 0) {
+                current
+            } else {
+                val server = current[index]
+                oldAddress = server.local!!.address
+                current.toMutableList().also {
+                    it[index] = server.copy(local = server.local!!.copy(address = address))
+                }
+            }
         }
-        if (index < 0) return false
-        val server = current[index]
-        val oldAddress = server.local!!.address
-        current[index] = server.copy(local = server.local!!.copy(address = address))
-        _savedServers.value = current
+        val previous = oldAddress ?: return false
         persistServers()
-        Log.i(TAG, "Refreshed saved server '$name' address: $oldAddress -> $address (mDNS)")
+        Log.i(TAG, "Refreshed saved server '$name' address: $previous -> $address (mDNS)")
         return true
     }
 

--- a/android/app/src/main/java/com/sendspindroid/UnifiedServerRepository.kt
+++ b/android/app/src/main/java/com/sendspindroid/UnifiedServerRepository.kt
@@ -274,6 +274,35 @@ object UnifiedServerRepository {
                 current + server
             }
         }
+        // Keep any matching saved server's stored address current (DHCP resilience).
+        refreshSavedServerAddress(name, address)
+    }
+
+    /**
+     * Keep a saved server's stored local address current when the server is seen
+     * via mDNS at a different address (e.g. after a DHCP lease change). Matches a
+     * saved server by [name] and updates its local address only if it differs.
+     *
+     * This keeps auto-connect resilient to the server's IP changing: the reported
+     * bug (#158) was auto-connect dialing a stale stored address while the server
+     * was reachable, and discoverable, at a new one.
+     *
+     * @return true if a saved server's address was updated.
+     */
+    fun refreshSavedServerAddress(name: String, address: String): Boolean {
+        ensurePersistedDataLoaded()
+        val current = _savedServers.value.toMutableList()
+        val index = current.indexOfFirst {
+            it.name == name && it.local != null && it.local!!.address != address
+        }
+        if (index < 0) return false
+        val server = current[index]
+        val oldAddress = server.local!!.address
+        current[index] = server.copy(local = server.local!!.copy(address = address))
+        _savedServers.value = current
+        persistServers()
+        Log.i(TAG, "Refreshed saved server '$name' address: $oldAddress -> $address (mDNS)")
+        return true
     }
 
     /**

--- a/android/app/src/main/java/com/sendspindroid/discovery/NsdDiscoveryManager.kt
+++ b/android/app/src/main/java/com/sendspindroid/discovery/NsdDiscoveryManager.kt
@@ -134,6 +134,9 @@ class NsdDiscoveryManager(
                 val errorMsg = nsdErrorToString(errorCode)
                 Log.e(TAG, "Start discovery failed: $errorMsg (code: $errorCode)")
                 isDiscovering = false
+                // onDiscoveryStopped won't fire, so release the lock acquired in
+                // startDiscovery() here to avoid leaking it.
+                releaseMulticastLock()
                 listener.onDiscoveryError("Failed to start discovery: $errorMsg")
             }
 
@@ -403,10 +406,20 @@ class NsdDiscoveryManager(
     fun isDiscovering(): Boolean = isDiscovering
 
     /**
-     * Cleanup resources.
+     * Cleanup resources. Unlike [stopDiscovery], this tears down even when
+     * [onDiscoveryStarted] never fired (bounded/one-shot use, or a start failure):
+     * it stops the registered discovery and releases the multicast lock
+     * unconditionally, so neither the lock nor the NSD registration leaks.
      */
     fun cleanup() {
-        stopDiscovery()
+        pendingRestart = false
+        try {
+            discoveryListener?.let { nsdManager?.stopServiceDiscovery(it) }
+        } catch (e: Exception) {
+            Log.d(TAG, "cleanup: stopServiceDiscovery ignored (likely not started): ${e.message}")
+        }
+        isDiscovering = false
+        releaseMulticastLock()
         nsdManager = null
         discoveryListener = null
     }

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -84,6 +84,7 @@ import com.sendspindroid.network.TransportType
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.DefaultMediaNotificationProvider
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -92,7 +93,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
@@ -4067,7 +4067,9 @@ class PlaybackService : MediaLibraryService() {
             val address = resolved ?: local.address
             when {
                 resolved == null ->
-                    Log.i(TAG, "Auto-connect: mDNS did not find '${server.name}'; using stored ${local.address}")
+                    // warn: on boot this correlates with a likely-failing connect
+                    // when the stored address has gone stale (the #158 scenario).
+                    Log.w(TAG, "Auto-connect: mDNS did not find '${server.name}'; using stored ${local.address}")
                 resolved != local.address ->
                     Log.i(TAG, "Auto-connect: mDNS resolved '${server.name}' to $resolved (stored ${local.address})")
                 else ->
@@ -4079,9 +4081,10 @@ class PlaybackService : MediaLibraryService() {
 
     /**
      * Run a short, bounded mDNS discovery and return the current address of the
-     * server whose mDNS name matches [serverName], or null on timeout. Every
-     * result is fed to [UnifiedServerRepository.addDiscoveredServer], which also
-     * refreshes the matching saved server's stored address.
+     * discovered server whose friendly name (or, as a fallback, raw mDNS service
+     * name) equals [serverName], or null on timeout. Every result is fed to
+     * [UnifiedServerRepository.addDiscoveredServer], which also refreshes the
+     * matching saved server's stored address (by friendly name).
      */
     private suspend fun resolveLocalAddressViaMdns(serverName: String, timeoutMs: Long): String? {
         val result = CompletableDeferred<String?>()
@@ -4095,13 +4098,20 @@ class PlaybackService : MediaLibraryService() {
             override fun onServerLost(name: String) {}
             override fun onDiscoveryStarted() {}
             override fun onDiscoveryStopped() {}
-            override fun onDiscoveryError(error: String) {}
+            override fun onDiscoveryError(error: String) {
+                // Complete so we fall back to the stored address immediately
+                // instead of stalling for the full timeout.
+                Log.w(TAG, "Auto-connect: mDNS discovery error for '$serverName': $error")
+                if (!result.isCompleted) result.complete(null)
+            }
         })
         return try {
             manager.startDiscovery()
             withTimeoutOrNull(timeoutMs) { result.await() }
         } finally {
-            manager.stopDiscovery()
+            // cleanup() (not stopDiscovery()) so the multicast lock is released
+            // even if onDiscoveryStarted never fired.
+            manager.cleanup()
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -92,6 +92,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
@@ -422,6 +423,10 @@ class PlaybackService : MediaLibraryService() {
 
         // Timeout for awaiting a terminal connection state in connectViaSelectedConnection.
         private const val CONNECT_TIMEOUT_MS = 15_000L
+
+        // How long boot auto-connect waits for mDNS to re-resolve a saved local
+        // server's current address before falling back to the stored one (#158).
+        private const val MDNS_AUTOCONNECT_TIMEOUT_MS = 5_000L
 
         // Custom session commands
         const val COMMAND_CANCEL_RECONNECT = "com.sendspindroid.CANCEL_RECONNECT"
@@ -4030,8 +4035,9 @@ class PlaybackService : MediaLibraryService() {
         // Connect using the server's preferred method
         when {
             server.local != null -> {
-                Log.i(TAG, "Auto-connect: local connection to ${server.local!!.address}")
-                connectToServer(server.local!!.address, server.local!!.path)
+                // Re-resolve via mDNS first: a stored static IP can go stale
+                // (DHCP) and cause a refused connect on boot. See #158.
+                autoConnectLocalWithMdns(server)
             }
             server.remote != null -> {
                 Log.i(TAG, "Auto-connect: remote connection with ID ${server.remote!!.remoteId.take(8)}...")
@@ -4044,6 +4050,58 @@ class PlaybackService : MediaLibraryService() {
             else -> {
                 Log.w(TAG, "Auto-connect: server ${server.name} has no configured connection methods")
             }
+        }
+    }
+
+    /**
+     * Auto-connect to a saved local server, re-resolving its current address via
+     * mDNS first so a stale stored address (DHCP change) doesn't cause a failed
+     * connect on boot. Falls back to the stored address if mDNS doesn't find the
+     * server within [MDNS_AUTOCONNECT_TIMEOUT_MS] (server offline, or the network
+     * not yet up on boot). See #158.
+     */
+    private fun autoConnectLocalWithMdns(server: UnifiedServer) {
+        val local = server.local ?: return
+        serviceScope.launch {
+            val resolved = resolveLocalAddressViaMdns(server.name, MDNS_AUTOCONNECT_TIMEOUT_MS)
+            val address = resolved ?: local.address
+            when {
+                resolved == null ->
+                    Log.i(TAG, "Auto-connect: mDNS did not find '${server.name}'; using stored ${local.address}")
+                resolved != local.address ->
+                    Log.i(TAG, "Auto-connect: mDNS resolved '${server.name}' to $resolved (stored ${local.address})")
+                else ->
+                    Log.i(TAG, "Auto-connect: mDNS confirmed '${server.name}' at $resolved")
+            }
+            connectToServer(address, local.path)
+        }
+    }
+
+    /**
+     * Run a short, bounded mDNS discovery and return the current address of the
+     * server whose mDNS name matches [serverName], or null on timeout. Every
+     * result is fed to [UnifiedServerRepository.addDiscoveredServer], which also
+     * refreshes the matching saved server's stored address.
+     */
+    private suspend fun resolveLocalAddressViaMdns(serverName: String, timeoutMs: Long): String? {
+        val result = CompletableDeferred<String?>()
+        val manager = NsdDiscoveryManager(this, object : NsdDiscoveryManager.DiscoveryListener {
+            override fun onServerDiscovered(name: String, address: String, path: String, friendlyName: String) {
+                UnifiedServerRepository.addDiscoveredServer(friendlyName, address, path)
+                if (!result.isCompleted && (friendlyName == serverName || name == serverName)) {
+                    result.complete(address)
+                }
+            }
+            override fun onServerLost(name: String) {}
+            override fun onDiscoveryStarted() {}
+            override fun onDiscoveryStopped() {}
+            override fun onDiscoveryError(error: String) {}
+        })
+        return try {
+            manager.startDiscovery()
+            withTimeoutOrNull(timeoutMs) { result.await() }
+        } finally {
+            manager.stopDiscovery()
         }
     }
 

--- a/android/app/src/test/java/com/sendspindroid/UnifiedServerRepositoryTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/UnifiedServerRepositoryTest.kt
@@ -271,6 +271,67 @@ class UnifiedServerRepositoryTest {
         assertEquals(0L, UnifiedServerRepository.savedServers.value[0].lastConnectedMs)
     }
 
+    // ========== refreshSavedServerAddress (mDNS DHCP resilience, #158) ==========
+
+    @Test
+    fun `refreshSavedServerAddress updates a matching saved server to the new address`() {
+        UnifiedServerRepository.saveServer(testServer("id-1", "Living Room", "192.168.1.50:8927"))
+
+        val changed = UnifiedServerRepository.refreshSavedServerAddress("Living Room", "192.168.1.60:8927")
+
+        assertTrue(changed)
+        assertEquals("192.168.1.60:8927", UnifiedServerRepository.getServer("id-1")?.local?.address)
+    }
+
+    @Test
+    fun `refreshSavedServerAddress is a no-op when the address is unchanged`() {
+        UnifiedServerRepository.saveServer(testServer("id-1", "Living Room", "192.168.1.50:8927"))
+
+        val changed = UnifiedServerRepository.refreshSavedServerAddress("Living Room", "192.168.1.50:8927")
+
+        assertFalse(changed)
+        assertEquals("192.168.1.50:8927", UnifiedServerRepository.getServer("id-1")?.local?.address)
+    }
+
+    @Test
+    fun `refreshSavedServerAddress ignores unknown server names`() {
+        UnifiedServerRepository.saveServer(testServer("id-1", "Living Room", "192.168.1.50:8927"))
+
+        val changed = UnifiedServerRepository.refreshSavedServerAddress("Kitchen", "192.168.1.99:8927")
+
+        assertFalse(changed)
+        assertEquals("192.168.1.50:8927", UnifiedServerRepository.getServer("id-1")?.local?.address)
+    }
+
+    @Test
+    fun `refreshSavedServerAddress preserves the server id, path and default flag`() {
+        UnifiedServerRepository.saveServer(
+            UnifiedServer(
+                id = "id-1",
+                name = "Living Room",
+                local = LocalConnection("192.168.1.50:8927", "/custom"),
+                isDefaultServer = true,
+            )
+        )
+
+        UnifiedServerRepository.refreshSavedServerAddress("Living Room", "192.168.1.60:8927")
+
+        val server = UnifiedServerRepository.getServer("id-1")!!
+        assertEquals("192.168.1.60:8927", server.local?.address)
+        assertEquals("/custom", server.local?.path)
+        assertTrue(server.isDefaultServer)
+    }
+
+    @Test
+    fun `addDiscoveredServer refreshes a matching saved server address`() {
+        UnifiedServerRepository.saveServer(testServer("id-1", "Living Room", "192.168.1.50:8927"))
+
+        // The same server reappears via mDNS at a new IP.
+        UnifiedServerRepository.addDiscoveredServer("Living Room", "192.168.1.60:8927")
+
+        assertEquals("192.168.1.60:8927", UnifiedServerRepository.getServer("id-1")?.local?.address)
+    }
+
     // ========== Helper ==========
 
     private fun testServer(id: String, name: String, address: String) = UnifiedServer(

--- a/android/app/src/test/java/com/sendspindroid/UnifiedServerRepositoryTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/UnifiedServerRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid
 
 import com.sendspindroid.model.LocalConnection
+import com.sendspindroid.model.RemoteConnection
 import com.sendspindroid.model.UnifiedServer
 import org.junit.After
 import org.junit.Assert.*
@@ -330,6 +331,37 @@ class UnifiedServerRepositoryTest {
         UnifiedServerRepository.addDiscoveredServer("Living Room", "192.168.1.60:8927")
 
         assertEquals("192.168.1.60:8927", UnifiedServerRepository.getServer("id-1")?.local?.address)
+    }
+
+    @Test
+    fun `refreshSavedServerAddress skips a name-matching server with no local connection`() {
+        // A remote-only saved server (local == null) must not be touched, and the
+        // null-guard must not throw.
+        UnifiedServerRepository.saveServer(
+            UnifiedServer(id = "id-1", name = "Living Room", remote = RemoteConnection("A".repeat(26)))
+        )
+
+        val changed = UnifiedServerRepository.refreshSavedServerAddress("Living Room", "192.168.1.60:8927")
+
+        assertFalse(changed)
+        assertNull(UnifiedServerRepository.getServer("id-1")?.local)
+    }
+
+    @Test
+    fun `refreshSavedServerAddress updates only the first server when names collide`() {
+        UnifiedServerRepository.saveServer(testServer("id-1", "Living Room", "192.168.1.50:8927"))
+        UnifiedServerRepository.saveServer(testServer("id-2", "Living Room", "192.168.1.51:8927"))
+
+        UnifiedServerRepository.refreshSavedServerAddress("Living Room", "192.168.1.60:8927")
+
+        // Documents the indexOfFirst semantics: only one duplicate-named server
+        // is updated; the other keeps its address.
+        val addresses = UnifiedServerRepository.savedServers.value
+            .filter { it.name == "Living Room" }
+            .mapNotNull { it.local?.address }
+            .toSet()
+        assertTrue(addresses.contains("192.168.1.60:8927"))
+        assertEquals(2, addresses.size)
     }
 
     // ========== Helper ==========


### PR DESCRIPTION
Fixes the substantive half of #158.

## Root cause

Auto-connect dialed the **static address stored when the server was saved**, with no mDNS re-resolution (`handleAutoConnect` → `connectToServer(server.local.address)`). After a DHCP lease change (common after a router/server reboot — which a tablet reboot often coincides with) the stored address goes stale, so auto-connect fails with "connection refused." The server is still reachable and **discoverable** at its new IP, so tapping the discovered entry works — and because the device never connects, MA never sees it as a player. Discovery only ever created *separate* `_discoveredServers` entries; it never refreshed a saved server's address.

## Fix

- **`UnifiedServerRepository.refreshSavedServerAddress(name, address)`** — updates a saved server's stored local address when the server is seen (by name) at a new one. Called from `addDiscoveredServer`, so **any** discovery (browse tree, app-open) keeps saved addresses fresh — this covers the app-open reconnect path.
- **Boot auto-connect** (`handleAutoConnect`) now re-resolves the address via a short, bounded mDNS discovery *before* connecting, since no discovery has run yet at boot. Falls back to the stored address on timeout (server offline, or network not up yet on boot) — preserving the previous behavior, no regression.

## Tests

5 new repository tests: update / no-op-when-unchanged / unknown-name-ignored / id+path+default-flag preserved / `addDiscoveredServer` reconciliation. Full app + shared suites pass.

## Note on the other half of #158

The issue title ("doesn't auto-connect on boot") also has an **Android 15+** dimension: you can't start a `mediaPlayback` foreground service from `BOOT_COMPLETED`, so fully hands-off auto-connect isn't possible there. That's already handled as a **tap-to-resume notification** (commit `c499693`, after the reporter's Beta8 build). Worth asking the reporter to retest on Beta11+ and confirm whether their server's IP had changed.

## Matching caveat

Servers are matched saved↔discovered by **name** (saved-from-discovery servers store the mDNS friendly name). A renamed saved server, or two servers sharing a name, won't match — acceptable for the common case; noted for follow-up if it bites.