### PR TITLE
fix(images): browse/search album art (MA 2.9 imageproxy format)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/home/components/MediaCard.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/home/components/MediaCard.kt
@@ -29,12 +29,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.sendspindroid.R
 import com.sendspindroid.musicassistant.MaAlbum
 import com.sendspindroid.musicassistant.MaArtist
@@ -81,7 +83,11 @@ fun MediaCard(
                     .aspectRatio(1f)
             ) {
                 AsyncImage(
-                    model = item.imageUri ?: R.drawable.placeholder_album,
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(item.imageUri)
+                        .error(R.drawable.placeholder_album)
+                        .fallback(R.drawable.placeholder_album)
+                        .build(),
                     contentDescription = item.name,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/search/components/SearchResultItem.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/search/components/SearchResultItem.kt
@@ -29,11 +29,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.sendspindroid.R
 import com.sendspindroid.musicassistant.MaAlbum
 import com.sendspindroid.musicassistant.MaArtist
@@ -93,7 +95,11 @@ fun SearchResultItem(
     ) {
         // Thumbnail
         AsyncImage(
-            model = item.imageUri ?: R.drawable.placeholder_album,
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(item.imageUri)
+                .error(R.drawable.placeholder_album)
+                .fallback(R.drawable.placeholder_album)
+                .build(),
             contentDescription = item.name,
             contentScale = ContentScale.Crop,
             modifier = Modifier

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/musicassistant/MaCommandClientImageTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/musicassistant/MaCommandClientImageTest.kt
@@ -1,5 +1,6 @@
 package com.sendspindroid.musicassistant
 
+import com.sendspindroid.shared.platform.Platform
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
@@ -104,11 +105,13 @@ class MaCommandClientImageTest {
         }
         """)
 
+        // Not remotely accessible -> MA canonical hashed imageproxy URL.
         val result = client.extractImageUri(json)
-        assertTrue(result.startsWith("http://192.168.1.100:8095/imageproxy"))
-        assertTrue(result.contains("provider=spotify"))
-        assertTrue(result.contains("size=300"))
-        assertTrue(result.contains("fmt=jpeg"))
+        val expectedId = Platform.sha256Hex("spotify/https://i.scdn.co/image/abc123")
+        assertEquals(
+            "http://192.168.1.100:8095/imageproxy/$expectedId?size=256&fmt=jpeg",
+            result
+        )
     }
 
     @Test
@@ -126,8 +129,11 @@ class MaCommandClientImageTest {
         """)
 
         val result = client.extractImageUri(json)
-        assertTrue(result.contains("/imageproxy"))
-        assertTrue(result.contains("provider=filesystem"))
+        val expectedId = Platform.sha256Hex("filesystem//music/cover.jpg")
+        assertEquals(
+            "http://192.168.1.100:8095/imageproxy/$expectedId?size=256&fmt=jpeg",
+            result
+        )
     }
 
     @Test
@@ -187,9 +193,9 @@ class MaCommandClientImageTest {
             "name": "Track",
             "metadata": {
                 "images": [
-                    {"path": "https://img.server.com/landscape.jpg", "provider": "url", "type": "landscape"},
-                    {"path": "https://img.server.com/thumb.jpg", "provider": "url", "type": "thumb"},
-                    {"path": "https://img.server.com/banner.jpg", "provider": "url", "type": "banner"}
+                    {"path": "https://img.server.com/landscape.jpg", "provider": "url", "remotely_accessible": true, "type": "landscape"},
+                    {"path": "https://img.server.com/thumb.jpg", "provider": "url", "remotely_accessible": true, "type": "thumb"},
+                    {"path": "https://img.server.com/banner.jpg", "provider": "url", "remotely_accessible": true, "type": "banner"}
                 ]
             }
         }
@@ -208,9 +214,9 @@ class MaCommandClientImageTest {
             "name": "Track",
             "metadata": {
                 "images": [
-                    {"path": "https://img.server.com/landscape.jpg", "provider": "url", "type": "landscape"},
-                    {"path": "https://img.server.com/cover.jpg", "provider": "url", "type": "cover"},
-                    {"path": "https://img.server.com/banner.jpg", "provider": "url", "type": "banner"}
+                    {"path": "https://img.server.com/landscape.jpg", "provider": "url", "remotely_accessible": true, "type": "landscape"},
+                    {"path": "https://img.server.com/cover.jpg", "provider": "url", "remotely_accessible": true, "type": "cover"},
+                    {"path": "https://img.server.com/banner.jpg", "provider": "url", "remotely_accessible": true, "type": "banner"}
                 ]
             }
         }
@@ -229,8 +235,8 @@ class MaCommandClientImageTest {
             "name": "Track",
             "metadata": {
                 "images": [
-                    {"path": "https://img.server.com/banner.jpg", "provider": "url", "type": "banner"},
-                    {"path": "https://img.server.com/front.jpg", "provider": "url", "type": "front"}
+                    {"path": "https://img.server.com/banner.jpg", "provider": "url", "remotely_accessible": true, "type": "banner"},
+                    {"path": "https://img.server.com/front.jpg", "provider": "url", "remotely_accessible": true, "type": "front"}
                 ]
             }
         }
@@ -249,9 +255,9 @@ class MaCommandClientImageTest {
             "name": "Track",
             "metadata": {
                 "images": [
-                    {"path": "https://img.server.com/cover.jpg", "provider": "url", "type": "cover"},
-                    {"path": "https://img.server.com/front.jpg", "provider": "url", "type": "front"},
-                    {"path": "https://img.server.com/thumb.jpg", "provider": "url", "type": "thumb"}
+                    {"path": "https://img.server.com/cover.jpg", "provider": "url", "remotely_accessible": true, "type": "cover"},
+                    {"path": "https://img.server.com/front.jpg", "provider": "url", "remotely_accessible": true, "type": "front"},
+                    {"path": "https://img.server.com/thumb.jpg", "provider": "url", "remotely_accessible": true, "type": "thumb"}
                 ]
             }
         }
@@ -270,8 +276,8 @@ class MaCommandClientImageTest {
             "name": "Track",
             "metadata": {
                 "images": [
-                    {"path": "https://img.server.com/first.jpg", "provider": "url", "type": "landscape"},
-                    {"path": "https://img.server.com/second.jpg", "provider": "url", "type": "banner"}
+                    {"path": "https://img.server.com/first.jpg", "provider": "url", "remotely_accessible": true, "type": "landscape"},
+                    {"path": "https://img.server.com/second.jpg", "provider": "url", "remotely_accessible": true, "type": "banner"}
                 ]
             }
         }
@@ -291,8 +297,8 @@ class MaCommandClientImageTest {
             "name": "Track",
             "metadata": {
                 "images": [
-                    {"path": "", "provider": "url", "type": "thumb"},
-                    {"path": "https://img.server.com/valid.jpg", "provider": "url", "type": "banner"}
+                    {"path": "", "provider": "url", "remotely_accessible": true, "type": "thumb"},
+                    {"path": "https://img.server.com/valid.jpg", "provider": "url", "remotely_accessible": true, "type": "banner"}
                 ]
             }
         }
@@ -401,6 +407,56 @@ class MaCommandClientImageTest {
 
         val result = client.extractImageUri(json)
         assertTrue(result.startsWith("https://music.example.com/imageproxy"))
+    }
+
+    // ========================================================================
+    // extractImageUri — Canonical imageproxy format (MA 2.9+)
+    // ========================================================================
+
+    @Test
+    fun `extractImageUri returns remotely_accessible image path directly`() {
+        client.setTransport(null, "ws://192.168.1.100:8095/ws", false)
+
+        val json = parseJson("""
+        {
+            "name": "Track",
+            "image": {
+                "path": "https://i.scdn.co/image/abc123",
+                "provider": "spotify",
+                "remotely_accessible": true
+            }
+        }
+        """)
+
+        assertEquals("https://i.scdn.co/image/abc123", client.extractImageUri(json))
+    }
+
+    @Test
+    fun `extractImageUri uses canonical imageproxy path not legacy query form`() {
+        client.setTransport(null, "ws://192.168.1.100:8095/ws", false)
+
+        val json = parseJson("""
+        {
+            "name": "Track",
+            "image": {
+                "path": "Artist/Album/track.flac",
+                "provider": "filesystem_local--abc"
+            }
+        }
+        """)
+
+        val result = client.extractImageUri(json)
+        val expectedId = Platform.sha256Hex("filesystem_local--abc/Artist/Album/track.flac")
+        assertEquals(
+            "http://192.168.1.100:8095/imageproxy/$expectedId?size=256&fmt=jpeg",
+            result
+        )
+        // The legacy query form (?provider=&path=&size=300) is rejected by MA 2.9+ with HTTP 400.
+        assertFalse(result.contains("?provider="))
+        assertFalse(result.contains("&path="))
+        assertFalse(result.contains("size=300"))
+        // imageId must be 64 lowercase hex chars.
+        assertTrue(Regex("/imageproxy/[0-9a-f]{64}\\?").containsMatchIn(result))
     }
 
     // ========================================================================

--- a/android/shared/src/androidMain/kotlin/com/sendspindroid/shared/platform/Platform.android.kt
+++ b/android/shared/src/androidMain/kotlin/com/sendspindroid/shared/platform/Platform.android.kt
@@ -9,4 +9,8 @@ actual object Platform {
     actual fun base64Decode(input: String): ByteArray =
         java.util.Base64.getDecoder().decode(input)
     actual fun manufacturer(): String = Build.MANUFACTURER
+    actual fun sha256Hex(input: String): String =
+        java.security.MessageDigest.getInstance("SHA-256")
+            .digest(input.encodeToByteArray())
+            .joinToString("") { (it.toInt() and 0xff).toString(16).padStart(2, '0') }
 }

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/MaCommandClient.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/musicassistant/MaCommandClient.kt
@@ -16,7 +16,7 @@ import com.sendspindroid.musicassistant.transport.optJsonObject
 import com.sendspindroid.musicassistant.transport.optLong
 import com.sendspindroid.musicassistant.transport.optString
 import com.sendspindroid.shared.log.Log
-import io.ktor.http.encodeURLParameter
+import com.sendspindroid.shared.platform.Platform
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -54,6 +54,13 @@ class MaCommandClient(private val settings: MaSettingsProvider) {
          * Matches MaProxyImageFetcher.SCHEME on Android.
          */
         const val IMAGE_PROXY_SCHEME = "ma-proxy"
+
+        /**
+         * Thumbnail size requested from MA's imageproxy. MA only accepts a fixed
+         * set of sizes ({0, 80, 160, 256, 512, 1024}); any other value is rejected
+         * with HTTP 400. 256 suits the browse/search grid thumbnails.
+         */
+        private const val IMAGE_PROXY_SIZE = 256
     }
 
     /**
@@ -2367,26 +2374,33 @@ class MaCommandClient(private val settings: MaSettingsProvider) {
     }
 
     /**
-     * Build imageproxy URL from an image object with path/provider fields.
+     * Build an image URL from an MA image object (`path` / `provider` /
+     * `remotely_accessible`).
+     *
+     * MA 2.x serves proxied images from the canonical path-style endpoint:
+     * ```
+     * {baseUrl}/imageproxy/{imageId}?size={size}&fmt=jpeg
+     * ```
+     * where `imageId = sha256("{provider}/{path}")` (MA's `create_thumb_hash`).
+     * The older query form (`?provider=&path=`) is the deprecated legacy endpoint
+     * and is rejected by MA 2.9+ with HTTP 400, so it must not be used.
+     *
+     * Remotely-accessible images already carry a reachable URL, so they are
+     * returned as-is rather than round-tripped through the proxy.
      */
     private fun buildImageProxyUrl(imageObj: JsonObject, baseUrl: String): String {
         val path = imageObj.optString("path")
-        val provider = imageObj.optString("provider")
-
         if (path.isEmpty() || baseUrl.isEmpty()) return ""
 
-        if (path.startsWith("http")) {
-            val encodedPath = path.encodeURLParameter()
-            return "$baseUrl/imageproxy?size=300&fmt=jpeg&path=$encodedPath" +
-                    if (provider.isNotEmpty()) "&provider=$provider" else ""
+        if (imageObj.optBoolean("remotely_accessible") && path.startsWith("http")) {
+            return path
         }
 
-        if (provider.isNotEmpty()) {
-            val encodedPath = path.encodeURLParameter()
-            return "$baseUrl/imageproxy?provider=$provider&size=300&fmt=jpeg&path=$encodedPath"
-        }
+        val provider = imageObj.optString("provider")
+        if (provider.isEmpty()) return ""
 
-        return ""
+        val imageId = Platform.sha256Hex("$provider/$path")
+        return "$baseUrl/imageproxy/$imageId?size=$IMAGE_PROXY_SIZE&fmt=jpeg"
     }
 
     /**

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/shared/platform/Platform.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/shared/platform/Platform.kt
@@ -12,4 +12,7 @@ expect object Platform {
 
     /** Device manufacturer name */
     fun manufacturer(): String
+
+    /** Lowercase hex SHA-256 of the UTF-8 bytes of [input]. */
+    fun sha256Hex(input: String): String
 }

--- a/android/shared/src/jvmMain/kotlin/com/sendspindroid/shared/platform/Platform.jvm.kt
+++ b/android/shared/src/jvmMain/kotlin/com/sendspindroid/shared/platform/Platform.jvm.kt
@@ -6,4 +6,8 @@ actual object Platform {
     actual fun base64Decode(input: String): ByteArray =
         java.util.Base64.getDecoder().decode(input)
     actual fun manufacturer(): String = "JVM"
+    actual fun sha256Hex(input: String): String =
+        java.security.MessageDigest.getInstance("SHA-256")
+            .digest(input.encodeToByteArray())
+            .joinToString("") { (it.toInt() and 0xff).toString(16).padStart(2, '0') }
 }


### PR DESCRIPTION
## Problem

Album art in the browse/search area renders as **black boxes**, while now-playing art loads fine. Reported on a nubia/ZTE; reproduced live against MA **2.9.1** (LOCAL mode).

## Root cause

Browse/search thumbnails go through `MaCommandClient.buildImageProxyUrl`, which built MA's **deprecated legacy** imageproxy URL:

```
http://host/imageproxy?provider=X&path=Y&size=300&fmt=jpeg
```

MA 2.9+ serves images only from the **canonical** endpoint and rejects the legacy form with **HTTP 400**. Two specific defects:

1. **Wrong format** — must be `/imageproxy/{imageId}` (path-style), where `imageId = sha256("{provider}/{path}")` (the server's `create_thumb_hash`), not the `?provider=&path=` query form.
2. **Illegal size** — `size=300` is not in MA's accepted set `{0,80,160,256,512,1024}`; it alone causes a 400.

Now-playing art was never affected because the SendSpin server hands the client a ready-made, correctly-formatted URL (`.../imageproxy/<hash>?size=512&fmt=jpg`).

## Fix

- Build MA's canonical URL: `{baseUrl}/imageproxy/{sha256("provider/path")}?size=256&fmt=jpeg`.
- Return `remotely_accessible` images directly (already reachable URLs).
- Add `Platform.sha256Hex` (`expect`/`actual`, `MessageDigest`) for the image id.
- Give home/search thumbnails a Coil `error`/`fallback` drawable via `ImageRequest`, so a failed load shows the placeholder instead of a black box. (A Compose `painterResource` can't render the non-vector `placeholder_album` drawable — it must go through Coil's request.)

## Tests

`MaCommandClientImageTest` updated to the canonical format; added a hash-format lock-in test (asserts the exact `/imageproxy/<64-hex>?size=256&fmt=jpeg` and that the legacy query form is gone) and a `remotely_accessible` passthrough test. Full `:app:testDebugUnitTest` + `:shared:testAndroidHostTest` green.

## Verified on device

nubia REDMAGIC NX809J, MA 2.9.1, LOCAL mode:

- **Before:** Recently Played / Recently Added tiles all black.
- **After:** Recently Played shows real album art; items that don't resolve degrade to the music-note placeholder; no crash.

## Notes for review

- Touches the shared (KMP) image-URL logic, so it also benefits PROXY/REMOTE paths (the `ma-proxy://` rewrite still wraps the new path form).
- Does **not** include a version bump — versioning left to the release process.
- Recently Added items currently show placeholders rather than art on the test server; worth a follow-up look at whether those item types expose a resolvable image path.