### PR TITLE
fix(ma): stop transient network drops from forcing MA re-login

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistant.kt
+++ b/android/app/src/main/java/com/sendspindroid/musicassistant/MusicAssistant.kt
@@ -263,8 +263,17 @@ object MusicAssistant {
         }
     }
 
-    // Coroutine scope for async operations
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    // Coroutine scope for async operations.
+    // `internal var` (not `private val`) solely so unit tests can substitute a
+    // test dispatcher; production code never reassigns it.
+    internal var scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    /**
+     * Test seam: when non-null, [createTransport] returns this instead of opening
+     * a real WebSocket/DataChannel, so unit tests never touch the network. Always
+     * null in production.
+     */
+    internal var transportFactoryOverride: ((String) -> MaApiTransport?)? = null
 
     @Volatile
     private var applicationContext: Context? = null
@@ -292,19 +301,19 @@ object MusicAssistant {
      * connectWithToken when a token is present. With no token, transitions to
      * Idle and fires loginRequired so the UI prompts the user.
      *
-     * The server must already be set on [currentServer] before calling this
-     * (onServerConnected does this). Callers external to onServerConnected
-     * (e.g., the setup wizard test path in Phase 6) must also ensure
-     * [currentServer] and [currentConnectionMode] are set.
+     * The target [serverId] is passed in (captured by the caller) rather than
+     * read from [currentServer] here. The actual transport connect happens on the
+     * cancellable [connectJob] inside connectWithToken, so this method itself does
+     * no suspending work and is safe to call synchronously. Login is required only
+     * when no token is stored -- never merely because [currentServer] changed.
      */
-    suspend fun connect(endpoint: MaEndpoint, token: String?) {
+    private fun connect(endpoint: MaEndpoint, token: String?, serverId: String) {
         val apiUrl = endpoint.toApiUrl()
         currentApiUrl = apiUrl
         Log.d(TAG, "MA API URL derived: $apiUrl")
 
-        val server = currentServer
-        if (token != null && server != null) {
-            connectWithToken(apiUrl, token, server.id)
+        if (token != null) {
+            connectWithToken(apiUrl, token, serverId)
         } else {
             Log.w(TAG, "No token stored for MA server - user needs to re-authenticate")
             currentServerInfo = null
@@ -373,10 +382,14 @@ object MusicAssistant {
         }
 
         // Check 3: Do we have a stored token? Facade handles the token/no-token split.
+        // Capture serverId and connect() synchronously. Previously this launched an
+        // untracked coroutine that re-read currentServer; a disconnect (e.g. WiFi->
+        // cellular) could null currentServer before it ran, firing a false
+        // loginRequired for a server whose token is still valid -- unrecoverable on
+        // Android Auto. The real connect runs on the cancellable connectJob inside
+        // connectWithToken, which onServerDisconnected() already cancels.
         val token = MaSettings.getTokenForServer(server.id)
-        scope.launch {
-            connect(endpoint, token)
-        }
+        connect(endpoint, token, server.id)
     }
 
     /**
@@ -580,6 +593,7 @@ object MusicAssistant {
      * a WebSocket if a local or proxy URL can be derived.
      */
     private fun createTransport(apiUrl: String): MaApiTransport? {
+        transportFactoryOverride?.let { return it(apiUrl) }
         val mode = currentConnectionMode ?: return null
 
         if (mode == ConnectionMode.REMOTE) {

--- a/android/app/src/test/java/com/sendspindroid/musicassistant/MusicAssistantReloginRaceTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/musicassistant/MusicAssistantReloginRaceTest.kt
@@ -1,0 +1,120 @@
+package com.sendspindroid.musicassistant
+
+import com.sendspindroid.UserSettings.ConnectionMode
+import com.sendspindroid.model.LocalConnection
+import com.sendspindroid.model.UnifiedServer
+import com.sendspindroid.musicassistant.transport.MaApiTransport
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Regression tests for the MA "forced re-login on network drop" race.
+ *
+ * The car scenario: WiFi drops to cellular mid-connect. Previously,
+ * [MusicAssistant.onServerConnected] launched an untracked coroutine that
+ * re-read `currentServer`; a concurrent [MusicAssistant.onServerDisconnected]
+ * could null it before that coroutine ran, firing a false `loginRequired` for a
+ * server whose token was still valid -- unrecoverable on Android Auto.
+ *
+ * Uses the [MusicAssistant.scope] and [MusicAssistant.transportFactoryOverride]
+ * test seams so connect work is deterministic and never touches the network.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class MusicAssistantReloginRaceTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        MaSettings.initialize(RuntimeEnvironment.getApplication())
+        // Deterministic, cancellable scope and a no-network transport.
+        MusicAssistant.scope = CoroutineScope(SupervisorJob() + dispatcher)
+        MusicAssistant.transportFactoryOverride = { mockk(relaxed = true) }
+        MaSettings.clearTokenForServer(SERVER_ID)
+    }
+
+    @After
+    fun tearDown() {
+        MusicAssistant.onServerDisconnected() // clears currentServer / connectJob / transport
+        MusicAssistant.transportFactoryOverride = null
+        MaSettings.clearTokenForServer(SERVER_ID)
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `transient disconnect during connect does not force re-login when token stored`() =
+        runTest(dispatcher) {
+            MaSettings.setTokenForServer(SERVER_ID, "valid-token")
+
+            val emissions = mutableListOf<Unit>()
+            val collector = launch { MusicAssistant.loginRequired.collect { emissions += it } }
+            runCurrent() // ensure the collector is subscribed before we emit
+
+            // Race: server connects, then immediately disconnects (WiFi -> cellular).
+            MusicAssistant.onServerConnected(testServer(), ConnectionMode.LOCAL)
+            MusicAssistant.onServerDisconnected()
+            advanceUntilIdle()
+
+            assertTrue(
+                "A transient disconnect must not force re-login when the token is still stored",
+                emissions.isEmpty()
+            )
+            assertNotNull(
+                "Token must be preserved across a transient disconnect",
+                MaSettings.getTokenForServer(SERVER_ID)
+            )
+            collector.cancel()
+        }
+
+    @Test
+    fun `connect with no stored token requires login`() = runTest(dispatcher) {
+        // No token stored for this server.
+        val emissions = mutableListOf<Unit>()
+        val collector = launch { MusicAssistant.loginRequired.collect { emissions += it } }
+        runCurrent()
+
+        MusicAssistant.onServerConnected(testServer(), ConnectionMode.LOCAL)
+        advanceUntilIdle()
+
+        assertEquals(
+            "A genuinely missing token must still surface loginRequired",
+            1,
+            emissions.size
+        )
+        collector.cancel()
+    }
+
+    private fun testServer() = UnifiedServer(
+        id = SERVER_ID,
+        name = "MA Home",
+        local = LocalConnection("10.0.0.1:8095"),
+        isMusicAssistant = true
+    )
+
+    companion object {
+        private const val SERVER_ID = "srv-relogin-race-test"
+    }
+}


### PR DESCRIPTION
## Problem (the car scenario)

Driving away from home, WiFi drops to cellular mid-connect, and the app **sometimes forces a Music Assistant re-login** — which is effectively **unrecoverable on Android Auto** (no way to type credentials). This is a top blocker for dropping the beta label.

## Root cause

`onServerConnected` launched an **untracked** coroutine (`scope.launch { connect(...) }`) that re-read `currentServer` inside `connect()`. A concurrent `onServerDisconnected` nulls `currentServer` (and its `connectJob` cancellation — the `H-22` guard — did **not** cover this launch). When the stray `connect()` then ran, it saw `currentServer == null`, fell into the no-server branch, and emitted `loginRequired` — **even though the token was still valid and stored**. Intermittent because it's a timing race.

## Fix

- `connect()` is now a private, non-suspend function that takes the **captured `serverId`** instead of re-reading `currentServer`, and is called **synchronously** from `onServerConnected`. It does no suspending work — the real transport connect runs on the cancellable `connectJob` inside `connectWithToken` (which `onServerDisconnected` already cancels).
- `loginRequired` now fires **only when no token is stored** — never because `currentServer` changed under a network drop.
- Token-clearing is untouched (still only on a confirmed auth rejection, never on a transient network error).

## Test harness + regression test

`MusicAssistant` is an Android-coupled singleton with no prior test harness. Added two minimal, documented **test-only seams** (a replaceable `scope` and a `transportFactoryOverride` so tests never touch the network) and a Robolectric + coroutines-test regression test that drives the **disconnect-during-connect race**.

**Verified discriminating:** with the fix temporarily reverted, the race test goes **red** (false `loginRequired` emitted); with the fix, it's green. The companion test confirms a genuinely-missing token still surfaces `loginRequired`.

- Full `:app:testDebugUnitTest` green.

## Scope note

This addresses **#1** of the network-handoff triage (the unrecoverable re-login). The other items — LOCAL→REMOTE failover for audio continuity (largely works but needs a remote path configured) and Android Auto reconnect visibility — are separate follow-ups, not included here.