### PR TITLE
feat(diagnostics): redact exported logs + lightweight always-on logging (Phase 1)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/SettingsActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/SettingsActivity.kt
@@ -40,7 +40,7 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     private fun exportDebugLogs() {
-        val shareIntent = AppLog.shareIntent(this)
+        val shareIntent = AppLog.shareIntent(this, collectRedactionTerms())
 
         if (shareIntent != null) {
             val chooserIntent = Intent.createChooser(
@@ -51,6 +51,19 @@ class SettingsActivity : AppCompatActivity() {
             Toast.makeText(this, R.string.debug_log_exported, Toast.LENGTH_SHORT).show()
         } else {
             Toast.makeText(this, R.string.debug_log_export_failed, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    /**
+     * Literal strings to scrub from exported logs: every known server's chosen
+     * name, LAN address, and proxy URL. (Remote IDs are identifiers, not secrets,
+     * so they're kept for debugging.)
+     */
+    private fun collectRedactionTerms(): List<String> {
+        val servers = UnifiedServerRepository.savedServers.value +
+            UnifiedServerRepository.discoveredServers.value
+        return servers.flatMap { server ->
+            listOfNotNull(server.name, server.local?.address, server.proxy?.url)
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/logging/AppLog.kt
+++ b/android/app/src/main/java/com/sendspindroid/logging/AppLog.kt
@@ -27,6 +27,10 @@ object AppLog {
 
     private const val PREF_LOG_LEVEL = "log_level"
     private const val PREF_LEGACY_DEBUG_LOGGING = "debug_logging_enabled"
+    private const val PREF_LIGHTWEIGHT_MIGRATED = "lightweight_logging_migrated"
+
+    /** Default for fresh installs / the one-time lightweight migration. */
+    private val DEFAULT_LEVEL = LogLevel.WARN
 
     @Volatile
     var level: LogLevel = LogLevel.OFF
@@ -86,17 +90,25 @@ object AppLog {
 
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         val stored = prefs.getString(PREF_LOG_LEVEL, null)
-        val resolved: LogLevel = when {
+        var resolved: LogLevel = when {
             stored != null -> runCatching { LogLevel.valueOf(stored) }.getOrDefault(LogLevel.OFF)
             prefs.contains(PREF_LEGACY_DEBUG_LOGGING) -> {
                 if (prefs.getBoolean(PREF_LEGACY_DEBUG_LOGGING, false)) LogLevel.DEBUG else LogLevel.OFF
             }
             else -> LogLevel.OFF
         }
+        // One-time migration to lightweight always-on logging: installs still sitting
+        // on the old OFF default are bumped to WARN once, so a first-occurrence bug
+        // report isn't empty. A user who deliberately picks OFF afterward is respected
+        // -- this runs a single time, guarded by PREF_LIGHTWEIGHT_MIGRATED.
+        if (!prefs.getBoolean(PREF_LIGHTWEIGHT_MIGRATED, false) && resolved == LogLevel.OFF) {
+            resolved = DEFAULT_LEVEL
+        }
         // Persist & strip legacy key regardless of which branch we took, so future runs skip this block.
         prefs.edit()
             .putString(PREF_LOG_LEVEL, resolved.name)
             .remove(PREF_LEGACY_DEBUG_LOGGING)
+            .putBoolean(PREF_LIGHTWEIGHT_MIGRATED, true)
             .apply()
 
         bridge?.stop()
@@ -137,8 +149,16 @@ object AppLog {
         return (totalBytes / 1024L) to files.size
     }
 
-    /** Create a share intent with a concatenated log file. */
-    fun shareIntent(context: Context): Intent? = writer?.shareIntent(context)
+    /**
+     * Create a share intent with a concatenated, **redacted** log file.
+     *
+     * [sensitiveTerms] are literal strings (saved/discovered server names, LAN
+     * addresses, proxy URLs) the caller knows are sensitive but that aren't
+     * pattern-matchable; they're scrubbed alongside the built-in IP/URL/token
+     * patterns. See [RedactionFilter].
+     */
+    fun shareIntent(context: Context, sensitiveTerms: Collection<String> = emptyList()): Intent? =
+        writer?.shareIntent(context, RedactionFilter(sensitiveTerms))
 
     /** Clear all rotated log files. */
     fun clear() {

--- a/android/app/src/main/java/com/sendspindroid/logging/LogFileWriter.kt
+++ b/android/app/src/main/java/com/sendspindroid/logging/LogFileWriter.kt
@@ -88,18 +88,21 @@ internal class LogFileWriter(
         }
     }
 
-    fun shareIntent(context: Context): Intent? {
+    fun shareIntent(context: Context, redactor: RedactionFilter = RedactionFilter()): Intent? {
         synchronized(lock) {
             val files = currentFiles()
             if (files.isEmpty()) return null
 
             val combined = File(dir, "sendspin-log-combined.txt")
             return try {
+                // Header is device/version only (intentionally shared, not redacted).
                 combined.writeText(buildShareHeader(context))
                 for (f in files) {
                     if (f.exists()) {
                         combined.appendText("\n----- ${f.name} -----\n")
-                        combined.appendBytes(f.readBytes())
+                        // Redact log bodies: they can contain server addresses, URLs,
+                        // and tokens that must not leave the device.
+                        combined.appendText(redactor.redact(f.readText()))
                     }
                 }
 

--- a/android/app/src/main/java/com/sendspindroid/logging/RedactionFilter.kt
+++ b/android/app/src/main/java/com/sendspindroid/logging/RedactionFilter.kt
@@ -1,0 +1,59 @@
+package com.sendspindroid.logging
+
+/**
+ * Scrubs sensitive data from text before it leaves the device (log export,
+ * bug-report bundles, telemetry).
+ *
+ * Combines two layers:
+ * - **Pattern-based**: IP addresses (v4 + v6), scheme URLs (`ws`/`wss`/`http`/
+ *   `https`/`ma-proxy`), JWTs, and labeled `key=value` tokens.
+ * - **Literal**: caller-supplied [sensitiveTerms] -- the saved servers' names and
+ *   addresses, which are not otherwise pattern-matchable (a chosen name like
+ *   "Living Room" or a LAN hostname can only be removed if we know it).
+ *
+ * Designed to never throw and to err toward over-redaction. Token detection is
+ * deliberately conservative (labeled/JWT/bearer only) to avoid mangling
+ * legitimate opaque payloads in logs (e.g. base64 codec headers); see the
+ * Diagnostics & Feedback spec, open question on token aggressiveness.
+ */
+class RedactionFilter(sensitiveTerms: Collection<String> = emptyList()) {
+
+    // Longest first so a term isn't partially clobbered by a shorter overlapping one.
+    private val literalTerms: List<String> = sensitiveTerms
+        .map { it.trim() }
+        .filter { it.length >= MIN_TERM_LENGTH }
+        .distinct()
+        .sortedByDescending { it.length }
+
+    fun redact(input: String): String {
+        var s = input
+        for (term in literalTerms) s = s.replace(term, REDACTED)
+        s = URL.replace(s) { "${it.groupValues[1]}://$REDACTED" }
+        s = IPV6_BRACKETED.replace(s, IP)
+        s = IPV6_COMPRESSED.replace(s, IP)
+        s = IPV4.replace(s, IP)
+        s = JWT.replace(s, TOKEN)
+        s = BEARER.replace(s) { "${it.groupValues[1]} $TOKEN" }
+        s = LABELED_TOKEN.replace(s) { "${it.groupValues[1]}${it.groupValues[2]}$TOKEN" }
+        return s
+    }
+
+    companion object {
+        private const val MIN_TERM_LENGTH = 3
+        private const val REDACTED = "<redacted>"
+        private const val IP = "<ip>"
+        private const val TOKEN = "<token>"
+
+        private val URL = Regex("(wss?|https?|ma-proxy)://[^\\s\"'<>]+")
+        private val IPV6_BRACKETED = Regex("\\[[0-9A-Fa-f:]+\\]")
+        // Compressed IPv6 (must contain "::"); the lookbehind avoids eating a
+        // preceding hextet/colon, and the trailing hex avoids matching a lone "::".
+        private val IPV6_COMPRESSED = Regex("(?<![\\w:])[0-9A-Fa-f:]*::[0-9A-Fa-f:]*[0-9A-Fa-f]")
+        private val IPV4 = Regex("\\b\\d{1,3}(?:\\.\\d{1,3}){3}(?::\\d{1,5})?\\b")
+        private val JWT = Regex("\\beyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\b")
+        private val BEARER = Regex("(?i)\\b(bearer)\\s+[A-Za-z0-9._-]{8,}")
+        private val LABELED_TOKEN = Regex(
+            "(?i)\\b(token|authtoken|auth_token|access_token|password|secret|api_key|apikey)(\\s*[=:]\\s*)[^\\s\"]+"
+        )
+    }
+}

--- a/android/app/src/test/java/com/sendspindroid/logging/AppLogTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/logging/AppLogTest.kt
@@ -100,16 +100,50 @@ class AppLogTest {
     }
 
     @Test
-    fun `preference migration - old false maps to OFF`() {
+    fun `lightweight migration - old false debug logging bumps to WARN once`() {
         val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
         val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
-        prefs.edit().putBoolean("debug_logging_enabled", false).commit()
-        prefs.edit().remove("log_level").commit()
+        prefs.edit()
+            .putBoolean("debug_logging_enabled", false)
+            .remove("log_level")
+            .remove("lightweight_logging_migrated")
+            .commit()
+
+        AppLog.init(ctx)
+
+        // Old OFF default is bumped to lightweight WARN so a first bug report isn't empty.
+        assertEquals(LogLevel.WARN, AppLog.level)
+        assertFalse(prefs.contains("debug_logging_enabled"))
+        assertTrue(prefs.getBoolean("lightweight_logging_migrated", false))
+    }
+
+    @Test
+    fun `lightweight migration - fresh install defaults to WARN`() {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
+        prefs.edit()
+            .remove("log_level")
+            .remove("debug_logging_enabled")
+            .remove("lightweight_logging_migrated")
+            .commit()
+
+        AppLog.init(ctx)
+
+        assertEquals(LogLevel.WARN, AppLog.level)
+    }
+
+    @Test
+    fun `lightweight migration - deliberate OFF is preserved once migration has run`() {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
+        prefs.edit()
+            .putString("log_level", "OFF")
+            .putBoolean("lightweight_logging_migrated", true)
+            .commit()
 
         AppLog.init(ctx)
 
         assertEquals(LogLevel.OFF, AppLog.level)
-        assertFalse(prefs.contains("debug_logging_enabled"))
     }
 
     @Test

--- a/android/app/src/test/java/com/sendspindroid/logging/RedactionFilterTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/logging/RedactionFilterTest.kt
@@ -1,0 +1,72 @@
+package com.sendspindroid.logging
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [RedactionFilter] — the scrubber applied to anything leaving the device
+ * (log export, bug-report bundles, telemetry). Verifies it removes IPs/hosts/URLs/
+ * tokens and caller-supplied sensitive terms while preserving normal log content
+ * (and, critically, not mangling timestamps).
+ */
+class RedactionFilterTest {
+
+    private val filter = RedactionFilter()
+
+    @Test
+    fun `redacts IPv4 address with port`() {
+        val out = filter.redact("connecting to 192.168.1.100:8927 now")
+        assertFalse(out.contains("192.168.1.100"))
+        assertTrue(out.contains("<ip>"))
+    }
+
+    @Test
+    fun `redacts ws and wss and http URLs keeping the scheme`() {
+        assertEquals("ws://<redacted>", filter.redact("ws://10.0.2.8:8927/ws"))
+        assertEquals("https://<redacted>", filter.redact("https://music.home.example.com/imageproxy/abc?size=512"))
+        assertEquals("ma-proxy://<redacted>", filter.redact("ma-proxy:///imageproxy/deadbeef"))
+    }
+
+    @Test
+    fun `redacts bracketed and compressed IPv6`() {
+        assertFalse(filter.redact("peer [2001:db8::1]:8927").contains("2001:db8"))
+        assertFalse(filter.redact("loopback ::1 reached").contains("::1"))
+    }
+
+    @Test
+    fun `does not mangle a logcat timestamp`() {
+        val line = "06-15 17:50:41.459 20413 D SendSpin: time sync ok"
+        assertEquals(line, filter.redact(line))
+    }
+
+    @Test
+    fun `redacts JWT and labeled tokens`() {
+        assertTrue(filter.redact("token=eyJhbGc.eyJzdWI.c2lnbmF0dXJl").contains("<token>"))
+        val labeled = filter.redact("authToken=s3cr3t-value-xyz")
+        assertFalse(labeled.contains("s3cr3t-value-xyz"))
+        assertTrue(labeled.contains("<token>"))
+    }
+
+    @Test
+    fun `redacts caller-supplied sensitive terms (server name and host)`() {
+        val f = RedactionFilter(listOf("Living Room", "music.home.example.com"))
+        val out = f.redact("Session started: Living Room (music.home.example.com:8095)")
+        assertFalse(out.contains("Living Room"))
+        assertFalse(out.contains("music.home.example.com"))
+    }
+
+    @Test
+    fun `ignores blank and too-short sensitive terms`() {
+        val f = RedactionFilter(listOf("", "  ", "a"))
+        // A lone short term must not redact every 'a' in the text.
+        assertEquals("a quick audio sample", f.redact("a quick audio sample"))
+    }
+
+    @Test
+    fun `preserves ordinary log content and app version`() {
+        val line = "AudioTrack initialized: 48000Hz, 2ch, 16bit (v2.0.0-Beta12)"
+        assertEquals(line, filter.redact(line))
+    }
+}


### PR DESCRIPTION
Phase 1 of the **Diagnostics & Feedback** system (spec: `docs/superpowers/specs/2026-06-16-diagnostics-feedback-system.md`). Goal: make the logs users *already* export **safe to share**, and **capture something by default** — the foundation every later piece (Report-a-problem, crash capture, handoff telemetry) builds on.

## What's here

**1. `RedactionFilter`** — scrubs anything leaving the device:
- IPv4 / IPv6 (bracketed + compressed) addresses
- scheme URLs (`ws`/`wss`/`http`/`https`/`ma-proxy`) → scheme kept, rest `<redacted>`
- JWTs and labeled `key=value` tokens (conservative, to avoid mangling legit payloads)
- caller-supplied **literal terms** — saved/discovered server *names*, LAN addresses, proxy URLs (a chosen name like "Living Room" can only be removed if we know it)
- **preserves** ordinary log content and, critically, **logcat timestamps** (no `::` / 8-group false positives)
- Remote IDs are kept (identifiers, not secrets).

**2. Redacted export** — `AppLog.shareIntent` / `LogFileWriter.shareIntent` now run every log body through the redactor; `SettingsActivity` supplies the known server names/addresses/proxy URLs. Previously the export leaked the server address and proxy URL straight into whatever share target (e.g. a public GitHub issue).

**3. Lightweight always-on logging** — default flips `OFF → WARN` via a one-time, flag-guarded migration so a first-occurrence bug report isn't empty. A user who deliberately picks `OFF` afterward is respected.

## Deferred (intentional)
Folding the `getStats()` diagnostic snapshot into reports moves to **Phase 2** (the Report-a-problem flow), which already orchestrates an async snapshot capture — building it twice would be wasteful.

## Tests
- `RedactionFilterTest` — 8 cases incl. IPv4+port, ws/wss/http URLs, bracketed/compressed IPv6, **timestamp non-mangling**, JWT/labeled tokens, literal server terms, blank/short-term guard, ordinary-content preservation.
- `AppLogTest` — updated for the lightweight migration: old-false→WARN bump, fresh-install→WARN, deliberate-OFF preserved once migrated.
- Full `:app:testDebugUnitTest` green.

## Manual check worth doing
On-device: export logs while connected and confirm the combined file shows `<ip>` / `scheme://<redacted>` / `<redacted>` in place of the real server address/name. (Not automated here — `LogFileWriter.shareIntent` needs a `Context`; the redactor itself is unit-tested.)