### PR TITLE
feat(diagnostics): crash capture + next-launch report prompt (Phase 2a)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/MainActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/MainActivity.kt
@@ -24,7 +24,9 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.util.Log
+import com.sendspindroid.diagnostics.DiagnosticsExport
 import com.sendspindroid.logging.AppLog
+import com.sendspindroid.logging.CrashHandler
 import android.app.UiModeManager
 import android.annotation.TargetApi
 import android.graphics.RenderEffect
@@ -364,6 +366,27 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
+     * If the previous run ended in an uncaught exception, show a gentle,
+     * dismissible Snackbar offering to share a (redacted) diagnostics report.
+     */
+    private fun maybeShowCrashReportPrompt() {
+        CrashHandler.consumePending(this) ?: return
+        Snackbar.make(snackbarView, R.string.crash_report_prompt, Snackbar.LENGTH_INDEFINITE)
+            .setAction(R.string.crash_report_action) { shareDiagnostics() }
+            .show()
+    }
+
+    /** Share the redacted diagnostics bundle via the system chooser. */
+    private fun shareDiagnostics() {
+        val intent = DiagnosticsExport.shareIntent(this)
+        if (intent != null) {
+            startActivity(Intent.createChooser(intent, getString(R.string.debug_share_chooser_title)))
+        } else {
+            Snackbar.make(snackbarView, R.string.debug_log_export_failed, Snackbar.LENGTH_LONG).show()
+        }
+    }
+
+    /**
      * Shows a success Snackbar with appropriate styling.
      *
      * @param message The success message to display
@@ -488,9 +511,7 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
-        // Initialize on-device logging facade. This also runs one-time pref migration from the
-        // legacy `debug_logging_enabled` flag to the new `log_level` string.
-        AppLog.init(this)
+        // Logging + crash capture are initialized in SendSpinApp.onCreate, before any Activity.
         AppLog.App.i("MainActivity onCreate (log level: ${AppLog.level})")
 
         // Initialize UnifiedServerRepository for unified server management
@@ -527,6 +548,9 @@ class MainActivity : AppCompatActivity() {
 
         // Show onboarding dialog for first-time users
         showOnboardingIfNeeded()
+
+        // If the previous run crashed, offer to send a report.
+        maybeShowCrashReportPrompt()
 
         // Request notification permission for Android 13+
         requestNotificationPermission()

--- a/android/app/src/main/java/com/sendspindroid/SendSpinApp.kt
+++ b/android/app/src/main/java/com/sendspindroid/SendSpinApp.kt
@@ -5,6 +5,8 @@ import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.request.CachePolicy
 import com.google.android.material.color.DynamicColors
+import com.sendspindroid.logging.AppLog
+import com.sendspindroid.logging.CrashHandler
 import com.sendspindroid.musicassistant.MaProxyImageFetcher
 import com.sendspindroid.musicassistant.MaSettings
 
@@ -13,6 +15,11 @@ class SendSpinApp : Application(), ImageLoaderFactory {
         super.onCreate()
         // Initialize MaSettings early so it is available before any Activity or Service.
         MaSettings.initialize(this)
+        // Initialize logging and install crash capture as early as possible, so
+        // startup-path issues are captured and an unexpected exit can be reported
+        // on the next launch. Runs the one-time log-level migration too.
+        AppLog.init(this)
+        CrashHandler.install(this)
         // On Android 12+, applies wallpaper-derived colors to all activities.
         // On older devices, falls back to the static theme colors.
         DynamicColors.applyToActivitiesIfAvailable(this)

--- a/android/app/src/main/java/com/sendspindroid/SettingsActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/SettingsActivity.kt
@@ -7,7 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import com.sendspindroid.logging.AppLog
+import com.sendspindroid.diagnostics.DiagnosticsExport
 import com.sendspindroid.ui.settings.SettingsScreen
 import com.sendspindroid.ui.settings.SettingsViewModel
 import com.sendspindroid.ui.theme.SendSpinTheme
@@ -40,7 +40,7 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     private fun exportDebugLogs() {
-        val shareIntent = AppLog.shareIntent(this, collectRedactionTerms())
+        val shareIntent = DiagnosticsExport.shareIntent(this)
 
         if (shareIntent != null) {
             val chooserIntent = Intent.createChooser(
@@ -51,19 +51,6 @@ class SettingsActivity : AppCompatActivity() {
             Toast.makeText(this, R.string.debug_log_exported, Toast.LENGTH_SHORT).show()
         } else {
             Toast.makeText(this, R.string.debug_log_export_failed, Toast.LENGTH_SHORT).show()
-        }
-    }
-
-    /**
-     * Literal strings to scrub from exported logs: every known server's chosen
-     * name, LAN address, and proxy URL. (Remote IDs are identifiers, not secrets,
-     * so they're kept for debugging.)
-     */
-    private fun collectRedactionTerms(): List<String> {
-        val servers = UnifiedServerRepository.savedServers.value +
-            UnifiedServerRepository.discoveredServers.value
-        return servers.flatMap { server ->
-            listOfNotNull(server.name, server.local?.address, server.proxy?.url)
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/diagnostics/DiagnosticsExport.kt
+++ b/android/app/src/main/java/com/sendspindroid/diagnostics/DiagnosticsExport.kt
@@ -1,0 +1,30 @@
+package com.sendspindroid.diagnostics
+
+import android.content.Context
+import android.content.Intent
+import com.sendspindroid.UnifiedServerRepository
+import com.sendspindroid.logging.AppLog
+
+/**
+ * Builds the shareable, **redacted** diagnostics bundle. Shared by the Settings
+ * "Export logs" action and the crash-report prompt so both scrub the same
+ * sensitive terms.
+ */
+object DiagnosticsExport {
+
+    /**
+     * Literal strings to scrub from exported logs: every known server's chosen
+     * name, LAN address, and proxy URL. (Remote IDs are identifiers, not secrets,
+     * so they're kept for debugging.)
+     */
+    fun redactionTerms(): List<String> {
+        val servers = UnifiedServerRepository.savedServers.value +
+            UnifiedServerRepository.discoveredServers.value
+        return servers.flatMap { server ->
+            listOfNotNull(server.name, server.local?.address, server.proxy?.url)
+        }
+    }
+
+    /** A redacted log share intent, or null when there's nothing to share. */
+    fun shareIntent(context: Context): Intent? = AppLog.shareIntent(context, redactionTerms())
+}

--- a/android/app/src/main/java/com/sendspindroid/logging/AppLog.kt
+++ b/android/app/src/main/java/com/sendspindroid/logging/AppLog.kt
@@ -164,6 +164,15 @@ object AppLog {
     fun clear() {
         writer?.clear()
     }
+
+    /**
+     * Synchronously append a crash record to the active log file. Used by
+     * [CrashHandler] on the dying process, so it bypasses the async [LogcatBridge]
+     * and the level gate to guarantee the trace is on disk before the process exits.
+     */
+    fun recordCrash(record: String) {
+        writer?.appendRaw("\n=== CRASH ===\n$record\n")
+    }
 }
 
 /**

--- a/android/app/src/main/java/com/sendspindroid/logging/CrashHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/logging/CrashHandler.kt
@@ -1,0 +1,66 @@
+package com.sendspindroid.logging
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Captures otherwise-silent crashes so the app can offer to report them.
+ *
+ * On an uncaught exception it appends the stack trace to the log file
+ * (synchronously, since the process is about to die) and sets a "pending crash"
+ * preference with a one-line summary. On the next launch the app reads the flag
+ * via [consumePending] and offers to send a report. It always delegates to the
+ * previously-installed handler so the OS still records/reports the crash normally.
+ */
+class CrashHandler private constructor(
+    private val appContext: Context,
+    private val previous: Thread.UncaughtExceptionHandler?,
+) : Thread.UncaughtExceptionHandler {
+
+    override fun uncaughtException(thread: Thread, throwable: Throwable) {
+        runCatching { record(thread, throwable) } // never let crash handling crash the crash
+        previous?.uncaughtException(thread, throwable)
+    }
+
+    private fun record(thread: Thread, throwable: Throwable) {
+        val stack = StringWriter().also { throwable.printStackTrace(PrintWriter(it)) }.toString()
+        val ts = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
+        AppLog.recordCrash("$ts on thread '${thread.name}'\n$stack")
+
+        val summary = "${throwable.javaClass.simpleName}: ${throwable.message ?: "no message"}"
+        // commit() (synchronous) so the flag survives the imminent process death.
+        PreferenceManager.getDefaultSharedPreferences(appContext).edit()
+            .putBoolean(PREF_PENDING_CRASH, true)
+            .putString(PREF_CRASH_SUMMARY, summary)
+            .commit()
+    }
+
+    companion object {
+        const val PREF_PENDING_CRASH = "pending_crash_report"
+        const val PREF_CRASH_SUMMARY = "pending_crash_summary"
+
+        /** Install once, as early as possible (Application.onCreate). Idempotent. */
+        fun install(context: Context) {
+            val current = Thread.getDefaultUncaughtExceptionHandler()
+            if (current is CrashHandler) return // already installed
+            Thread.setDefaultUncaughtExceptionHandler(CrashHandler(context.applicationContext, current))
+        }
+
+        /**
+         * If the previous run crashed, returns its summary and clears the flag;
+         * otherwise null. Call once at startup to drive the report prompt.
+         */
+        fun consumePending(context: Context): String? {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            if (!prefs.getBoolean(PREF_PENDING_CRASH, false)) return null
+            val summary = prefs.getString(PREF_CRASH_SUMMARY, null) ?: "Unexpected error"
+            prefs.edit().remove(PREF_PENDING_CRASH).remove(PREF_CRASH_SUMMARY).commit()
+            return summary
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -228,6 +228,10 @@
     <string name="debug_log_exported">Debug log exported</string>
     <string name="debug_log_export_failed">Failed to export debug log</string>
 
+    <!-- Crash report prompt -->
+    <string name="crash_report_prompt">SendSpin closed unexpectedly last time</string>
+    <string name="crash_report_action">Report</string>
+
     <!-- About -->
     <string name="pref_category_about">About</string>
     <string name="pref_version_title">Version</string>

--- a/android/app/src/test/java/com/sendspindroid/logging/CrashHandlerTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/logging/CrashHandlerTest.kt
@@ -1,0 +1,81 @@
+package com.sendspindroid.logging
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class CrashHandlerTest {
+
+    private var original: Thread.UncaughtExceptionHandler? = null
+
+    @Before
+    fun setUp() {
+        original = Thread.getDefaultUncaughtExceptionHandler()
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        AppLog.init(ctx) // creates the log writer used by recordCrash()
+        PreferenceManager.getDefaultSharedPreferences(ctx).edit().clear().commit()
+    }
+
+    @After
+    fun tearDown() {
+        Thread.setDefaultUncaughtExceptionHandler(original)
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        PreferenceManager.getDefaultSharedPreferences(ctx).edit().clear().commit()
+    }
+
+    @Test
+    fun `consumePending returns null when nothing crashed`() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        assertNull(CrashHandler.consumePending(ctx))
+    }
+
+    @Test
+    fun `uncaught exception records crash, flags pending, and delegates to previous handler`() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        var delegated = false
+        Thread.setDefaultUncaughtExceptionHandler { _, _ -> delegated = true }
+        CrashHandler.install(ctx)
+
+        Thread.getDefaultUncaughtExceptionHandler()!!
+            .uncaughtException(Thread.currentThread(), IllegalStateException("kaboom"))
+
+        assertTrue("must delegate to the previously-installed handler", delegated)
+
+        val logged = AppLog.writer!!.currentFiles().joinToString("\n") { it.readText() }
+        assertTrue("crash marker present in log file", logged.contains("=== CRASH ==="))
+        assertTrue(
+            "exception present in log file",
+            logged.contains("kaboom") || logged.contains("IllegalStateException")
+        )
+
+        val summary = CrashHandler.consumePending(ctx)
+        assertNotNull("pending crash summary present", summary)
+        assertTrue("summary mentions the exception", summary!!.contains("kaboom"))
+        assertNull("flag cleared after consume", CrashHandler.consumePending(ctx))
+    }
+
+    @Test
+    fun `install is idempotent`() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        CrashHandler.install(ctx)
+        val first = Thread.getDefaultUncaughtExceptionHandler()
+        CrashHandler.install(ctx)
+        assertSame(
+            "second install must not re-wrap the handler",
+            first,
+            Thread.getDefaultUncaughtExceptionHandler()
+        )
+    }
+}


### PR DESCRIPTION
Phase 2a of the **Diagnostics & Feedback** system (spec: `docs/superpowers/specs/2026-06-16-diagnostics-feedback-system.md`).

> **Stacked on #175** (Phase 1 redactor) — the crash report shares its redacted export, so this PR targets the Phase 1 branch. Retarget to `main` once #175 merges.

## What's here

- **`CrashHandler`** — installs a default uncaught-exception handler that:
  - writes the stack trace to the log file **synchronously** (`AppLog.recordCrash`, bypassing the async LogcatBridge so the trace lands before the process dies),
  - sets a pending-crash pref (`commit()`, so it survives the imminent exit) with a one-line summary,
  - then **delegates to the previous handler** so the OS still records/reports the crash normally.
- **Init moved to the Application** — `AppLog.init` + `CrashHandler.install` now run in `SendSpinApp.onCreate` (before any Activity), so startup-path issues are captured and logging is live from app start. Removed the old `MainActivity` init call.
- **Next-launch prompt** — `MainActivity` shows a gentle, dismissible Snackbar after a crash ("SendSpin closed unexpectedly last time" → **Report**) that shares the redacted diagnostics bundle.
- **`DiagnosticsExport`** — extracted so the Settings "Export logs" action and the crash prompt share one redacted-bundle path (replaces the per-Activity helper).

## Tests
- `CrashHandlerTest` (Robolectric): records the stack to the log file + flags pending + delegates to the previous handler; `consumePending` returns the summary then clears; `install` is idempotent.
- Full `:app:testDebugUnitTest` green.

## Manual check (device was disconnected during this work)
1. **Startup**: launch the app and confirm it starts cleanly (verifies the `init`-into-Application move).
2. **Crash loop**: trigger a crash, relaunch, and confirm the "closed unexpectedly" Snackbar appears with a working **Report** action. (No in-app crash trigger exists; needs a real/forced crash.)

## Next (Phase 2b / 2c)
- 2b — "Report a problem": live `getStats()` snapshot folded into the bundle + pre-filled GitHub issue + `.github` issue template.
- 2c — the "Diagnostics & Feedback" hub UI consolidating the surfaces.