### PR TITLE
feat(diagnostics): Report a problem flow (Phase 2b)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,34 @@
+name: Bug report
+description: Report a problem with SendSpin Player
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The in-app **Settings → Report a problem** action pre-fills this form's
+        environment and shares a redacted diagnostics file. Please attach that file.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+      description: What happened, and what did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1.
+        2.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: App version, device, Android version, connection methods (auto-filled by the app).
+  - type: checkboxes
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      options:
+        - label: I've attached the redacted diagnostics file shared from the app.

--- a/android/app/src/main/java/com/sendspindroid/SettingsActivity.kt
+++ b/android/app/src/main/java/com/sendspindroid/SettingsActivity.kt
@@ -7,10 +7,13 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.sendspindroid.diagnostics.DiagnosticSnapshot
 import com.sendspindroid.diagnostics.DiagnosticsExport
 import com.sendspindroid.ui.settings.SettingsScreen
 import com.sendspindroid.ui.settings.SettingsViewModel
 import com.sendspindroid.ui.theme.SendSpinTheme
+import kotlinx.coroutines.launch
 
 /**
  * Activity hosting the Compose-based settings screen.
@@ -33,6 +36,7 @@ class SettingsActivity : AppCompatActivity() {
                     viewModel = viewModel,
                     onNavigateBack = { finish() },
                     onExportLogs = { exportDebugLogs() },
+                    onReportProblem = { reportProblem() },
                     onRestartApp = { restartApp() }
                 )
             }
@@ -51,6 +55,29 @@ class SettingsActivity : AppCompatActivity() {
             Toast.makeText(this, R.string.debug_log_exported, Toast.LENGTH_SHORT).show()
         } else {
             Toast.makeText(this, R.string.debug_log_export_failed, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    /**
+     * Capture a live diagnostic snapshot, bundle it with the redacted logs, and
+     * open the share sheet (the share text carries the environment + a pre-filled
+     * GitHub issue link). Snapshot capture is async, so this runs in a coroutine.
+     */
+    private fun reportProblem() {
+        lifecycleScope.launch {
+            val snapshot = DiagnosticSnapshot.capture(this@SettingsActivity)
+            val shareIntent = DiagnosticsExport.reportIntent(this@SettingsActivity, snapshot)
+            if (shareIntent != null) {
+                startActivity(
+                    Intent.createChooser(shareIntent, getString(R.string.report_chooser_title))
+                )
+            } else {
+                Toast.makeText(
+                    this@SettingsActivity,
+                    R.string.debug_log_export_failed,
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/diagnostics/DiagnosticSnapshot.kt
+++ b/android/app/src/main/java/com/sendspindroid/diagnostics/DiagnosticSnapshot.kt
@@ -1,0 +1,62 @@
+package com.sendspindroid.diagnostics
+
+import android.content.ComponentName
+import android.content.Context
+import android.os.Bundle
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionToken
+import com.sendspindroid.playback.PlaybackService
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+
+/**
+ * Captures the live diagnostic stats from [PlaybackService] as a text block for
+ * bug reports. The same data shown in "Stats for Nerds", obtained one-shot via a
+ * short-lived [MediaController] so any Context (e.g. Settings) can request it.
+ *
+ * Returned text is **not** redacted here -- the report path redacts the whole
+ * bundle (snapshot + logs) uniformly. See [DiagnosticsExport].
+ */
+object DiagnosticSnapshot {
+
+    private const val TIMEOUT_MS = 3_000L
+
+    suspend fun capture(context: Context): String {
+        val bundle = withTimeoutOrNull(TIMEOUT_MS) { requestStats(context.applicationContext) }
+        return if (bundle == null || bundle.isEmpty) {
+            "--- Diagnostic snapshot ---\n(unavailable -- not connected to a server)"
+        } else {
+            format(bundle)
+        }
+    }
+
+    private suspend fun requestStats(context: Context): Bundle? =
+        suspendCancellableCoroutine { cont ->
+            val token = SessionToken(context, ComponentName(context, PlaybackService::class.java))
+            val future = MediaController.Builder(context, token).buildAsync()
+            future.addListener({
+                val controller = runCatching { future.get() }.getOrNull()
+                if (controller == null) {
+                    if (cont.isActive) cont.resume(null)
+                    return@addListener
+                }
+                val command = SessionCommand(PlaybackService.COMMAND_GET_STATS, Bundle.EMPTY)
+                val result = controller.sendCustomCommand(command, Bundle.EMPTY)
+                result.addListener({
+                    val extras = runCatching { result.get().extras }.getOrNull()
+                    controller.release()
+                    if (cont.isActive) cont.resume(extras)
+                }, context.mainExecutor)
+            }, context.mainExecutor)
+        }
+
+    private fun format(bundle: Bundle): String = buildString {
+        appendLine("--- Diagnostic snapshot ---")
+        for (key in bundle.keySet().sorted()) {
+            @Suppress("DEPRECATION")
+            appendLine("$key=${bundle.get(key)}")
+        }
+    }
+}

--- a/android/app/src/main/java/com/sendspindroid/diagnostics/DiagnosticsExport.kt
+++ b/android/app/src/main/java/com/sendspindroid/diagnostics/DiagnosticsExport.kt
@@ -27,4 +27,28 @@ object DiagnosticsExport {
 
     /** A redacted log share intent, or null when there's nothing to share. */
     fun shareIntent(context: Context): Intent? = AppLog.shareIntent(context, redactionTerms())
+
+    /**
+     * A bug-report share intent: the redacted logs plus a diagnostic [snapshot]
+     * (also redacted), with the share text carrying the non-sensitive environment
+     * block and a pre-filled GitHub issue link. Returns null when there's nothing
+     * to share.
+     */
+    fun reportIntent(context: Context, snapshot: String): Intent? {
+        val intent = AppLog.shareIntent(context, redactionTerms(), prepend = snapshot) ?: return null
+        val environment = DiagnosticsReport.environmentBlock(context)
+        intent.putExtra(Intent.EXTRA_SUBJECT, "SendSpin bug report")
+        intent.putExtra(
+            Intent.EXTRA_TEXT,
+            buildString {
+                appendLine("SendSpin diagnostics attached (redacted).")
+                appendLine()
+                appendLine(environment)
+                appendLine()
+                appendLine("File a GitHub issue and attach the file:")
+                append(DiagnosticsReport.githubIssueUrl(environment))
+            }
+        )
+        return intent
+    }
 }

--- a/android/app/src/main/java/com/sendspindroid/diagnostics/DiagnosticsReport.kt
+++ b/android/app/src/main/java/com/sendspindroid/diagnostics/DiagnosticsReport.kt
@@ -1,0 +1,62 @@
+package com.sendspindroid.diagnostics
+
+import android.content.Context
+import android.os.Build
+import com.sendspindroid.UnifiedServerRepository
+import java.net.URLEncoder
+
+/**
+ * Builds the non-sensitive parts of a bug report: the environment block and a
+ * pre-filled GitHub "new issue" URL. The redacted logs + diagnostic snapshot
+ * travel as an attached file (see [DiagnosticsExport.reportIntent]); GitHub URLs
+ * can't carry attachments, so the URL only carries the environment + a template.
+ */
+object DiagnosticsReport {
+
+    private const val REPO = "chrisuthe/SendspinDroid"
+
+    /**
+     * Non-sensitive environment: app version, device, Android, and the configured
+     * connection method *types* (LOCAL/REMOTE/PROXY) -- never addresses or names.
+     */
+    fun environmentBlock(context: Context): String {
+        val version = runCatching {
+            context.packageManager.getPackageInfo(context.packageName, 0).versionName
+        }.getOrNull() ?: "unknown"
+        val methods = UnifiedServerRepository.savedServers.value
+            .flatMap { it.configuredMethods }
+            .map { it.name }
+            .distinct()
+            .ifEmpty { listOf("none") }
+            .joinToString(", ")
+        return buildString {
+            appendLine("- App: $version")
+            appendLine("- Device: ${Build.MANUFACTURER} ${Build.MODEL}")
+            appendLine("- Android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
+            append("- Connection methods: $methods")
+        }
+    }
+
+    /** Pre-filled GitHub new-issue URL carrying the [environment] block + a template. */
+    fun githubIssueUrl(environment: String): String {
+        val body = """
+            **Describe the problem**
+
+
+            **Steps to reproduce**
+            1.
+            2.
+
+            **Environment**
+            $environment
+
+            **Diagnostics**
+            Please attach the diagnostics file shared from the app.
+        """.trimIndent()
+        val title = enc("[Bug] ")
+        val encodedBody = enc(body)
+        return "https://github.com/$REPO/issues/new?labels=bug&title=$title&body=$encodedBody"
+    }
+
+    private fun enc(s: String): String = URLEncoder.encode(s, "UTF-8")
+}

--- a/android/app/src/main/java/com/sendspindroid/logging/AppLog.kt
+++ b/android/app/src/main/java/com/sendspindroid/logging/AppLog.kt
@@ -156,9 +156,16 @@ object AppLog {
      * addresses, proxy URLs) the caller knows are sensitive but that aren't
      * pattern-matchable; they're scrubbed alongside the built-in IP/URL/token
      * patterns. See [RedactionFilter].
+     *
+     * [prepend] is an optional block (e.g. a diagnostic snapshot) written above
+     * the logs and redacted with the same filter.
      */
-    fun shareIntent(context: Context, sensitiveTerms: Collection<String> = emptyList()): Intent? =
-        writer?.shareIntent(context, RedactionFilter(sensitiveTerms))
+    fun shareIntent(
+        context: Context,
+        sensitiveTerms: Collection<String> = emptyList(),
+        prepend: String = "",
+    ): Intent? =
+        writer?.shareIntent(context, RedactionFilter(sensitiveTerms), prepend)
 
     /** Clear all rotated log files. */
     fun clear() {

--- a/android/app/src/main/java/com/sendspindroid/logging/LogFileWriter.kt
+++ b/android/app/src/main/java/com/sendspindroid/logging/LogFileWriter.kt
@@ -88,7 +88,11 @@ internal class LogFileWriter(
         }
     }
 
-    fun shareIntent(context: Context, redactor: RedactionFilter = RedactionFilter()): Intent? {
+    fun shareIntent(
+        context: Context,
+        redactor: RedactionFilter = RedactionFilter(),
+        prepend: String = "",
+    ): Intent? {
         synchronized(lock) {
             val files = currentFiles()
             if (files.isEmpty()) return null
@@ -97,6 +101,10 @@ internal class LogFileWriter(
             return try {
                 // Header is device/version only (intentionally shared, not redacted).
                 combined.writeText(buildShareHeader(context))
+                // Optional diagnostic snapshot, redacted like the log bodies.
+                if (prepend.isNotBlank()) {
+                    combined.appendText("\n${redactor.redact(prepend)}\n")
+                }
                 for (f in files) {
                     if (f.exists()) {
                         combined.appendText("\n----- ${f.name} -----\n")

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -64,6 +64,7 @@ import com.sendspindroid.ui.theme.SendSpinTheme
  * @param viewModel SettingsViewModel for state management
  * @param onNavigateBack Called when back navigation is triggered
  * @param onExportLogs Called when export logs is clicked
+ * @param onReportProblem Called when "Report a problem" is clicked
  * @param onRestartApp Called when app restart is confirmed
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -72,6 +73,7 @@ fun SettingsScreen(
     viewModel: SettingsViewModel,
     onNavigateBack: () -> Unit,
     onExportLogs: () -> Unit,
+    onReportProblem: () -> Unit,
     onRestartApp: () -> Unit
 ) {
     val playerName by viewModel.playerName.collectAsStateWithLifecycle()
@@ -293,6 +295,12 @@ fun SettingsScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+
+            TextPreference(
+                title = stringResource(R.string.pref_report_problem_title),
+                summary = stringResource(R.string.pref_report_problem_summary),
+                onClick = onReportProblem
+            )
 
             TextPreference(
                 title = stringResource(R.string.pref_export_logs_title),

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -227,6 +227,9 @@
     <string name="debug_share_chooser_title">Share Debug Log</string>
     <string name="debug_log_exported">Debug log exported</string>
     <string name="debug_log_export_failed">Failed to export debug log</string>
+    <string name="pref_report_problem_title">Report a problem</string>
+    <string name="pref_report_problem_summary">Share redacted diagnostics and open a GitHub issue</string>
+    <string name="report_chooser_title">Send bug report</string>
 
     <!-- Crash report prompt -->
     <string name="crash_report_prompt">SendSpin closed unexpectedly last time</string>

--- a/android/app/src/test/java/com/sendspindroid/diagnostics/DiagnosticsReportTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/diagnostics/DiagnosticsReportTest.kt
@@ -1,0 +1,42 @@
+package com.sendspindroid.diagnostics
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.net.URLDecoder
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class DiagnosticsReportTest {
+
+    @Test
+    fun `githubIssueUrl targets the repo with the bug label and carries the environment`() {
+        val url = DiagnosticsReport.githubIssueUrl("- App: 2.0.0-Beta12\n- Device: nubia NX809J")
+
+        assertTrue(url.startsWith("https://github.com/chrisuthe/SendspinDroid/issues/new?"))
+        assertTrue("issue is labeled bug", url.contains("labels=bug"))
+
+        val body = URLDecoder.decode(url.substringAfter("body="), "UTF-8")
+        assertTrue("environment carried in body", body.contains("- App: 2.0.0-Beta12"))
+        assertTrue("template prompts for repro", body.contains("Steps to reproduce"))
+        assertTrue("template asks for the diagnostics file", body.contains("attach", ignoreCase = true))
+    }
+
+    @Test
+    fun `environmentBlock reports app device android and method types, never an address`() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val env = DiagnosticsReport.environmentBlock(ctx)
+
+        assertTrue(env.contains("- App:"))
+        assertTrue(env.contains("- Device:"))
+        assertTrue(env.contains("- Android:"))
+        assertTrue(env.contains("Connection methods:"))
+        // No saved servers in the test -> "none"; and never an IP-looking address.
+        assertFalse("must not leak an address", Regex("""\d{1,3}(\.\d{1,3}){3}""").containsMatchIn(env))
+    }
+}


### PR DESCRIPTION
Phase 2b of the **Diagnostics & Feedback** system (spec: `docs/superpowers/specs/2026-06-16-diagnostics-feedback-system.md`).

> **Depends on #177** (which lands Phase 2a on `main`). Merge #177 first — then this PR's diff narrows to just the Phase 2b changes. Until then the diff also shows the 2a delta.

## What's here

- **`DiagnosticSnapshot`** — captures the live `getStats()` diagnostics one-shot via a short-lived `MediaController` + `COMMAND_GET_STATS` (works from any Context, e.g. Settings), with a 3s timeout and graceful "unavailable" fallback. Dumped generically (all bundle keys) so it stays complete as stats evolve.
- **Snapshot folded into the bundle** — `LogFileWriter`/`AppLog.shareIntent` gained a `prepend` that's redacted with the same filter as the logs. So the report = redacted logs **+** redacted snapshot.
- **`DiagnosticsReport`** — a non-sensitive **environment block** (app version, device, Android, connection method *types* — never addresses) and a **pre-filled GitHub new-issue URL** (`URLEncoder`, so it's plain-JVM testable).
- **`DiagnosticsExport.reportIntent`** — assembles the share intent: the bundle file + share text carrying the environment + the issue link.
- **Settings → "Report a problem"** — runs it (async snapshot, then the share sheet). Sits above "Export Debug Logs".
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — structured form for manual filers.

## UX note
GitHub issue URLs can't carry attachments, so the flow shares the redacted bundle **file** and puts the pre-filled issue link + environment in the share **text**; the user attaches the file on GitHub. A more guided one-tap flow can come with the hub (Phase 2c).

## Tests
- `DiagnosticsReportTest`: the issue URL targets the repo with the `bug` label and carries the environment in the body; the environment block has version/device/Android/method-types and never an IP. Full `:app:testDebugUnitTest` green.

## Manual check (device was disconnected during this work)
Settings → Report a problem while connected → confirm the shared file contains a `--- Diagnostic snapshot ---` block with `<ip>`/`<redacted>` in place of real values, and the share text has the environment + GitHub link.

## Next (Phase 2c)
The "Diagnostics & Feedback" hub consolidating status, connection health, live diagnostics, logging, telemetry opt-in, and this report flow.