### PR TITLE
feat(diagnostics): Connection Health handoff recorder (Phase 3)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/diagnostics/HandoffEpisode.kt
+++ b/android/app/src/main/java/com/sendspindroid/diagnostics/HandoffEpisode.kt
@@ -1,0 +1,34 @@
+package com.sendspindroid.diagnostics
+
+/**
+ * One network-handoff "episode": a connection drop + the reconnect attempts that
+ * followed, and whether audio recovered. This is the field instrument for the
+ * "drive away from Wi-Fi" scenario (#2). All fields are categorical/timing -- no
+ * addresses or names -- so an episode is safe to include in a (redacted) report
+ * and, later, in opt-in telemetry.
+ *
+ * See docs/superpowers/specs/2026-06-16-connection-telemetry-design.md.
+ */
+data class HandoffEpisode(
+    val startTs: Long,
+    val fromTransport: String,           // TransportType at episode start (WIFI/CELLULAR/...)
+    val toTransport: String,             // TransportType at close
+    val wasPlaying: Boolean,
+    val configuredMethods: List<String>, // the server's method types (LOCAL/REMOTE/PROXY) -- the denominator
+    val attempts: List<Attempt>,
+    val outcome: Outcome,
+    val recoveredMethod: String?,        // method that succeeded, if RECOVERED
+    val recoveryMs: Long?,               // start -> recovered, if RECOVERED
+) {
+    data class Attempt(val method: String?)
+
+    enum class Outcome { RECOVERED, EXHAUSTED, ABANDONED }
+
+    /** One-line, non-sensitive summary for the diagnostic snapshot / report. */
+    fun summarize(): String {
+        val methods = attempts.joinToString(">") { it.method ?: "?" }
+        val recovery = recoveryMs?.let { " in ${it}ms via ${recoveredMethod ?: "?"}" } ?: ""
+        return "$fromTransport->$toTransport playing=$wasPlaying configured=${configuredMethods.joinToString("/").ifEmpty { "none" }} " +
+            "attempts=[${methods}] -> $outcome$recovery"
+    }
+}

--- a/android/app/src/main/java/com/sendspindroid/diagnostics/HandoffEpisodeRecorder.kt
+++ b/android/app/src/main/java/com/sendspindroid/diagnostics/HandoffEpisodeRecorder.kt
@@ -1,0 +1,95 @@
+package com.sendspindroid.diagnostics
+
+/**
+ * Builds [HandoffEpisode]s from reconnect-status transitions and keeps a bounded
+ * ring buffer of recent ones.
+ *
+ * Decoupled from the coordinator types (it takes primitives) so it's pure and
+ * unit-testable; [com.sendspindroid.playback.PlaybackService] translates
+ * `ReconnectStatus` + the current network/server context into these calls.
+ *
+ * The reconnect cycle `Idle -> Attempting(1) -> Attempting(2) -> Succeeded/Failed`
+ * maps to one episode: the first Attempting opens it, each further Attempting adds
+ * an attempt, and Succeeded/Failed (or a stray Idle) closes it.
+ */
+class HandoffEpisodeRecorder(
+    private val capacity: Int = MAX_EPISODES,
+    private val clock: () -> Long = { System.currentTimeMillis() },
+) {
+    enum class Phase { ATTEMPTING, SUCCEEDED, FAILED, IDLE }
+
+    private class OpenEpisode(
+        val startTs: Long,
+        val fromTransport: String,
+        val wasPlaying: Boolean,
+        val configuredMethods: List<String>,
+        val attempts: MutableList<HandoffEpisode.Attempt> = mutableListOf(),
+    )
+
+    private val ring = ArrayDeque<HandoffEpisode>()
+    private var open: OpenEpisode? = null
+
+    @Synchronized
+    fun onReconnect(
+        phase: Phase,
+        method: String?,
+        transportType: String,
+        configuredMethods: List<String>,
+        isPlaying: Boolean,
+    ) {
+        when (phase) {
+            Phase.ATTEMPTING -> {
+                val ep = open ?: OpenEpisode(
+                    startTs = clock(),
+                    fromTransport = transportType,
+                    wasPlaying = isPlaying,
+                    configuredMethods = configuredMethods,
+                ).also { open = it }
+                ep.attempts.add(HandoffEpisode.Attempt(method))
+            }
+            Phase.SUCCEEDED -> close(
+                HandoffEpisode.Outcome.RECOVERED,
+                transportType,
+                recoveredMethod = open?.attempts?.lastOrNull()?.method,
+            )
+            Phase.FAILED -> close(HandoffEpisode.Outcome.EXHAUSTED, transportType, null)
+            Phase.IDLE -> if (open != null) close(HandoffEpisode.Outcome.ABANDONED, transportType, null)
+        }
+    }
+
+    private fun close(outcome: HandoffEpisode.Outcome, toTransport: String, recoveredMethod: String?) {
+        val ep = open ?: return
+        ring.addLast(
+            HandoffEpisode(
+                startTs = ep.startTs,
+                fromTransport = ep.fromTransport,
+                toTransport = toTransport,
+                wasPlaying = ep.wasPlaying,
+                configuredMethods = ep.configuredMethods,
+                attempts = ep.attempts.toList(),
+                outcome = outcome,
+                recoveredMethod = recoveredMethod,
+                recoveryMs = if (outcome == HandoffEpisode.Outcome.RECOVERED) clock() - ep.startTs else null,
+            )
+        )
+        while (ring.size > capacity) ring.removeFirst()
+        open = null
+    }
+
+    @Synchronized
+    fun recent(): List<HandoffEpisode> = ring.toList()
+
+    /** Newest-first summary block for the diagnostic snapshot / report. */
+    @Synchronized
+    fun summary(): String {
+        if (ring.isEmpty()) return "--- Connection health ---\n(no handoff episodes recorded)"
+        return buildString {
+            appendLine("--- Connection health (${ring.size} recent handoff episodes) ---")
+            ring.reversed().forEach { appendLine(it.summarize()) }
+        }.trimEnd()
+    }
+
+    companion object {
+        const val MAX_EPISODES = 50
+    }
+}

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -51,6 +51,7 @@ import com.sendspindroid.coordinator.ConnectionCoordinator
 import com.sendspindroid.coordinator.FailureReason
 import com.sendspindroid.coordinator.ReconnectStatus
 import com.sendspindroid.coordinator.TransportState
+import com.sendspindroid.diagnostics.HandoffEpisodeRecorder
 import com.sendspindroid.logging.AppLog
 import com.sendspindroid.logging.LogLevel
 import com.sendspindroid.model.PlaybackState
@@ -152,6 +153,10 @@ class PlaybackService : MediaLibraryService() {
     private val _currentServerFlow = MutableStateFlow<UnifiedServer?>(null)
 
     private lateinit var coordinator: ConnectionCoordinator
+
+    // Records network-handoff episodes (drop + reconnect attempts + outcome) from
+    // the coordinator's reconnect status, surfaced in getStats() / bug reports.
+    private val handoffRecorder = HandoffEpisodeRecorder()
 
     // mDNS discovery for Android Auto browse tree
     private var browseDiscoveryManager: NsdDiscoveryManager? = null
@@ -744,6 +749,7 @@ class PlaybackService : MediaLibraryService() {
         serviceScope.launch {
             coordinator.reconnectStatus.collect { status ->
                 _reconnectStatusRelay.value = status
+                recordHandoff(status)
             }
         }
 
@@ -3143,6 +3149,21 @@ class PlaybackService : MediaLibraryService() {
      * Collects current stats from SyncAudioPlayer and SendSpin.
      * Returns a Bundle containing all stats for Stats for Nerds display.
      */
+    /** Translate a coordinator reconnect status into a handoff-episode event. */
+    private fun recordHandoff(status: ReconnectStatus) {
+        val transport = coordinator.networkState.value.transportType.name
+        val methods = coordinator.sessionState.value.server?.configuredMethods?.map { it.name } ?: emptyList()
+        val playing = syncAudioPlayer?.getStats()?.isPlaying ?: false
+        val phase = when (status) {
+            is ReconnectStatus.Attempting -> HandoffEpisodeRecorder.Phase.ATTEMPTING
+            is ReconnectStatus.Succeeded -> HandoffEpisodeRecorder.Phase.SUCCEEDED
+            is ReconnectStatus.Failed -> HandoffEpisodeRecorder.Phase.FAILED
+            ReconnectStatus.Idle -> HandoffEpisodeRecorder.Phase.IDLE
+        }
+        val method = (status as? ReconnectStatus.Attempting)?.method?.name
+        handoffRecorder.onReconnect(phase, method, transport, methods, playing)
+    }
+
     private fun getStats(): Bundle {
         val bundle = Bundle()
 
@@ -3156,6 +3177,9 @@ class PlaybackService : MediaLibraryService() {
             bundle.putString("connection_state", "Disconnected")
             bundle.putString("audio_codec", "--")
         }
+
+        // Network-handoff episodes (drop + reconnect outcomes) for bug reports.
+        bundle.putString("handoff_episodes", handoffRecorder.summary())
 
         // Get stats from SyncAudioPlayer
         val audioStats = syncAudioPlayer?.getStats()

--- a/android/app/src/test/java/com/sendspindroid/diagnostics/HandoffEpisodeRecorderTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/diagnostics/HandoffEpisodeRecorderTest.kt
@@ -1,0 +1,72 @@
+package com.sendspindroid.diagnostics
+
+import com.sendspindroid.diagnostics.HandoffEpisodeRecorder.Phase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HandoffEpisodeRecorderTest {
+
+    private var now = 1_000L
+    private val methods = listOf("LOCAL", "REMOTE")
+    private val recorder = HandoffEpisodeRecorder(capacity = 3, clock = { now })
+
+    private fun attempt(method: String, transport: String = "CELLULAR", playing: Boolean = true) =
+        recorder.onReconnect(Phase.ATTEMPTING, method, transport, methods, playing)
+
+    @Test
+    fun `attempting then succeeded records a RECOVERED episode with timing`() {
+        now = 1_000L
+        attempt("PROXY", transport = "CELLULAR")
+        now = 1_500L
+        recorder.onReconnect(Phase.SUCCEEDED, null, "CELLULAR", methods, true)
+
+        val episodes = recorder.recent()
+        assertEquals(1, episodes.size)
+        val e = episodes[0]
+        assertEquals(HandoffEpisode.Outcome.RECOVERED, e.outcome)
+        assertEquals(500L, e.recoveryMs)
+        assertEquals("PROXY", e.recoveredMethod)
+        assertEquals("CELLULAR", e.fromTransport)
+        assertEquals(methods, e.configuredMethods)
+        assertTrue(e.wasPlaying)
+        assertEquals(1, e.attempts.size)
+    }
+
+    @Test
+    fun `multiple attempts then failed records an EXHAUSTED episode`() {
+        attempt("PROXY")
+        attempt("REMOTE")
+        attempt("LOCAL")
+        recorder.onReconnect(Phase.FAILED, null, "CELLULAR", methods, true)
+
+        val e = recorder.recent().single()
+        assertEquals(HandoffEpisode.Outcome.EXHAUSTED, e.outcome)
+        assertEquals(3, e.attempts.size)
+        assertNull(e.recoveryMs)
+        assertNull(e.recoveredMethod)
+    }
+
+    @Test
+    fun `idle while an episode is open records ABANDONED`() {
+        attempt("LOCAL")
+        recorder.onReconnect(Phase.IDLE, null, "WIFI", methods, true)
+        assertEquals(HandoffEpisode.Outcome.ABANDONED, recorder.recent().single().outcome)
+    }
+
+    @Test
+    fun `idle with no open episode is ignored`() {
+        recorder.onReconnect(Phase.IDLE, null, "WIFI", methods, false)
+        assertTrue(recorder.recent().isEmpty())
+    }
+
+    @Test
+    fun `ring buffer drops the oldest beyond capacity`() {
+        repeat(4) {
+            attempt("LOCAL")
+            recorder.onReconnect(Phase.SUCCEEDED, null, "WIFI", methods, true)
+        }
+        assertEquals(3, recorder.recent().size) // capacity = 3
+    }
+}


### PR DESCRIPTION
Phase 3 of the **Diagnostics & Feedback** system — the substantive instrumentation for the "drive away from Wi-Fi" scenario (#2). Clean off `main` (1+2a+2b merged).

## What's here
- **`HandoffEpisode` + `HandoffEpisodeRecorder`** — a bounded ring buffer that turns the coordinator's reconnect-status cycle (`Idle → Attempting(1) → Attempting(2) → Succeeded/Failed`) into **episodes**: from/to transport, the server's **configured method types** (LOCAL/REMOTE/PROXY — *the denominator* that separates "expected" local-only failures from real bugs), the attempts, the outcome (`RECOVERED`/`EXHAUSTED`/`ABANDONED`), and recovery time. All categorical/timing — **no addresses or names**, so it's redaction-safe and telemetry-ready (Phase 4).
- **`PlaybackService` wiring** — feeds the recorder from `coordinator.reconnectStatus` (reusing the existing relay collector) and surfaces a summary via `getStats()` under `handoff_episodes`. Because `DiagnosticSnapshot` dumps the whole stats bundle, **episodes now flow into every bug report automatically** — the recovery-rate-by-config data the spec is after.

The recorder is decoupled from coordinator types (takes primitives), so it's a pure, unit-tested state machine; `PlaybackService` does the translation.

## Tests
`HandoffEpisodeRecorderTest`: recovered (with timing + recovered-method), multi-attempt exhausted, abandoned-on-idle, idle-with-no-open ignored, ring-capacity eviction. Full `:app:testDebugUnitTest` green.

## Scope notes
- The **Connection Health timeline UI** lands with the **hub (Phase 2c)**, where it's a designated section — the data is already captured and visible in reports now.
- On-device episode capture needs a **real Wi-Fi↔cellular change** to exercise (can't force a handoff from adb); the state machine itself is unit-covered.

## Next
- **Phase 2c** — the "Diagnostics & Feedback" hub, now with a real Connection Health pillar to consolidate.
- **Phase 4** — opt-in telemetry upload of these episodes + the Node/SQLite collector on sendspinapp.com.