### PR TITLE
feat(diagnostics): Connection Health UI + Diagnostics & Feedback hub (Phase 2c)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/stats/StatsBottomSheetContent.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/stats/StatsBottomSheetContent.kt
@@ -224,8 +224,46 @@ fun StatsContent(
         StatRow(stringResource(R.string.stats_reanchors), state.reanchorCount.toString(),
             if (state.reanchorCount > 0) ColorWarning else ColorGood)
 
+        HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
+        // === CONNECTION HEALTH (network-handoff episodes) ===
+        SectionHeader(stringResource(R.string.stats_section_connection_health))
+        val episodes = handoffEpisodeLines(state.handoffEpisodes)
+        if (episodes.isEmpty()) {
+            Text(
+                text = stringResource(R.string.stats_no_handoffs),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 4.dp),
+            )
+        } else {
+            episodes.forEach { line ->
+                Text(
+                    text = line,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = handoffLineColor(line),
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+            }
+        }
+
         Spacer(modifier = Modifier.height(32.dp))
     }
+}
+
+/** Episode lines from the recorder's summary, dropping its header / empty marker. */
+private fun handoffEpisodeLines(summary: String?): List<String> =
+    summary?.lineSequence()
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() && !it.startsWith("---") && !it.startsWith("(no ") }
+        ?.toList()
+        ?: emptyList()
+
+private fun handoffLineColor(line: String): Color = when {
+    line.contains("RECOVERED") -> ColorGood
+    line.contains("EXHAUSTED") -> ColorBad
+    else -> ColorWarning
 }
 
 @Composable

--- a/android/app/src/main/java/com/sendspindroid/ui/stats/StatsViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/stats/StatsViewModel.kt
@@ -184,6 +184,9 @@ class StatsViewModel(application: Application) : AndroidViewModel(application) {
             lastDisconnectReason = bundle.getString("last_disconnect_reason", null),
             timeFilterStability = bundle.getDouble("time_filter_stability", 1.0),
             timeFilterConvergenceMs = bundle.getLong("time_filter_convergence_ms", 0L),
+
+            // Connection health (handoff episodes)
+            handoffEpisodes = bundle.getString("handoff_episodes", null),
         )
     }
 
@@ -270,6 +273,9 @@ data class StatsState(
     val lastDisconnectReason: String? = null,
     val timeFilterStability: Double = 1.0,
     val timeFilterConvergenceMs: Long = 0L,
+
+    // Connection health: newline-delimited handoff-episode summary from the recorder.
+    val handoffEpisodes: String? = null,
 ) {
     // Derived values
     val syncErrorMs: Double get() = syncErrorUs / 1000.0

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -112,6 +112,8 @@
     <string name="stats_section_sync_correction">SYNC CORRECTION</string>
     <string name="stats_section_clock_sync">CLOCK SYNC</string>
     <string name="stats_section_dac_audio">DAC / AUDIO</string>
+    <string name="stats_section_connection_health">CONNECTION HEALTH</string>
+    <string name="stats_no_handoffs">No handoff episodes recorded</string>
 
     <!-- Stats labels - Connection -->
     <string name="stats_audio_codec">Codec</string>
@@ -210,7 +212,7 @@
     <string name="pref_search_library_only_summary">When enabled, search results show only content from your local music library.</string>
 
     <!-- Debug logging -->
-    <string name="pref_category_debug">Debug</string>
+    <string name="pref_category_debug">Diagnostics &amp; Feedback</string>
     <string name="pref_log_level_title">Log Level</string>
     <string name="pref_log_level_summary">%1$s (%2$d KB, %3$d files)</string>
     <string name="log_level_off">Off</string>


### PR DESCRIPTION
Phase 2c of the **Diagnostics & Feedback** system. Off clean `main` (Phases 1/2a/2b/3 merged).

## What's here
- **Connection Health section in "Stats for Nerds"** — renders Phase 3's recent network-handoff episodes (it already polls `getStats()`, which now carries `handoff_episodes`), colored by outcome (recovered=green / exhausted=red / abandoned=amber), with a friendly empty state. This gives the handoff timeline its UI home.
- **Settings "Debug" → "Diagnostics & Feedback"** — the in-app hub for logging controls, Report a problem, and export, now framed as such.

## Why this shape
The diagnostics surfaces span two activities (Settings + the live Stats bottom sheet). Rather than a risky refactor to force everything onto one screen, the pragmatic hub puts the **timeline where live diagnostics already live** and reframes the Settings section. A single unified screen can come later if desired.

Full `:app:testDebugUnitTest` green.

## Next
- **Phase 4** — opt-in telemetry upload of the handoff episodes + the Node/SQLite collector on sendspinapp.com (the original fleet-feedback goal). That's the last phase.