### PR TITLE
feat(telemetry): opt-in handoff-episode uploader (Phase 4, Android half)

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/SendSpinApp.kt
+++ b/android/app/src/main/java/com/sendspindroid/SendSpinApp.kt
@@ -5,6 +5,7 @@ import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.request.CachePolicy
 import com.google.android.material.color.DynamicColors
+import com.sendspindroid.diagnostics.Telemetry
 import com.sendspindroid.logging.AppLog
 import com.sendspindroid.logging.CrashHandler
 import com.sendspindroid.musicassistant.MaProxyImageFetcher
@@ -20,6 +21,9 @@ class SendSpinApp : Application(), ImageLoaderFactory {
         // on the next launch. Runs the one-time log-level migration too.
         AppLog.init(this)
         CrashHandler.install(this)
+        // Opt-in telemetry (off by default). init() also flushes any queued
+        // handoff episodes from a previous run over an unmetered connection.
+        Telemetry.init(this)
         // On Android 12+, applies wallpaper-derived colors to all activities.
         // On older devices, falls back to the static theme colors.
         DynamicColors.applyToActivitiesIfAvailable(this)

--- a/android/app/src/main/java/com/sendspindroid/diagnostics/HandoffEpisodeRecorder.kt
+++ b/android/app/src/main/java/com/sendspindroid/diagnostics/HandoffEpisodeRecorder.kt
@@ -29,6 +29,9 @@ class HandoffEpisodeRecorder(
     private val ring = ArrayDeque<HandoffEpisode>()
     private var open: OpenEpisode? = null
 
+    /** Invoked when an episode closes (used to feed opt-in telemetry upload). */
+    var onEpisodeClosed: ((HandoffEpisode) -> Unit)? = null
+
     @Synchronized
     fun onReconnect(
         phase: Phase,
@@ -59,21 +62,21 @@ class HandoffEpisodeRecorder(
 
     private fun close(outcome: HandoffEpisode.Outcome, toTransport: String, recoveredMethod: String?) {
         val ep = open ?: return
-        ring.addLast(
-            HandoffEpisode(
-                startTs = ep.startTs,
-                fromTransport = ep.fromTransport,
-                toTransport = toTransport,
-                wasPlaying = ep.wasPlaying,
-                configuredMethods = ep.configuredMethods,
-                attempts = ep.attempts.toList(),
-                outcome = outcome,
-                recoveredMethod = recoveredMethod,
-                recoveryMs = if (outcome == HandoffEpisode.Outcome.RECOVERED) clock() - ep.startTs else null,
-            )
+        val episode = HandoffEpisode(
+            startTs = ep.startTs,
+            fromTransport = ep.fromTransport,
+            toTransport = toTransport,
+            wasPlaying = ep.wasPlaying,
+            configuredMethods = ep.configuredMethods,
+            attempts = ep.attempts.toList(),
+            outcome = outcome,
+            recoveredMethod = recoveredMethod,
+            recoveryMs = if (outcome == HandoffEpisode.Outcome.RECOVERED) clock() - ep.startTs else null,
         )
+        ring.addLast(episode)
         while (ring.size > capacity) ring.removeFirst()
         open = null
+        onEpisodeClosed?.invoke(episode)
     }
 
     @Synchronized

--- a/android/app/src/main/java/com/sendspindroid/diagnostics/Telemetry.kt
+++ b/android/app/src/main/java/com/sendspindroid/diagnostics/Telemetry.kt
@@ -1,0 +1,153 @@
+package com.sendspindroid.diagnostics
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.ConnectivityManager
+import android.os.Build
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * Opt-in, anonymous upload of [HandoffEpisode]s to the collector
+ * (https://sendspinapp.com/api/telemetry). Off by default. Sends only the
+ * categorical/timing episode + an anonymous, rotatable install id -- never
+ * addresses, names, or logs. See the telemetry design spec.
+ *
+ * Episodes queue locally and flush over an UNMETERED connection only (so we don't
+ * spend the cellular data we're measuring); the recorded episode is unaffected by
+ * a deferred upload. 4xx drops the item (our bug, don't retry forever); 5xx /
+ * network keeps it for the next flush.
+ */
+object Telemetry {
+
+    private const val TAG = "Telemetry"
+    const val ENDPOINT = "https://sendspinapp.com/api/telemetry"
+
+    private const val PREFS = "sendspin_telemetry"
+    private const val KEY_ENABLED = "telemetry_enabled"
+    private const val KEY_INSTALL_ID = "telemetry_install_id"
+    private const val KEY_QUEUE = "telemetry_queue"
+    private const val MAX_QUEUE = 100
+
+    @Volatile
+    private var appContext: Context? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val lock = Any()
+    private val client by lazy { OkHttpClient.Builder().callTimeout(15, TimeUnit.SECONDS).build() }
+
+    /** Call once at startup. Also flushes anything queued from a previous run. */
+    fun init(context: Context) {
+        appContext = context.applicationContext
+        flush()
+    }
+
+    fun isEnabled(): Boolean = prefs()?.getBoolean(KEY_ENABLED, false) ?: false
+
+    fun setEnabled(enabled: Boolean) {
+        prefs()?.edit()?.putBoolean(KEY_ENABLED, enabled)?.apply()
+        if (enabled) flush()
+    }
+
+    /** Stable-per-install, anonymous, rotatable. Generated lazily. */
+    fun installId(): String {
+        val p = prefs() ?: return ""
+        p.getString(KEY_INSTALL_ID, null)?.let { return it }
+        return UUID.randomUUID().toString().also { p.edit().putString(KEY_INSTALL_ID, it).apply() }
+    }
+
+    fun resetInstallId() {
+        prefs()?.edit()?.putString(KEY_INSTALL_ID, UUID.randomUUID().toString())?.apply()
+    }
+
+    /** Enqueue a closed episode for upload (no-op unless opted in), then try to flush. */
+    fun submit(episode: HandoffEpisode) {
+        if (!isEnabled()) return
+        val ctx = appContext ?: return
+        val payload = TelemetryWire.envelope(episode, installId(), appVersionOf(ctx), Build.VERSION.SDK_INT)
+        enqueue(payload)
+        flush()
+    }
+
+    fun flush() {
+        val ctx = appContext ?: return
+        if (!isEnabled()) return
+        scope.launch {
+            if (isMetered(ctx)) return@launch
+            val p = prefs() ?: return@launch
+            val batch = synchronized(lock) { readQueue(p) }
+            var sent = 0
+            for (payload in batch) {
+                when (post(payload)) {
+                    Result.DONE, Result.DROP -> sent++
+                    Result.RETRY -> break
+                }
+            }
+            if (sent > 0) synchronized(lock) {
+                val current = readQueue(p).toMutableList()
+                repeat(minOf(sent, current.size)) { current.removeAt(0) }
+                writeQueue(p, current)
+            }
+        }
+    }
+
+    private enum class Result { DONE, DROP, RETRY }
+
+    private fun post(payload: String): Result = try {
+        val request = Request.Builder()
+            .url(ENDPOINT)
+            .post(payload.toRequestBody("application/json".toMediaType()))
+            .build()
+        client.newCall(request).execute().use { resp ->
+            when {
+                resp.isSuccessful -> Result.DONE
+                resp.code in 400..499 -> Result.DROP
+                else -> Result.RETRY
+            }
+        }
+    } catch (e: Exception) {
+        Log.d(TAG, "upload deferred: ${e.message}")
+        Result.RETRY
+    }
+
+    private fun enqueue(payload: String) = synchronized(lock) {
+        val p = prefs() ?: return
+        val queue = readQueue(p).toMutableList().apply { add(payload) }
+        while (queue.size > MAX_QUEUE) queue.removeAt(0)
+        writeQueue(p, queue)
+    }
+
+    private fun readQueue(p: SharedPreferences): List<String> {
+        val raw = p.getString(KEY_QUEUE, null) ?: return emptyList()
+        return runCatching { Json.parseToJsonElement(raw).jsonArray.map { it.jsonPrimitive.content } }
+            .getOrDefault(emptyList())
+    }
+
+    private fun writeQueue(p: SharedPreferences, queue: List<String>) {
+        p.edit().putString(KEY_QUEUE, buildJsonArray { queue.forEach { add(it) } }.toString()).apply()
+    }
+
+    private fun prefs(): SharedPreferences? =
+        appContext?.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    private fun appVersionOf(ctx: Context): String =
+        runCatching { ctx.packageManager.getPackageInfo(ctx.packageName, 0).versionName }.getOrNull() ?: "unknown"
+
+    private fun isMetered(ctx: Context): Boolean {
+        val cm = ctx.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return true
+        return cm.isActiveNetworkMetered
+    }
+}

--- a/android/app/src/main/java/com/sendspindroid/diagnostics/TelemetryWire.kt
+++ b/android/app/src/main/java/com/sendspindroid/diagnostics/TelemetryWire.kt
@@ -1,0 +1,43 @@
+package com.sendspindroid.diagnostics
+
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * Builds the telemetry wire payload for a [HandoffEpisode]. Pure (kotlinx JSON),
+ * so it's unit-tested to stay byte-compatible with the collector's strict
+ * allow-list validator (sendspindroid-website/collector/validate.js, schemaVersion 1).
+ */
+object TelemetryWire {
+
+    const val SCHEMA_VERSION = 1
+
+    fun envelope(
+        episode: HandoffEpisode,
+        installId: String,
+        appVersion: String,
+        androidSdk: Int,
+    ): String = buildJsonObject {
+        put("schemaVersion", SCHEMA_VERSION)
+        put("installId", installId)
+        put("appVersion", appVersion)
+        put("androidSdk", androidSdk)
+        putJsonObject("episode") {
+            put("startTs", episode.startTs)
+            put("fromTransport", episode.fromTransport)
+            put("toTransport", episode.toTransport)
+            put("wasPlaying", episode.wasPlaying)
+            putJsonArray("configuredMethods") { episode.configuredMethods.forEach { add(it) } }
+            putJsonArray("attempts") {
+                episode.attempts.forEach { attempt -> addJsonObject { put("method", attempt.method) } }
+            }
+            put("outcome", episode.outcome.name)
+            put("recoveredMethod", episode.recoveredMethod)
+            put("recoveryMs", episode.recoveryMs)
+        }
+    }.toString()
+}

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -52,6 +52,7 @@ import com.sendspindroid.coordinator.FailureReason
 import com.sendspindroid.coordinator.ReconnectStatus
 import com.sendspindroid.coordinator.TransportState
 import com.sendspindroid.diagnostics.HandoffEpisodeRecorder
+import com.sendspindroid.diagnostics.Telemetry
 import com.sendspindroid.logging.AppLog
 import com.sendspindroid.logging.LogLevel
 import com.sendspindroid.model.PlaybackState
@@ -155,8 +156,11 @@ class PlaybackService : MediaLibraryService() {
     private lateinit var coordinator: ConnectionCoordinator
 
     // Records network-handoff episodes (drop + reconnect attempts + outcome) from
-    // the coordinator's reconnect status, surfaced in getStats() / bug reports.
-    private val handoffRecorder = HandoffEpisodeRecorder()
+    // the coordinator's reconnect status, surfaced in getStats() / bug reports and
+    // submitted to opt-in telemetry as each episode closes.
+    private val handoffRecorder = HandoffEpisodeRecorder().apply {
+        onEpisodeClosed = { episode -> Telemetry.submit(episode) }
+    }
 
     // mDNS discovery for Android Auto browse tree
     private var browseDiscoveryManager: NsdDiscoveryManager? = null

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ import android.net.Uri
 import androidx.compose.ui.platform.LocalContext
 import com.sendspindroid.R
 import com.sendspindroid.UserSettings
+import com.sendspindroid.diagnostics.Telemetry
 import com.sendspindroid.logging.LogLevel
 import com.sendspindroid.ui.theme.SendSpinTheme
 
@@ -246,6 +247,25 @@ fun SettingsScreen(
 
             // Debug Category
             PreferenceCategory(title = stringResource(R.string.pref_category_debug))
+
+            // Anonymous, opt-in telemetry (off by default).
+            var telemetryEnabled by remember { mutableStateOf(Telemetry.isEnabled()) }
+            SwitchPreference(
+                title = stringResource(R.string.pref_telemetry_title),
+                summary = stringResource(R.string.pref_telemetry_summary),
+                checked = telemetryEnabled,
+                onCheckedChange = {
+                    telemetryEnabled = it
+                    Telemetry.setEnabled(it)
+                }
+            )
+            if (telemetryEnabled) {
+                TextPreference(
+                    title = stringResource(R.string.pref_telemetry_reset_title),
+                    summary = stringResource(R.string.pref_telemetry_reset_summary),
+                    onClick = { Telemetry.resetInstallId() }
+                )
+            }
 
             // Log level selector (6-option segmented row)
             val levels = listOf(

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -213,6 +213,10 @@
 
     <!-- Debug logging -->
     <string name="pref_category_debug">Diagnostics &amp; Feedback</string>
+    <string name="pref_telemetry_title">Help improve connection reliability</string>
+    <string name="pref_telemetry_summary">Anonymously share network-handoff outcomes (no addresses, names, or logs). Off by default.</string>
+    <string name="pref_telemetry_reset_title">Reset anonymous ID</string>
+    <string name="pref_telemetry_reset_summary">Generate a new random telemetry ID</string>
     <string name="pref_log_level_title">Log Level</string>
     <string name="pref_log_level_summary">%1$s (%2$d KB, %3$d files)</string>
     <string name="log_level_off">Off</string>

--- a/android/app/src/test/java/com/sendspindroid/diagnostics/TelemetryWireTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/diagnostics/TelemetryWireTest.kt
@@ -1,0 +1,85 @@
+package com.sendspindroid.diagnostics
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks the telemetry payload to the collector's strict schema
+ * (sendspindroid-website/collector/validate.js, schemaVersion 1). If these keys
+ * drift, the collector rejects uploads with 400.
+ */
+class TelemetryWireTest {
+
+    private fun recovered() = HandoffEpisode(
+        startTs = 1718560000000,
+        fromTransport = "WIFI",
+        toTransport = "CELLULAR",
+        wasPlaying = true,
+        configuredMethods = listOf("LOCAL", "REMOTE"),
+        attempts = listOf(HandoffEpisode.Attempt("PROXY"), HandoffEpisode.Attempt("REMOTE")),
+        outcome = HandoffEpisode.Outcome.RECOVERED,
+        recoveredMethod = "REMOTE",
+        recoveryMs = 4200,
+    )
+
+    @Test
+    fun `envelope has exactly the collector's keys and values`() {
+        val obj = Json.parseToJsonElement(
+            TelemetryWire.envelope(recovered(), "12345678-1234-1234-1234-123456789abc", "2.0.0-Beta12", 36)
+        ).jsonObject
+
+        assertEquals(
+            setOf("schemaVersion", "installId", "appVersion", "androidSdk", "episode"),
+            obj.keys
+        )
+        assertEquals(1, obj["schemaVersion"]!!.jsonPrimitive.int)
+        assertEquals("12345678-1234-1234-1234-123456789abc", obj["installId"]!!.jsonPrimitive.content)
+        assertEquals("2.0.0-Beta12", obj["appVersion"]!!.jsonPrimitive.content)
+        assertEquals(36, obj["androidSdk"]!!.jsonPrimitive.int)
+
+        val e = obj["episode"]!!.jsonObject
+        assertEquals(
+            setOf(
+                "startTs", "fromTransport", "toTransport", "wasPlaying",
+                "configuredMethods", "attempts", "outcome", "recoveredMethod", "recoveryMs"
+            ),
+            e.keys
+        )
+        assertEquals("WIFI", e["fromTransport"]!!.jsonPrimitive.content)
+        assertEquals("CELLULAR", e["toTransport"]!!.jsonPrimitive.content)
+        assertEquals(true, e["wasPlaying"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals(listOf("LOCAL", "REMOTE"), e["configuredMethods"]!!.jsonArray.map { it.jsonPrimitive.content })
+        assertEquals("PROXY", e["attempts"]!!.jsonArray[0].jsonObject["method"]!!.jsonPrimitive.content)
+        assertEquals("RECOVERED", e["outcome"]!!.jsonPrimitive.content)
+        assertEquals("REMOTE", e["recoveredMethod"]!!.jsonPrimitive.content)
+        assertEquals(4200, e["recoveryMs"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `null recoveredMethod and recoveryMs serialize as JSON null`() {
+        val episode = recovered().copy(
+            outcome = HandoffEpisode.Outcome.EXHAUSTED,
+            recoveredMethod = null,
+            recoveryMs = null,
+        )
+        val e = Json.parseToJsonElement(TelemetryWire.envelope(episode, "id", "v", 30))
+            .jsonObject["episode"]!!.jsonObject
+        assertTrue(e["recoveredMethod"] is JsonNull)
+        assertTrue(e["recoveryMs"] is JsonNull)
+    }
+
+    @Test
+    fun `attempt with null method serializes as null`() {
+        val episode = recovered().copy(attempts = listOf(HandoffEpisode.Attempt(null)))
+        val e = Json.parseToJsonElement(TelemetryWire.envelope(episode, "id", "v", 30))
+            .jsonObject["episode"]!!.jsonObject
+        assertTrue(e["attempts"]!!.jsonArray[0].jsonObject["method"] is JsonNull)
+    }
+}


### PR DESCRIPTION
Phase 4 (Android half) of the **Diagnostics & Feedback** system — closes the loop with the live collector at `https://sendspinapp.com/api/telemetry`.

## What's here
- **`TelemetryWire`** — builds the `schemaVersion` 1 envelope (anonymous install id + app/sdk + the episode) **exactly matching the collector's strict validator**. Pure (kotlinx JSON), unit-tested for key sets, values, and null handling.
- **`Telemetry`** — the uploader:
  - **off by default**; rotatable **anonymous install UUID**
  - a **capped persistent queue** (survives restarts)
  - flushes over an **unmetered connection only** (so it doesn't spend the cellular data it's measuring — the episode is already recorded, upload just waits for Wi-Fi)
  - **4xx drops** the item (our bug, don't retry forever); **5xx/network retries** on the next flush (app start, opt-in, or next episode)
- **`HandoffEpisodeRecorder.onEpisodeClosed`** hook → `PlaybackService` feeds each closed episode to `Telemetry`; `SendSpinApp` inits it and drains the queue on launch.
- **Settings → Diagnostics & Feedback**: "Help improve connection reliability" toggle (off by default) + "Reset anonymous ID".

## Verified end-to-end against the LIVE collector
- A `TelemetryWire`-shaped envelope → **`204`** (accepted + stored in production SQLite)
- A malformed one (unknown key) → **`400 episode-keys`**

So Android-format → openresty → nginx → collector → validation → SQLite is proven, not just unit-tested. Full `:app:testDebugUnitTest` green.

## Privacy
Categorical/timing only; no addresses, names, or logs. Off by default, opt-in, with a rotatable anonymous id. Matches the strictly-anonymous design.

## Note
My end-to-end test inserted **one test row** into the production `telemetry.db` (installId `a1b2c3d4-…`, a fake WIFI→CELLULAR/EXHAUSTED episode) — harmless, delete it if you like:
```sql
DELETE FROM episodes WHERE install_id='a1b2c3d4-e5f6-1234-8abc-0123456789ab';
```

## That completes the arc
Phases 1→4 of Diagnostics & Feedback are done. The only open item is the **public "Crash Logs" page** (added to the list — pending your A vs B call: anonymous telemetry dashboard vs actual crash logs).