### PR TITLE
fix(ui): prevent LazyList duplicate-key crash on Home/Library load

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/MaLibraryItemKeys.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/MaLibraryItemKeys.kt
@@ -1,0 +1,24 @@
+package com.sendspindroid.ui.navigation
+
+import com.sendspindroid.musicassistant.model.MaLibraryItem
+
+/**
+ * Stable Compose list key for a Music Assistant library item.
+ *
+ * This is the single source of truth for the key used by every LazyColumn/LazyRow
+ * that renders [MaLibraryItem]s, and for [distinctByItemKey]. They MUST share this
+ * function: Compose throws IllegalArgumentException if a lazy list ever sees two
+ * items with the same key, so the key used for de-duplication can never be allowed
+ * to drift from the key used for rendering.
+ */
+fun maLibraryItemKey(item: MaLibraryItem): String = "${item.mediaType}_${item.id}"
+
+/**
+ * Removes items that would collide on [maLibraryItemKey], keeping the first occurrence.
+ *
+ * Music Assistant can surface the same album/artist under multiple providers (same
+ * id, different provider), and offset-based paging can overlap pages -- either way a
+ * list ends up with two items sharing a key. Rendering both in a LazyColumn/LazyRow
+ * crashes the UI thread, so lists are de-duplicated here before they reach the screen.
+ */
+fun <T : MaLibraryItem> List<T>.distinctByItemKey(): List<T> = distinctBy(::maLibraryItemKey)

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import com.sendspindroid.musicassistant.MaAlbum
 import com.sendspindroid.musicassistant.MaTrack
 import com.sendspindroid.musicassistant.MusicAssistant
 import com.sendspindroid.musicassistant.model.MaLibraryItem
+import com.sendspindroid.ui.navigation.distinctByItemKey
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -156,7 +157,7 @@ class HomeViewModel : ViewModel() {
                         .take(ITEMS_PER_SECTION)
 
                     Log.d(TAG, "Recently played after grouping: ${grouped.size} items")
-                    _recentlyPlayed.value = SectionState.Success(grouped)
+                    _recentlyPlayed.value = SectionState.Success(grouped.distinctByItemKey())
                 },
                 onFailure = { error ->
                     Log.e(TAG, "Failed to load recently played", error)
@@ -190,7 +191,7 @@ class HomeViewModel : ViewModel() {
                         .take(ITEMS_PER_SECTION)
 
                     Log.d(TAG, "Recently added after grouping: ${grouped.size} items")
-                    _recentlyAdded.value = SectionState.Success(grouped)
+                    _recentlyAdded.value = SectionState.Success(grouped.distinctByItemKey())
                 },
                 onFailure = { error ->
                     Log.e(TAG, "Failed to load recently added", error)
@@ -244,7 +245,7 @@ class HomeViewModel : ViewModel() {
             result.fold(
                 onSuccess = { items ->
                     Log.d(TAG, "Playlists: ${items.size} items")
-                    _playlists.value = SectionState.Success(items)
+                    _playlists.value = SectionState.Success(items.distinctByItemKey())
                 },
                 onFailure = { error ->
                     Log.e(TAG, "Failed to load playlists", error)
@@ -266,7 +267,7 @@ class HomeViewModel : ViewModel() {
             result.fold(
                 onSuccess = { items ->
                     Log.d(TAG, "Albums: ${items.size} items")
-                    _albums.value = SectionState.Success(items)
+                    _albums.value = SectionState.Success(items.distinctByItemKey())
                 },
                 onFailure = { error ->
                     Log.e(TAG, "Failed to load albums", error)
@@ -288,7 +289,7 @@ class HomeViewModel : ViewModel() {
             result.fold(
                 onSuccess = { items ->
                     Log.d(TAG, "Artists: ${items.size} items")
-                    _artists.value = SectionState.Success(items)
+                    _artists.value = SectionState.Success(items.distinctByItemKey())
                 },
                 onFailure = { error ->
                     Log.e(TAG, "Failed to load artists", error)
@@ -310,7 +311,7 @@ class HomeViewModel : ViewModel() {
             result.fold(
                 onSuccess = { items ->
                     Log.d(TAG, "Radio stations: ${items.size} items")
-                    _radioStations.value = SectionState.Success(items)
+                    _radioStations.value = SectionState.Success(items.distinctByItemKey())
                 },
                 onFailure = { error ->
                     Log.e(TAG, "Failed to load radio stations", error)

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/home/components/MediaCarousel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/home/components/MediaCarousel.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import com.sendspindroid.ui.navigation.maLibraryItemKey
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -99,7 +100,7 @@ private fun CarouselContent(
     ) {
         items(
             items = items,
-            key = { "${it.mediaType}_${it.id}" }
+            key = { maLibraryItemKey(it) }
         ) { item ->
             MediaCard(
                 item = item,

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseListScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseListScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import com.sendspindroid.ui.navigation.maLibraryItemKey
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
@@ -236,7 +237,7 @@ private fun ItemsList(
     ) {
         items(
             items = items,
-            key = { "${it.mediaType}_${it.id}" }
+            key = { maLibraryItemKey(it) }
         ) { item ->
             val isActionable = item is MaTrack || item is MaAlbum || item is MaArtist
             SearchResultItem(

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/LibraryViewModel.kt
@@ -7,6 +7,7 @@ import com.sendspindroid.UserSettings
 import com.sendspindroid.musicassistant.MusicAssistant
 import com.sendspindroid.musicassistant.model.MaLibraryItem
 import com.sendspindroid.musicassistant.model.MaMediaType
+import com.sendspindroid.ui.navigation.distinctByItemKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -206,11 +207,14 @@ class LibraryViewModel : ViewModel() {
 
         viewModelScope.launch {
             try {
-                val items = fetchItems(type, 0, currentState.sortOption)
+                val fetched = fetchItems(type, 0, currentState.sortOption)
+                val items = fetched.distinctByItemKey()
                 stateFlow.value = TabState(
                     items = items,
                     isLoading = false,
-                    hasMore = items.size >= PAGE_SIZE,
+                    // hasMore keys off the raw page size, not the de-duplicated count,
+                    // so a duplicate in a full page doesn't prematurely stop paging.
+                    hasMore = fetched.size >= PAGE_SIZE,
                     sortOption = currentState.sortOption,
                     albumArtistsOnly = currentState.albumArtistsOnly
                 )
@@ -251,7 +255,10 @@ class LibraryViewModel : ViewModel() {
             try {
                 val newItems = fetchItems(type, offset, currentState.sortOption)
                 stateFlow.value = currentState.copy(
-                    items = currentState.items + newItems,
+                    // De-dup the combined list: offset paging can return an item that
+                    // overlaps the previous page, and a duplicate LazyColumn key crashes
+                    // the UI. hasMore stays on the raw page size (see loadTab).
+                    items = (currentState.items + newItems).distinctByItemKey(),
                     isLoadingMore = false,
                     hasMore = newItems.size >= PAGE_SIZE
                 )

--- a/android/app/src/test/java/com/sendspindroid/ui/navigation/MaLibraryItemKeysTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/ui/navigation/MaLibraryItemKeysTest.kt
@@ -1,0 +1,70 @@
+package com.sendspindroid.ui.navigation
+
+import com.sendspindroid.musicassistant.MaAlbum
+import com.sendspindroid.musicassistant.MaArtist
+import com.sendspindroid.musicassistant.model.MaLibraryItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the LazyColumn/LazyRow duplicate-key crash: Compose throws
+ * IllegalArgumentException ("Key ... was already used") if a lazy list ever sees
+ * two items with the same key. The reported field crash was key "ALBUM_1014".
+ */
+class MaLibraryItemKeysTest {
+
+    private fun album(id: String, provider: String = "library") =
+        MaAlbum(
+            albumId = id,
+            name = "Album $id",
+            imageUri = null,
+            uri = null,
+            artist = "Artist",
+            year = 2024,
+            trackCount = 10,
+            albumType = "album",
+            provider = provider,
+        )
+
+    private fun artist(id: String) =
+        MaArtist(artistId = id, name = "Artist $id", imageUri = null, uri = null)
+
+    @Test
+    fun `key matches the format that crashed in the field`() {
+        // The crash report showed key "ALBUM_1014"; the key fn must reproduce it.
+        assertEquals("ALBUM_1014", maLibraryItemKey(album("1014")))
+    }
+
+    @Test
+    fun `same album id from different providers collapses to one item`() {
+        // Music Assistant surfaces the same album under multiple providers: same
+        // albumId, different provider -> identical key -> would crash the UI.
+        val items: List<MaLibraryItem> =
+            listOf(album("1014", "library"), album("1014", "spotify"))
+        val deduped = items.distinctByItemKey()
+        assertEquals(1, deduped.size)
+        assertEquals("library", (deduped[0] as MaAlbum).provider) // first wins
+    }
+
+    @Test
+    fun `de-dup preserves order and keeps first occurrence`() {
+        val items = listOf(album("1"), album("2"), album("1"), album("3"))
+        val deduped = items.distinctByItemKey()
+        assertEquals(listOf("1", "2", "3"), deduped.map { it.id })
+    }
+
+    @Test
+    fun `same id across different media types does not collide`() {
+        // ALBUM_1 and ARTIST_1 are distinct keys; both must survive.
+        val items: List<MaLibraryItem> = listOf(album("1"), artist("1"))
+        assertEquals(2, items.distinctByItemKey().size)
+    }
+
+    @Test
+    fun `de-dup output never contains a duplicate key`() {
+        val items = listOf(album("1"), album("1"), album("2"), album("2"), album("2"))
+        val keys = items.distinctByItemKey().map { maLibraryItemKey(it) }
+        assertTrue(keys.size == keys.toSet().size)
+    }
+}


### PR DESCRIPTION
## The crash (Beta13, captured on-device by `CrashHandler`)
```
FATAL EXCEPTION: main
java.lang.IllegalArgumentException: Key "ALBUM_1014" was already used.
If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```
Reported as: *app on the tablet, connects, then crashes "as it loads all the MA library bits" — no browsing.* The exported diagnostics log carried the exact stack and key string, which is how this was pinned (not OOM, not Binder — both earlier hypotheses were wrong).

## Root cause
Compose hard-crashes the UI thread if a `LazyColumn`/`LazyRow` ever sees two items with the same `key`. The Home carousels and Library tabs key items by `"${mediaType}_${id}"`, but:
- **Music Assistant returns the same album/artist under multiple providers** — same `id`, different `provider` → identical key.
- **Library uses offset paging with blind append** (`items + newItems`); a page that overlaps the previous one introduces a duplicate `id`.

The **Home screen loads all six carousels in parallel on connect**, so a single duplicate crashes the app before any interaction — exactly matching "crashed on connect, no browsing."

## Fix — one source of truth for the key
- **`maLibraryItemKey(item)`** is now used by *both* the `LazyColumn`/`LazyRow` `key =` lambdas (`MediaCarousel`, `BrowseListScreen`) and the de-dup, so the render key and the de-dup key can never drift apart.
- **`distinctByItemKey()`** drops collisions (keeps first), applied where the lists are built: all six `HomeViewModel` sections and both `LibraryViewModel` load paths.
- Library `hasMore` keys off the **raw** page size, so de-dup can't prematurely stop infinite scroll.

## Tests
`MaLibraryItemKeysTest` (pure JVM, green) reproduces the exact `ALBUM_1014` key and covers: same-id/different-provider collapse, order preservation + first-wins, cross-type non-collision (`ALBUM_1` vs `ARTIST_1`), and "output never contains a duplicate key." Full `:app:testDebugUnitTest` + `assembleDebug` green.

## Known follow-up (intentionally out of scope)
`BrowseContentScreen` (folder browser) and `SearchScreen` use the same composite-key pattern on other surfaces, reachable only by **active browsing/searching** (not the on-connect path). The folder list keys by *path*, so it needs a path-aware key rather than this generic helper. Tracked for a focused follow-up PR.