### PR TITLE
fix(ui): close LazyList duplicate-key crash on Browse and Search

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/MaLibraryItemKeys.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/MaLibraryItemKeys.kt
@@ -1,5 +1,7 @@
 package com.sendspindroid.ui.navigation
 
+import com.sendspindroid.musicassistant.MaBrowseFolder
+import com.sendspindroid.musicassistant.SearchResults
 import com.sendspindroid.musicassistant.model.MaLibraryItem
 
 /**
@@ -10,8 +12,14 @@ import com.sendspindroid.musicassistant.model.MaLibraryItem
  * function: Compose throws IllegalArgumentException if a lazy list ever sees two
  * items with the same key, so the key used for de-duplication can never be allowed
  * to drift from the key used for rendering.
+ *
+ * Browse folders are keyed by [MaBrowseFolder.path] (the value the browse UI keys
+ * on and navigates with), not by their id.
  */
-fun maLibraryItemKey(item: MaLibraryItem): String = "${item.mediaType}_${item.id}"
+fun maLibraryItemKey(item: MaLibraryItem): String = when (item) {
+    is MaBrowseFolder -> "folder_${item.path}"
+    else -> "${item.mediaType}_${item.id}"
+}
 
 /**
  * Removes items that would collide on [maLibraryItemKey], keeping the first occurrence.
@@ -22,3 +30,20 @@ fun maLibraryItemKey(item: MaLibraryItem): String = "${item.mediaType}_${item.id
  * crashes the UI thread, so lists are de-duplicated here before they reach the screen.
  */
 fun <T : MaLibraryItem> List<T>.distinctByItemKey(): List<T> = distinctBy(::maLibraryItemKey)
+
+/**
+ * De-duplicates every per-type list in a [SearchResults] by [maLibraryItemKey].
+ *
+ * The search screen renders each type in its own LazyColumn section, so a duplicate
+ * id within one type (e.g. the same album from two providers) would crash that
+ * section. Each list holds a single media type, so per-list de-dup is sufficient.
+ */
+fun SearchResults.distinctByItemKeys(): SearchResults = copy(
+    artists = artists.distinctByItemKey(),
+    albums = albums.distinctByItemKey(),
+    tracks = tracks.distinctByItemKey(),
+    playlists = playlists.distinctByItemKey(),
+    radios = radios.distinctByItemKey(),
+    podcasts = podcasts.distinctByItemKey(),
+    audiobooks = audiobooks.distinctByItemKey(),
+)

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseContentScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/BrowseContentScreen.kt
@@ -53,6 +53,7 @@ import coil.compose.AsyncImage
 import com.sendspindroid.R
 import com.sendspindroid.musicassistant.MaBrowseFolder
 import com.sendspindroid.musicassistant.model.MaLibraryItem
+import com.sendspindroid.ui.navigation.maLibraryItemKey
 import com.sendspindroid.ui.navigation.search.components.SearchResultItem
 
 /**
@@ -143,9 +144,7 @@ private fun BrowseItemsList(
         }
         items(
             items = items,
-            key = { item ->
-                if (item is MaBrowseFolder) "folder_${item.path}" else "${item.mediaType}_${item.id}"
-            }
+            key = { item -> maLibraryItemKey(item) }
         ) { item ->
             if (item is MaBrowseFolder) {
                 BrowseFolderItem(

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/library/LibraryViewModel.kt
@@ -330,7 +330,7 @@ class LibraryViewModel : ViewModel() {
 
         viewModelScope.launch {
             try {
-                val items = MusicAssistant.browse(currentPath).getOrThrow()
+                val items = MusicAssistant.browse(currentPath).getOrThrow().distinctByItemKey()
                 _browseState.value = TabState(
                     items = items,
                     isLoading = false,

--- a/android/app/src/main/java/com/sendspindroid/ui/navigation/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/navigation/search/SearchViewModel.kt
@@ -7,6 +7,7 @@ import com.sendspindroid.UserSettings
 import com.sendspindroid.musicassistant.MusicAssistant
 import com.sendspindroid.musicassistant.SearchResults
 import com.sendspindroid.musicassistant.model.MaMediaType
+import com.sendspindroid.ui.navigation.distinctByItemKeys
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -207,7 +208,9 @@ class SearchViewModel : ViewModel() {
             onSuccess = { results ->
                 Log.d(TAG, "Search successful: ${results.totalCount()} results")
                 _searchState.value = _searchState.value.copy(
-                    results = results,
+                    // De-dup each type list so a duplicate id within a section
+                    // can't crash its LazyColumn with a repeated key.
+                    results = results.distinctByItemKeys(),
                     isLoading = false,
                     error = null
                 )

--- a/android/app/src/test/java/com/sendspindroid/ui/navigation/MaLibraryItemKeysTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/ui/navigation/MaLibraryItemKeysTest.kt
@@ -2,6 +2,8 @@ package com.sendspindroid.ui.navigation
 
 import com.sendspindroid.musicassistant.MaAlbum
 import com.sendspindroid.musicassistant.MaArtist
+import com.sendspindroid.musicassistant.MaBrowseFolder
+import com.sendspindroid.musicassistant.SearchResults
 import com.sendspindroid.musicassistant.model.MaLibraryItem
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -29,6 +31,9 @@ class MaLibraryItemKeysTest {
 
     private fun artist(id: String) =
         MaArtist(artistId = id, name = "Artist $id", imageUri = null, uri = null)
+
+    private fun folder(id: String, path: String) =
+        MaBrowseFolder(folderId = id, name = "Folder", imageUri = null, uri = null, path = path)
 
     @Test
     fun `key matches the format that crashed in the field`() {
@@ -66,5 +71,25 @@ class MaLibraryItemKeysTest {
         val items = listOf(album("1"), album("1"), album("2"), album("2"), album("2"))
         val keys = items.distinctByItemKey().map { maLibraryItemKey(it) }
         assertTrue(keys.size == keys.toSet().size)
+    }
+
+    @Test
+    fun `browse folder is keyed by path, not id`() {
+        // The browse UI keys and navigates by path; the key must match so de-dup
+        // and rendering agree. Same id + different path must NOT collide.
+        assertEquals("folder_/library/albums", maLibraryItemKey(folder("7", "/library/albums")))
+        val items = listOf(folder("7", "/a"), folder("7", "/b"))
+        assertEquals(2, items.distinctByItemKey().size)
+    }
+
+    @Test
+    fun `search results de-dup each type list independently`() {
+        val results = SearchResults(
+            artists = listOf(artist("1"), artist("1")),
+            albums = listOf(album("9"), album("9"), album("10")),
+        )
+        val deduped = results.distinctByItemKeys()
+        assertEquals(1, deduped.artists.size)
+        assertEquals(listOf("9", "10"), deduped.albums.map { it.id })
     }
 }


### PR DESCRIPTION
Follow-up to #182. The same `LazyColumn`/`LazyRow` duplicate-key pattern lived on two more surfaces, reachable only by **active browsing/searching** (not the on-connect path #182 fixed).

> **Stacked on #182** — base is `fix/lazylist-duplicate-key-crash`. Merge #182 first; GitHub will retarget this to `main` automatically.

## Browse (folder browser)
Two issues:
1. `loadBrowse()` set `items` straight from `MusicAssistant.browse()` with **no de-dup**.
2. Folders are keyed by **path** (`folder_${path}`) while everything else is keyed by `mediaType_id` — and #182's browse de-dup keyed folders by **id**, so de-dup and render disagreed for folders (a latent mismatch I introduced there).

Fix: `maLibraryItemKey` now centralises the folder-by-path case, `loadBrowse()` de-dups, and `BrowseContentScreen` renders through the shared key. De-dup key == render key for every item type, folders included.

## Search
Each result type renders in its own `LazyColumn` section keyed by `"${type}_${id}"`; a duplicate id within one type (same album from two providers) would crash that section. `SearchResults.distinctByItemKeys()` de-dups every per-type list at the source — render keys untouched (within a single-type list, the de-dup removes exactly the colliding render keys).

## Tests
Extended `MaLibraryItemKeysTest`: folder keyed by path (same id + different path do **not** collide), and per-type `SearchResults` de-dup. Full `:app:testDebugUnitTest` + `assembleDebug` green.

## Coverage after this PR
Every `MaLibraryItem` lazy list — Home carousels, Library tabs, Browse folders, Search — now keys and de-dups through the single `maLibraryItemKey` source of truth.