### PR TITLE
fix(auto): never show an empty Android Auto browse list (Play rejection)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,56 @@
+name: PR Unit Tests
+
+on:
+  pull_request:
+    paths:
+      - 'android/**'
+      - '.github/workflows/pr-tests.yml'
+
+# One test run per PR at a time - cancel superseded runs on new pushes
+concurrency:
+  group: pr-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: android
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Make Gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-test-results
+          path: android/app/build/reports/tests/

--- a/android/app/src/main/java/com/sendspindroid/playback/AutoBrowseTree.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/AutoBrowseTree.kt
@@ -1,0 +1,253 @@
+package com.sendspindroid.playback
+
+import android.net.Uri
+import android.os.Bundle
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import com.sendspindroid.R
+import com.sendspindroid.model.UnifiedServer
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Builds the media item lists for the Android Auto / MediaLibraryService
+ * browse tree.
+ *
+ * Extracted from PlaybackService so the list-shaping rules are unit-testable
+ * without a running service. The critical invariant enforced here:
+ *
+ * **A browsable node must never resolve to an empty list.** Android Auto
+ * renders an empty children list as a blank "unable to load content" screen,
+ * which fails Google Play's automated Auto quality review (the app was
+ * rejected for exactly this when no SendSpin server was reachable). Every
+ * list-producing function therefore falls back to a non-interactive message
+ * item that tells the user what to do next.
+ */
+object AutoBrowseTree {
+
+    // Browse tree media IDs
+    const val MEDIA_ID_ROOT = "root"
+    const val MEDIA_ID_DISCOVERED = "discovered_servers"
+    const val MEDIA_ID_SERVER_PREFIX = "server_"
+    const val MEDIA_ID_SAVED_SERVER_PREFIX = "saved_server_"
+
+    // Music Assistant category nodes
+    const val MEDIA_ID_MA_PLAYLISTS = "ma_playlists"
+    const val MEDIA_ID_MA_ALBUMS = "ma_albums"
+    const val MEDIA_ID_MA_ARTISTS = "ma_artists"
+    const val MEDIA_ID_MA_RADIO = "ma_radio"
+
+    // Music Assistant drill-down prefixes
+    const val MEDIA_ID_MA_PLAYLIST_PREFIX = "ma_playlist_"
+    const val MEDIA_ID_MA_ALBUM_PREFIX = "ma_album_"
+    const val MEDIA_ID_MA_ARTIST_PREFIX = "ma_artist_"
+
+    // Non-interactive informational rows (neither playable nor browsable)
+    const val MEDIA_ID_MESSAGE_PREFIX = "message_"
+    const val MEDIA_ID_MESSAGE_NO_SERVERS = "${MEDIA_ID_MESSAGE_PREFIX}no_servers"
+
+    // Android Auto content style hint keys
+    const val CONTENT_STYLE_BROWSABLE = "android.media.browse.CONTENT_STYLE_BROWSABLE_HINT"
+    const val CONTENT_STYLE_PLAYABLE = "android.media.browse.CONTENT_STYLE_PLAYABLE_HINT"
+    const val CONTENT_STYLE_SINGLE_ITEM = "android.media.browse.CONTENT_STYLE_SINGLE_ITEM_HINT"
+    const val CONTENT_STYLE_GROUP_TITLE = "android.media.browse.CONTENT_STYLE_GROUP_TITLE_HINT"
+    const val CONTENT_STYLE_LIST = 1
+    const val CONTENT_STYLE_GRID = 2
+
+    /**
+     * Root tabs. Mirrors the previous PlaybackService.getRootChildren():
+     * a single "Connect" node until Music Assistant is available, then the
+     * four MA library categories.
+     */
+    fun rootChildren(maAvailable: Boolean, isConnected: Boolean): List<MediaItem> {
+        if (!maAvailable) {
+            return listOf(
+                browsableItem(
+                    mediaId = MEDIA_ID_DISCOVERED,
+                    title = "Connect",
+                    subtitle = if (isConnected) "Connected" else null
+                )
+            )
+        }
+        return listOf(
+            browsableItem(
+                mediaId = MEDIA_ID_MA_PLAYLISTS,
+                title = "Playlists",
+                iconRes = R.drawable.ic_auto_playlists
+            ),
+            browsableItem(
+                mediaId = MEDIA_ID_MA_ALBUMS,
+                title = "Albums",
+                extras = Bundle().apply {
+                    putInt(CONTENT_STYLE_PLAYABLE, CONTENT_STYLE_GRID)
+                },
+                iconRes = R.drawable.ic_auto_albums
+            ),
+            browsableItem(
+                mediaId = MEDIA_ID_MA_ARTISTS,
+                title = "Artists",
+                extras = Bundle().apply {
+                    putInt(CONTENT_STYLE_BROWSABLE, CONTENT_STYLE_GRID)
+                },
+                iconRes = R.drawable.ic_auto_artists
+            ),
+            browsableItem(
+                mediaId = MEDIA_ID_MA_RADIO,
+                title = "Radio",
+                iconRes = R.drawable.ic_auto_radio
+            ),
+        )
+    }
+
+    /**
+     * Children of the "Connect" node: saved servers (most recently connected
+     * first) followed by mDNS-discovered servers not already saved.
+     *
+     * When there is nothing to show yet, waits up to [discoveryWaitMs] for the
+     * first mDNS result so the initial browse on Android Auto doesn't race
+     * discovery and come back empty. If still nothing after the wait, returns
+     * a "No servers found" guidance row instead of an empty list. Later
+     * discoveries refresh the node via notifyChildrenChanged.
+     */
+    suspend fun serverListChildren(
+        savedServers: List<UnifiedServer>,
+        discoveredServersFlow: StateFlow<List<UnifiedServer>>,
+        discoveryWaitMs: Long,
+    ): List<MediaItem> {
+        var discovered = discoveredServersFlow.value
+        if (savedServers.isEmpty() && discovered.isEmpty() && discoveryWaitMs > 0) {
+            withTimeoutOrNull(discoveryWaitMs) {
+                discoveredServersFlow.first { it.isNotEmpty() }
+            }
+            discovered = discoveredServersFlow.value
+        }
+
+        val savedItems = savedServers
+            .sortedByDescending { it.lastConnectedMs }
+            .map { savedServerItem(it) }
+        val discoveredItems = discovered.mapNotNull { server ->
+            val address = server.local?.address ?: return@mapNotNull null
+            playableServerItem(server.name, address)
+        }
+
+        val items = savedItems + discoveredItems
+        return items.ifEmpty {
+            listOf(
+                messageItem(
+                    mediaId = MEDIA_ID_MESSAGE_NO_SERVERS,
+                    title = "No servers found",
+                    subtitle = "Open SendSpin Player on your phone to add a server"
+                )
+            )
+        }
+    }
+
+    /**
+     * Guards a Music Assistant children list against the empty case: an empty
+     * fetch result (no content, or a failed request) is replaced with a
+     * non-interactive message row appropriate for the node.
+     */
+    fun withEmptyState(parentId: String, items: List<MediaItem>): List<MediaItem> {
+        if (items.isNotEmpty()) return items
+        val title = when {
+            parentId == MEDIA_ID_MA_PLAYLISTS -> "No playlists found"
+            parentId == MEDIA_ID_MA_ALBUMS -> "No albums found"
+            parentId == MEDIA_ID_MA_ARTISTS -> "No artists found"
+            parentId == MEDIA_ID_MA_RADIO -> "No radio stations found"
+            parentId.startsWith(MEDIA_ID_MA_PLAYLIST_PREFIX) -> "No tracks found"
+            parentId.startsWith(MEDIA_ID_MA_ALBUM_PREFIX) -> "No tracks found"
+            parentId.startsWith(MEDIA_ID_MA_ARTIST_PREFIX) -> "No albums found"
+            else -> "Nothing to show"
+        }
+        return listOf(
+            messageItem(
+                mediaId = "$MEDIA_ID_MESSAGE_PREFIX$parentId",
+                title = title,
+                subtitle = "Check Music Assistant on your phone"
+            )
+        )
+    }
+
+    /** A browsable (folder) node. */
+    fun browsableItem(
+        mediaId: String,
+        title: String,
+        subtitle: String? = null,
+        extras: Bundle? = null,
+        iconRes: Int = 0
+    ): MediaItem {
+        return MediaItem.Builder()
+            .setMediaId(mediaId)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle(title)
+                    .setSubtitle(subtitle)
+                    .setIsPlayable(false)
+                    .setIsBrowsable(true)
+                    .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_MIXED)
+                    .apply {
+                        if (extras != null) setExtras(extras)
+                        if (iconRes != 0) {
+                            setArtworkUri(Uri.parse("android.resource://com.sendspindroid/$iconRes"))
+                        }
+                    }
+                    .build()
+            )
+            .build()
+    }
+
+    /** A playable row for an mDNS-discovered server (media ID keyed by address). */
+    fun playableServerItem(name: String, address: String): MediaItem {
+        return MediaItem.Builder()
+            .setMediaId("$MEDIA_ID_SERVER_PREFIX$address")
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle(name)
+                    .setSubtitle(address)
+                    .setIsPlayable(true)
+                    .setIsBrowsable(false)
+                    .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
+                    .build()
+            )
+            .build()
+    }
+
+    /** A playable row for a saved server (media ID keyed by server UUID). */
+    fun savedServerItem(server: UnifiedServer): MediaItem {
+        val subtitle = server.local?.address
+            ?: if (server.proxy != null) "Proxy"
+            else if (server.remote != null) "Remote Access"
+            else ""
+        return MediaItem.Builder()
+            .setMediaId("$MEDIA_ID_SAVED_SERVER_PREFIX${server.id}")
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle(server.name)
+                    .setSubtitle(subtitle)
+                    .setIsPlayable(true)
+                    .setIsBrowsable(false)
+                    .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
+                    .build()
+            )
+            .build()
+    }
+
+    /**
+     * A non-interactive informational row. Neither playable nor browsable, so
+     * Android Auto renders it as plain text the user can read but not tap.
+     */
+    fun messageItem(mediaId: String, title: String, subtitle: String? = null): MediaItem {
+        return MediaItem.Builder()
+            .setMediaId(mediaId)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle(title)
+                    .setSubtitle(subtitle)
+                    .setIsPlayable(false)
+                    .setIsBrowsable(false)
+                    .build()
+            )
+            .build()
+    }
+}

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -42,7 +42,6 @@ import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
-import com.sendspindroid.R
 import com.sendspindroid.MainActivity
 
 import com.sendspindroid.SyncOffsetPreference
@@ -521,29 +520,37 @@ class PlaybackService : MediaLibraryService() {
         // in-app display quality.
         private const val MAX_ARTWORK_SIZE = 300
 
-        private const val MEDIA_ID_ROOT = "root"
-        private const val MEDIA_ID_DISCOVERED = "discovered_servers"
-        private const val MEDIA_ID_SERVER_PREFIX = "server_"
-        private const val MEDIA_ID_SAVED_SERVER_PREFIX = "saved_server_"
+        // Browse tree media IDs and content style hints live in AutoBrowseTree
+        // (the testable list builder); aliased here so the rest of the service
+        // reads unchanged.
+        private const val MEDIA_ID_ROOT = AutoBrowseTree.MEDIA_ID_ROOT
+        private const val MEDIA_ID_DISCOVERED = AutoBrowseTree.MEDIA_ID_DISCOVERED
+        private const val MEDIA_ID_SERVER_PREFIX = AutoBrowseTree.MEDIA_ID_SERVER_PREFIX
+        private const val MEDIA_ID_SAVED_SERVER_PREFIX = AutoBrowseTree.MEDIA_ID_SAVED_SERVER_PREFIX
 
         // Android Auto content style hint keys
-        private const val CONTENT_STYLE_BROWSABLE = "android.media.browse.CONTENT_STYLE_BROWSABLE_HINT"
-        private const val CONTENT_STYLE_PLAYABLE = "android.media.browse.CONTENT_STYLE_PLAYABLE_HINT"
-        private const val CONTENT_STYLE_SINGLE_ITEM = "android.media.browse.CONTENT_STYLE_SINGLE_ITEM_HINT"
-        private const val CONTENT_STYLE_GROUP_TITLE = "android.media.browse.CONTENT_STYLE_GROUP_TITLE_HINT"
-        private const val CONTENT_STYLE_LIST = 1
-        private const val CONTENT_STYLE_GRID = 2
+        private const val CONTENT_STYLE_BROWSABLE = AutoBrowseTree.CONTENT_STYLE_BROWSABLE
+        private const val CONTENT_STYLE_PLAYABLE = AutoBrowseTree.CONTENT_STYLE_PLAYABLE
+        private const val CONTENT_STYLE_SINGLE_ITEM = AutoBrowseTree.CONTENT_STYLE_SINGLE_ITEM
+        private const val CONTENT_STYLE_GROUP_TITLE = AutoBrowseTree.CONTENT_STYLE_GROUP_TITLE
+        private const val CONTENT_STYLE_LIST = AutoBrowseTree.CONTENT_STYLE_LIST
+        private const val CONTENT_STYLE_GRID = AutoBrowseTree.CONTENT_STYLE_GRID
 
         // Music Assistant browse tree media IDs
-        private const val MEDIA_ID_MA_PLAYLISTS = "ma_playlists"
-        private const val MEDIA_ID_MA_ALBUMS = "ma_albums"
-        private const val MEDIA_ID_MA_ARTISTS = "ma_artists"
-        private const val MEDIA_ID_MA_RADIO = "ma_radio"
+        private const val MEDIA_ID_MA_PLAYLISTS = AutoBrowseTree.MEDIA_ID_MA_PLAYLISTS
+        private const val MEDIA_ID_MA_ALBUMS = AutoBrowseTree.MEDIA_ID_MA_ALBUMS
+        private const val MEDIA_ID_MA_ARTISTS = AutoBrowseTree.MEDIA_ID_MA_ARTISTS
+        private const val MEDIA_ID_MA_RADIO = AutoBrowseTree.MEDIA_ID_MA_RADIO
 
         // MA item prefixes (for drill-down into children)
-        private const val MEDIA_ID_MA_PLAYLIST_PREFIX = "ma_playlist_"
-        private const val MEDIA_ID_MA_ALBUM_PREFIX = "ma_album_"
-        private const val MEDIA_ID_MA_ARTIST_PREFIX = "ma_artist_"
+        private const val MEDIA_ID_MA_PLAYLIST_PREFIX = AutoBrowseTree.MEDIA_ID_MA_PLAYLIST_PREFIX
+        private const val MEDIA_ID_MA_ALBUM_PREFIX = AutoBrowseTree.MEDIA_ID_MA_ALBUM_PREFIX
+        private const val MEDIA_ID_MA_ARTIST_PREFIX = AutoBrowseTree.MEDIA_ID_MA_ARTIST_PREFIX
+
+        // How long the "Connect" browse node waits for the first mDNS result
+        // before showing the "No servers found" guidance row. Keeps the first
+        // browse on Android Auto from racing discovery and rendering empty.
+        private const val BROWSE_DISCOVERY_WAIT_MS = 3_000L
 
         // MA leaf item prefixes (playable, URI encoded as Base64)
         private const val MEDIA_ID_MA_TRACK_PREFIX = "ma_track_"
@@ -2768,22 +2775,19 @@ class PlaybackService : MediaLibraryService() {
         ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
             Log.d(TAG, "onGetChildren: parentId=$parentId, page=$page")
 
-            // Sync path: existing browse tree nodes
-            val syncChildren: List<MediaItem>? = when (parentId) {
-                MEDIA_ID_ROOT -> getRootChildren()
-                MEDIA_ID_DISCOVERED -> getDiscoveredServers()
-                else -> null  // Not a sync node, check async path
-            }
-
-            if (syncChildren != null) {
+            // Sync path: root tabs
+            if (parentId == MEDIA_ID_ROOT) {
                 return Futures.immediateFuture(
-                    LibraryResult.ofItemList(ImmutableList.copyOf(syncChildren), params)
+                    LibraryResult.ofItemList(ImmutableList.copyOf(getRootChildren()), params)
                 )
             }
 
-            // Async path: MA data fetches
+            // Async path: server discovery (bounded mDNS wait) and MA data fetches
             return suspendToFuture {
-                val items = getMaChildren(parentId)
+                val items = when (parentId) {
+                    MEDIA_ID_DISCOVERED -> getDiscoveredServers()
+                    else -> getMaChildren(parentId)
+                }
                 LibraryResult.ofItemList(ImmutableList.copyOf(items), params)
             }
         }
@@ -2911,10 +2915,13 @@ class PlaybackService : MediaLibraryService() {
         ): ListenableFuture<LibraryResult<Void>> {
             Log.d(TAG, "onSearch: query='$query'")
 
+            // The root always advertises SEARCH_SUPPORTED, so report zero
+            // results instead of an error when MA isn't available. Android
+            // Auto then shows its own "no results" UI rather than a failure.
             if (MusicAssistant.connectionState.value !is TransportState.Ready) {
-                return Futures.immediateFuture(
-                    LibraryResult.ofError(SessionError.ERROR_NOT_SUPPORTED)
-                )
+                maSearchResultsCache = emptyList()
+                session.notifySearchResultChanged(browser, query, 0, params)
+                return Futures.immediateFuture(LibraryResult.ofVoid())
             }
 
             // Execute search async, cache results, notify when done
@@ -3312,77 +3319,22 @@ class PlaybackService : MediaLibraryService() {
     }
 
     private fun getRootChildren(): List<MediaItem> {
-        val children = mutableListOf<MediaItem>()
         val maAvailable = MusicAssistant.connectionState.value is TransportState.Ready
-
-        // Show "Connect" until MA is available (avoids empty root during MA handshake)
-        if (!maAvailable) {
-            children.add(
-                createBrowsableItem(
-                    mediaId = MEDIA_ID_DISCOVERED,
-                    title = "Connect",
-                    subtitle = if (isConnected()) "Connected" else null
-                )
-            )
-        }
-
-        // Show library categories directly as root tabs when MA is connected
-        if (maAvailable) {
-            children.add(
-                createBrowsableItem(
-                    mediaId = MEDIA_ID_MA_PLAYLISTS,
-                    title = "Playlists",
-                    iconRes = R.drawable.ic_auto_playlists
-                )
-            )
-            children.add(
-                createBrowsableItem(
-                    mediaId = MEDIA_ID_MA_ALBUMS,
-                    title = "Albums",
-                    extras = Bundle().apply {
-                        putInt(CONTENT_STYLE_PLAYABLE, CONTENT_STYLE_GRID)
-                    },
-                    iconRes = R.drawable.ic_auto_albums
-                )
-            )
-            children.add(
-                createBrowsableItem(
-                    mediaId = MEDIA_ID_MA_ARTISTS,
-                    title = "Artists",
-                    extras = Bundle().apply {
-                        putInt(CONTENT_STYLE_BROWSABLE, CONTENT_STYLE_GRID)
-                    },
-                    iconRes = R.drawable.ic_auto_artists
-                )
-            )
-            children.add(
-                createBrowsableItem(
-                    mediaId = MEDIA_ID_MA_RADIO,
-                    title = "Radio",
-                    iconRes = R.drawable.ic_auto_radio
-                )
-            )
-        }
-
-        return children
+        return AutoBrowseTree.rootChildren(maAvailable, isConnected())
     }
 
-    private fun getDiscoveredServers(): List<MediaItem> {
+    private suspend fun getDiscoveredServers(): List<MediaItem> {
         // Trigger mDNS scan so servers populate for Android Auto / external browsers
         ensureBrowseDiscoveryRunning()
 
-        // Saved servers first, sorted by most recently connected
-        val savedItems = UnifiedServerRepository.savedServers.value
-            .sortedByDescending { it.lastConnectedMs }
-            .map { createSavedServerItem(it) }
-
-        // Discovered servers that aren't already in the saved list
-        val discoveredItems = UnifiedServerRepository.filteredDiscoveredServers.value.mapNotNull { server ->
-            val address = server.local?.address ?: return@mapNotNull null
-            createPlayableServerItem(server.name, address)
-        }
-
-        return savedItems + discoveredItems
+        // AutoBrowseTree waits briefly for the first mDNS result when nothing
+        // is known yet, and guarantees a non-empty list (guidance row when no
+        // servers are available) so Android Auto never shows a blank screen.
+        return AutoBrowseTree.serverListChildren(
+            savedServers = UnifiedServerRepository.savedServers.value,
+            discoveredServersFlow = UnifiedServerRepository.filteredDiscoveredServers,
+            discoveryWaitMs = BROWSE_DISCOVERY_WAIT_MS,
+        )
     }
 
     /**
@@ -3432,7 +3384,7 @@ class PlaybackService : MediaLibraryService() {
      * Called from onGetChildren for any parentId not handled by the sync path.
      */
     private suspend fun getMaChildren(parentId: String): List<MediaItem> {
-        return when (parentId) {
+        val items = when (parentId) {
             MEDIA_ID_MA_PLAYLISTS -> getMaPlaylists()
             MEDIA_ID_MA_ALBUMS -> getMaAlbums()
             MEDIA_ID_MA_ARTISTS -> getMaArtists()
@@ -3453,67 +3405,9 @@ class PlaybackService : MediaLibraryService() {
                 }
             }
         }
-    }
-
-    private fun createBrowsableItem(
-        mediaId: String,
-        title: String,
-        subtitle: String? = null,
-        extras: Bundle? = null,
-        iconRes: Int = 0
-    ): MediaItem {
-        return MediaItem.Builder()
-            .setMediaId(mediaId)
-            .setMediaMetadata(
-                MediaMetadata.Builder()
-                    .setTitle(title)
-                    .setSubtitle(subtitle)
-                    .setIsPlayable(false)
-                    .setIsBrowsable(true)
-                    .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_MIXED)
-                    .apply {
-                        if (extras != null) setExtras(extras)
-                        if (iconRes != 0) {
-                            setArtworkUri(Uri.parse("android.resource://com.sendspindroid/$iconRes"))
-                        }
-                    }
-                    .build()
-            )
-            .build()
-    }
-
-    private fun createPlayableServerItem(name: String, address: String): MediaItem {
-        return MediaItem.Builder()
-            .setMediaId("$MEDIA_ID_SERVER_PREFIX$address")
-            .setMediaMetadata(
-                MediaMetadata.Builder()
-                    .setTitle(name)
-                    .setSubtitle(address)
-                    .setIsPlayable(true)
-                    .setIsBrowsable(false)
-                    .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
-                    .build()
-            )
-            .build()
-    }
-
-    private fun createSavedServerItem(server: UnifiedServer): MediaItem {
-        val subtitle = server.local?.address
-            ?: if (server.proxy != null) "Proxy"
-            else if (server.remote != null) "Remote Access"
-            else ""
-        return MediaItem.Builder()
-            .setMediaId("$MEDIA_ID_SAVED_SERVER_PREFIX${server.id}")
-            .setMediaMetadata(
-                MediaMetadata.Builder()
-                    .setTitle(server.name)
-                    .setSubtitle(subtitle)
-                    .setIsPlayable(true)
-                    .setIsBrowsable(false)
-                    .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
-                    .build()
-            )
-            .build()
+        // Never hand Android Auto an empty list -- it renders as a blank
+        // "unable to load content" screen (Play Auto quality rejection).
+        return AutoBrowseTree.withEmptyState(parentId, items)
     }
 
     // ========================================================================
@@ -3969,31 +3863,31 @@ class PlaybackService : MediaLibraryService() {
                     .build()
             }
             mediaId == MEDIA_ID_DISCOVERED -> {
-                createBrowsableItem(MEDIA_ID_DISCOVERED, "Connect", "Choose a server")
+                AutoBrowseTree.browsableItem(MEDIA_ID_DISCOVERED, "Connect", "Choose a server")
             }
             mediaId.startsWith(MEDIA_ID_SAVED_SERVER_PREFIX) -> {
                 val serverId = mediaId.removePrefix(MEDIA_ID_SAVED_SERVER_PREFIX)
                 UnifiedServerRepository.savedServers.value
                     .find { it.id == serverId }
-                    ?.let { createSavedServerItem(it) }
+                    ?.let { AutoBrowseTree.savedServerItem(it) }
             }
             mediaId.startsWith(MEDIA_ID_SERVER_PREFIX) -> {
                 val address = mediaId.removePrefix(MEDIA_ID_SERVER_PREFIX)
                 val server = UnifiedServerRepository.getServerByAddress(address)
-                server?.let { createPlayableServerItem(it.name, it.local?.address ?: address) }
+                server?.let { AutoBrowseTree.playableServerItem(it.name, it.local?.address ?: address) }
             }
             // MA category folders (root-level tabs)
             mediaId == MEDIA_ID_MA_PLAYLISTS -> {
-                createBrowsableItem(MEDIA_ID_MA_PLAYLISTS, "Playlists")
+                AutoBrowseTree.browsableItem(MEDIA_ID_MA_PLAYLISTS, "Playlists")
             }
             mediaId == MEDIA_ID_MA_ALBUMS -> {
-                createBrowsableItem(MEDIA_ID_MA_ALBUMS, "Albums")
+                AutoBrowseTree.browsableItem(MEDIA_ID_MA_ALBUMS, "Albums")
             }
             mediaId == MEDIA_ID_MA_ARTISTS -> {
-                createBrowsableItem(MEDIA_ID_MA_ARTISTS, "Artists")
+                AutoBrowseTree.browsableItem(MEDIA_ID_MA_ARTISTS, "Artists")
             }
             mediaId == MEDIA_ID_MA_RADIO -> {
-                createBrowsableItem(MEDIA_ID_MA_RADIO, "Radio")
+                AutoBrowseTree.browsableItem(MEDIA_ID_MA_RADIO, "Radio")
             }
             // MA items - search through caches
             mediaId.startsWith("ma_") -> {

--- a/android/app/src/test/java/com/sendspindroid/playback/BrowseTreeTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/playback/BrowseTreeTest.kt
@@ -1,306 +1,332 @@
 package com.sendspindroid.playback
 
-import android.util.Log
-import com.sendspindroid.UnifiedServerRepository
 import com.sendspindroid.model.LocalConnection
 import com.sendspindroid.model.ProxyConnection
 import com.sendspindroid.model.RemoteConnection
 import com.sendspindroid.model.UnifiedServer
-import io.mockk.*
-import org.junit.After
-import org.junit.Assert.*
-import org.junit.Before
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 /**
- * Integration test: PlaybackService browse tree for Android Auto.
+ * Tests for [AutoBrowseTree], the Android Auto browse tree list builder.
  *
- * Verifies that onGetChildren returns the correct root items and categories
- * based on connection state and MA availability. This reproduces the
- * getRootChildren() and getDiscoveredServers() logic from PlaybackService.
+ * These exercise the real production code (real Media3 MediaItems via
+ * Robolectric), unlike the previous version of this test which re-implemented
+ * the service logic.
  *
- * Browse tree structure:
- * - When disconnected (no MA): root -> "Connect" folder -> server list
- * - When connected with MA: root -> Playlists, Albums, Artists, Radio
+ * The load-bearing invariant: no browse node ever resolves to an empty list.
+ * Google Play's automated Android Auto quality review browses the app with no
+ * SendSpin server reachable; an empty children list renders as a blank
+ * "unable to load content" screen and fails review (rejection of Jun 26).
+ * When there is nothing to show, a non-interactive guidance row is returned
+ * instead.
  */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class BrowseTreeTest {
 
-    // Media ID constants (mirror PlaybackService companion)
-    private val MEDIA_ID_ROOT = "root"
-    private val MEDIA_ID_DISCOVERED = "discovered_servers"
-    private val MEDIA_ID_MA_PLAYLISTS = "ma_playlists"
-    private val MEDIA_ID_MA_ALBUMS = "ma_albums"
-    private val MEDIA_ID_MA_ARTISTS = "ma_artists"
-    private val MEDIA_ID_MA_RADIO = "ma_radio"
-    private val MEDIA_ID_SERVER_PREFIX = "server_"
-    private val MEDIA_ID_SAVED_SERVER_PREFIX = "saved_server_"
-
-    data class BrowseItem(
-        val mediaId: String,
-        val title: String,
-        val subtitle: String? = null,
-        val isPlayable: Boolean = false,
-        val isBrowsable: Boolean = true
+    private fun localServer(
+        id: String,
+        name: String,
+        address: String,
+        lastConnectedMs: Long = 0L,
+    ) = UnifiedServer(
+        id = id,
+        name = name,
+        local = LocalConnection(address),
+        lastConnectedMs = lastConnectedMs,
     )
 
-    @Before
-    fun setUp() {
-        mockkStatic(Log::class)
-        every { Log.v(any(), any()) } returns 0
-        every { Log.d(any(), any()) } returns 0
-        every { Log.i(any(), any()) } returns 0
-        every { Log.w(any(), any<String>()) } returns 0
-        every { Log.e(any(), any<String>()) } returns 0
-        every { Log.e(any(), any(), any()) } returns 0
-
-        UnifiedServerRepository.clearDiscoveredServers()
-        UnifiedServerRepository.savedServers.value.forEach {
-            UnifiedServerRepository.deleteServer(it.id)
-        }
-    }
-
-    @After
-    fun tearDown() {
-        UnifiedServerRepository.clearDiscoveredServers()
-        UnifiedServerRepository.savedServers.value.forEach {
-            UnifiedServerRepository.deleteServer(it.id)
-        }
-        unmockkAll()
-    }
-
-    /**
-     * Reproduces PlaybackService.getRootChildren() logic.
-     */
-    private fun getRootChildren(maAvailable: Boolean, isConnected: Boolean): List<BrowseItem> {
-        val children = mutableListOf<BrowseItem>()
-
-        // Show "Connect" until MA is available
-        if (!maAvailable) {
-            children.add(
-                BrowseItem(
-                    mediaId = MEDIA_ID_DISCOVERED,
-                    title = "Connect",
-                    subtitle = if (isConnected) "Connected" else null,
-                    isBrowsable = true,
-                    isPlayable = false
-                )
-            )
-        }
-
-        // Show library categories when MA is connected
-        if (maAvailable) {
-            children.add(BrowseItem(mediaId = MEDIA_ID_MA_PLAYLISTS, title = "Playlists"))
-            children.add(BrowseItem(mediaId = MEDIA_ID_MA_ALBUMS, title = "Albums"))
-            children.add(BrowseItem(mediaId = MEDIA_ID_MA_ARTISTS, title = "Artists"))
-            children.add(BrowseItem(mediaId = MEDIA_ID_MA_RADIO, title = "Radio"))
-        }
-
-        return children
-    }
-
-    /**
-     * Reproduces PlaybackService.getDiscoveredServers() logic.
-     */
-    private fun getDiscoveredServers(): List<BrowseItem> {
-        val savedItems = UnifiedServerRepository.savedServers.value
-            .sortedByDescending { it.lastConnectedMs }
-            .map { server ->
-                val subtitle = server.local?.address
-                    ?: if (server.proxy != null) "Proxy"
-                    else if (server.remote != null) "Remote Access"
-                    else ""
-                BrowseItem(
-                    mediaId = "$MEDIA_ID_SAVED_SERVER_PREFIX${server.id}",
-                    title = server.name,
-                    subtitle = subtitle,
-                    isPlayable = true,
-                    isBrowsable = false
-                )
-            }
-
-        val discoveredItems = UnifiedServerRepository.discoveredServers.value.mapNotNull { server ->
-            val address = server.local?.address ?: return@mapNotNull null
-            BrowseItem(
-                mediaId = "$MEDIA_ID_SERVER_PREFIX$address",
-                title = server.name,
-                subtitle = address,
-                isPlayable = true,
-                isBrowsable = false
-            )
-        }
-
-        return savedItems + discoveredItems
-    }
-
-    // ========== Root children tests ==========
+    // ========== Root children ==========
 
     @Test
     fun `root shows Connect when MA unavailable and disconnected`() {
-        val children = getRootChildren(maAvailable = false, isConnected = false)
+        val children = AutoBrowseTree.rootChildren(maAvailable = false, isConnected = false)
 
         assertEquals(1, children.size)
-        assertEquals(MEDIA_ID_DISCOVERED, children[0].mediaId)
-        assertEquals("Connect", children[0].title)
-        assertNull("Subtitle should be null when disconnected", children[0].subtitle)
+        assertEquals(AutoBrowseTree.MEDIA_ID_DISCOVERED, children[0].mediaId)
+        assertEquals("Connect", children[0].mediaMetadata.title)
+        assertNull("Subtitle should be null when disconnected", children[0].mediaMetadata.subtitle)
+        assertEquals(true, children[0].mediaMetadata.isBrowsable)
     }
 
     @Test
     fun `root shows Connect with Connected subtitle when connected without MA`() {
-        val children = getRootChildren(maAvailable = false, isConnected = true)
+        val children = AutoBrowseTree.rootChildren(maAvailable = false, isConnected = true)
 
         assertEquals(1, children.size)
-        assertEquals("Connect", children[0].title)
-        assertEquals("Connected", children[0].subtitle)
+        assertEquals("Connect", children[0].mediaMetadata.title)
+        assertEquals("Connected", children[0].mediaMetadata.subtitle)
     }
 
     @Test
     fun `root shows library categories when MA is available`() {
-        val children = getRootChildren(maAvailable = true, isConnected = true)
+        val children = AutoBrowseTree.rootChildren(maAvailable = true, isConnected = true)
 
-        assertEquals(4, children.size)
-        assertEquals(MEDIA_ID_MA_PLAYLISTS, children[0].mediaId)
-        assertEquals("Playlists", children[0].title)
-        assertEquals(MEDIA_ID_MA_ALBUMS, children[1].mediaId)
-        assertEquals("Albums", children[1].title)
-        assertEquals(MEDIA_ID_MA_ARTISTS, children[2].mediaId)
-        assertEquals("Artists", children[2].title)
-        assertEquals(MEDIA_ID_MA_RADIO, children[3].mediaId)
-        assertEquals("Radio", children[3].title)
+        assertEquals(
+            listOf(
+                AutoBrowseTree.MEDIA_ID_MA_PLAYLISTS,
+                AutoBrowseTree.MEDIA_ID_MA_ALBUMS,
+                AutoBrowseTree.MEDIA_ID_MA_ARTISTS,
+                AutoBrowseTree.MEDIA_ID_MA_RADIO,
+            ),
+            children.map { it.mediaId }
+        )
+        assertEquals(
+            listOf("Playlists", "Albums", "Artists", "Radio"),
+            children.map { it.mediaMetadata.title.toString() }
+        )
     }
 
     @Test
-    fun `root does not show Connect when MA is available`() {
-        val children = getRootChildren(maAvailable = true, isConnected = true)
-
-        val hasConnect = children.any { it.mediaId == MEDIA_ID_DISCOVERED }
-        assertFalse("Connect should not appear when MA is available", hasConnect)
+    fun `root never returns an empty list`() {
+        assertTrue(AutoBrowseTree.rootChildren(maAvailable = false, isConnected = false).isNotEmpty())
+        assertTrue(AutoBrowseTree.rootChildren(maAvailable = false, isConnected = true).isNotEmpty())
+        assertTrue(AutoBrowseTree.rootChildren(maAvailable = true, isConnected = true).isNotEmpty())
     }
 
     @Test
     fun `library categories are browsable not playable`() {
-        val children = getRootChildren(maAvailable = true, isConnected = true)
+        val children = AutoBrowseTree.rootChildren(maAvailable = true, isConnected = true)
 
         children.forEach { item ->
-            assertTrue("${item.title} should be browsable", item.isBrowsable)
-            assertFalse("${item.title} should not be playable", item.isPlayable)
+            assertEquals("${item.mediaMetadata.title} should be browsable",
+                true, item.mediaMetadata.isBrowsable)
+            assertEquals("${item.mediaMetadata.title} should not be playable",
+                false, item.mediaMetadata.isPlayable)
         }
     }
 
-    // ========== Discovered servers tests ==========
+    // ========== Server list ("Connect" node) ==========
 
     @Test
-    fun `discovered servers list shows saved servers first`() {
-        UnifiedServerRepository.saveServer(
-            UnifiedServer(
-                id = "saved-1", name = "Saved Server",
-                local = LocalConnection("192.168.1.10:8927"),
-                lastConnectedMs = 1000L
-            )
+    fun `server list shows saved servers first`() = runTest {
+        val discovered = MutableStateFlow(
+            listOf(localServer("disc-1", "Discovered Server", "192.168.1.20:8927"))
         )
-        UnifiedServerRepository.addDiscoveredServer("Discovered Server", "192.168.1.20:8927")
 
-        val servers = getDiscoveredServers()
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = listOf(
+                localServer("saved-1", "Saved Server", "192.168.1.10:8927", lastConnectedMs = 1000L)
+            ),
+            discoveredServersFlow = discovered,
+            discoveryWaitMs = 3000L,
+        )
 
-        assertEquals(2, servers.size)
+        assertEquals(2, items.size)
         assertTrue(
             "First item should be saved server",
-            servers[0].mediaId.startsWith(MEDIA_ID_SAVED_SERVER_PREFIX)
+            items[0].mediaId.startsWith(AutoBrowseTree.MEDIA_ID_SAVED_SERVER_PREFIX)
         )
         assertTrue(
             "Second item should be discovered server",
-            servers[1].mediaId.startsWith(MEDIA_ID_SERVER_PREFIX)
+            items[1].mediaId.startsWith(AutoBrowseTree.MEDIA_ID_SERVER_PREFIX)
         )
     }
 
     @Test
-    fun `saved servers are sorted by last connected time`() {
-        UnifiedServerRepository.saveServer(
-            UnifiedServer(
-                id = "old", name = "Old Server",
-                local = LocalConnection("10.0.0.1:8927"),
-                lastConnectedMs = 100L
-            )
-        )
-        UnifiedServerRepository.saveServer(
-            UnifiedServer(
-                id = "recent", name = "Recent Server",
-                local = LocalConnection("10.0.0.2:8927"),
-                lastConnectedMs = 500L
-            )
+    fun `saved servers are sorted by last connected time`() = runTest {
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = listOf(
+                localServer("old", "Old Server", "10.0.0.1:8927", lastConnectedMs = 100L),
+                localServer("recent", "Recent Server", "10.0.0.2:8927", lastConnectedMs = 500L),
+            ),
+            discoveredServersFlow = MutableStateFlow(emptyList()),
+            discoveryWaitMs = 0L,
         )
 
-        val servers = getDiscoveredServers()
-
-        assertEquals("Recent Server", servers[0].title)
-        assertEquals("Old Server", servers[1].title)
+        assertEquals("Recent Server", items[0].mediaMetadata.title)
+        assertEquals("Old Server", items[1].mediaMetadata.title)
     }
 
     @Test
-    fun `server items are playable not browsable`() {
-        UnifiedServerRepository.addDiscoveredServer("Test", "192.168.1.10:8927")
+    fun `server items are playable not browsable`() = runTest {
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = emptyList(),
+            discoveredServersFlow = MutableStateFlow(
+                listOf(localServer("d", "Test", "192.168.1.10:8927"))
+            ),
+            discoveryWaitMs = 0L,
+        )
 
-        val servers = getDiscoveredServers()
-
-        assertEquals(1, servers.size)
-        assertTrue("Server should be playable", servers[0].isPlayable)
-        assertFalse("Server should not be browsable", servers[0].isBrowsable)
+        assertEquals(1, items.size)
+        assertEquals(true, items[0].mediaMetadata.isPlayable)
+        assertEquals(false, items[0].mediaMetadata.isBrowsable)
     }
 
     @Test
-    fun `saved server with proxy shows Proxy subtitle`() {
-        UnifiedServerRepository.saveServer(
-            UnifiedServer(
-                id = "proxy-1", name = "Proxy Server",
-                proxy = ProxyConnection(
-                    url = "https://ma.example.com/sendspin",
-                    authToken = "token123"
+    fun `discovered server media ID includes address`() = runTest {
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = emptyList(),
+            discoveredServersFlow = MutableStateFlow(
+                listOf(localServer("d", "Test", "192.168.1.10:8927"))
+            ),
+            discoveryWaitMs = 0L,
+        )
+
+        assertEquals("server_192.168.1.10:8927", items[0].mediaId)
+    }
+
+    @Test
+    fun `saved server media ID includes server UUID`() = runTest {
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = listOf(localServer("uuid-123", "Saved", "10.0.0.1:8927")),
+            discoveredServersFlow = MutableStateFlow(emptyList()),
+            discoveryWaitMs = 0L,
+        )
+
+        assertEquals("saved_server_uuid-123", items[0].mediaId)
+    }
+
+    @Test
+    fun `saved server with proxy shows Proxy subtitle`() = runTest {
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = listOf(
+                UnifiedServer(
+                    id = "proxy-1", name = "Proxy Server",
+                    proxy = ProxyConnection(
+                        url = "https://ma.example.com/sendspin",
+                        authToken = "token123"
+                    )
                 )
-            )
+            ),
+            discoveredServersFlow = MutableStateFlow(emptyList()),
+            discoveryWaitMs = 0L,
         )
 
-        val servers = getDiscoveredServers()
-        assertEquals(1, servers.size)
-        assertEquals("Proxy", servers[0].subtitle)
+        assertEquals(1, items.size)
+        assertEquals("Proxy", items[0].mediaMetadata.subtitle)
     }
 
     @Test
-    fun `saved server with remote shows Remote Access subtitle`() {
-        UnifiedServerRepository.saveServer(
-            UnifiedServer(
-                id = "remote-1", name = "Remote Server",
-                remote = RemoteConnection(remoteId = "ABCDE12345FGHIJ67890KLMNOP")
-            )
+    fun `saved server with remote shows Remote Access subtitle`() = runTest {
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = listOf(
+                UnifiedServer(
+                    id = "remote-1", name = "Remote Server",
+                    remote = RemoteConnection(remoteId = "ABCDE12345FGHIJ67890KLMNOP")
+                )
+            ),
+            discoveredServersFlow = MutableStateFlow(emptyList()),
+            discoveryWaitMs = 0L,
         )
 
-        val servers = getDiscoveredServers()
-        assertEquals(1, servers.size)
-        assertEquals("Remote Access", servers[0].subtitle)
+        assertEquals(1, items.size)
+        assertEquals("Remote Access", items[0].mediaMetadata.subtitle)
     }
 
-    @Test
-    fun `empty server list returns empty`() {
-        val servers = getDiscoveredServers()
-        assertTrue("Should be empty", servers.isEmpty())
-    }
+    // ========== Play rejection regression: never-empty guarantees ==========
 
     @Test
-    fun `discovered server media ID includes address`() {
-        UnifiedServerRepository.addDiscoveredServer("Test", "192.168.1.10:8927")
-
-        val servers = getDiscoveredServers()
-        assertEquals("server_192.168.1.10:8927", servers[0].mediaId)
-    }
-
-    @Test
-    fun `saved server media ID includes server UUID`() {
-        UnifiedServerRepository.saveServer(
-            UnifiedServer(
-                id = "uuid-123", name = "Saved",
-                local = LocalConnection("10.0.0.1:8927")
-            )
+    fun `empty server list returns No servers found guidance instead of empty`() = runTest {
+        // This is what Google's automated Auto review sees: fresh install,
+        // no saved servers, no SendSpin server on the network.
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = emptyList(),
+            discoveredServersFlow = MutableStateFlow(emptyList()),
+            discoveryWaitMs = 3000L,
         )
 
-        val servers = getDiscoveredServers()
-        assertEquals("saved_server_uuid-123", servers[0].mediaId)
+        assertEquals(1, items.size)
+        assertEquals(AutoBrowseTree.MEDIA_ID_MESSAGE_NO_SERVERS, items[0].mediaId)
+        assertEquals("No servers found", items[0].mediaMetadata.title)
+        assertEquals(
+            "Open SendSpin Player on your phone to add a server",
+            items[0].mediaMetadata.subtitle
+        )
+    }
+
+    @Test
+    fun `guidance row is neither playable nor browsable`() = runTest {
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = emptyList(),
+            discoveredServersFlow = MutableStateFlow(emptyList()),
+            discoveryWaitMs = 0L,
+        )
+
+        assertEquals(false, items[0].mediaMetadata.isPlayable)
+        assertEquals(false, items[0].mediaMetadata.isBrowsable)
+    }
+
+    @Test
+    fun `server list waits for first mDNS discovery before answering`() = runTest {
+        // First browse races mDNS: the flow is empty at call time and a
+        // server appears 1s later, inside the 3s discovery window.
+        val discovered = MutableStateFlow<List<UnifiedServer>>(emptyList())
+        launch {
+            delay(1000L)
+            discovered.value = listOf(localServer("d", "Living Room", "192.168.1.30:8927"))
+        }
+
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = emptyList(),
+            discoveredServersFlow = discovered,
+            discoveryWaitMs = 3000L,
+        )
+
+        assertEquals(1, items.size)
+        assertEquals("Living Room", items[0].mediaMetadata.title)
+        assertEquals(true, items[0].mediaMetadata.isPlayable)
+    }
+
+    @Test
+    fun `server list does not wait when a saved server exists`() = runTest {
+        // A saved server means there is content to show immediately; the
+        // discovery wait must not delay the browse response.
+        val discovered = MutableStateFlow<List<UnifiedServer>>(emptyList())
+
+        val items = AutoBrowseTree.serverListChildren(
+            savedServers = listOf(localServer("saved-1", "Saved", "10.0.0.1:8927")),
+            discoveredServersFlow = discovered,
+            discoveryWaitMs = 3000L,
+        )
+
+        assertEquals(1, items.size)
+        assertEquals("Saved", items[0].mediaMetadata.title)
+        assertEquals(0L, currentTime)
+    }
+
+    @Test
+    fun `MA category nodes replace empty results with a message row`() {
+        val categories = listOf(
+            AutoBrowseTree.MEDIA_ID_MA_PLAYLISTS to "No playlists found",
+            AutoBrowseTree.MEDIA_ID_MA_ALBUMS to "No albums found",
+            AutoBrowseTree.MEDIA_ID_MA_ARTISTS to "No artists found",
+            AutoBrowseTree.MEDIA_ID_MA_RADIO to "No radio stations found",
+            AutoBrowseTree.MEDIA_ID_MA_PLAYLIST_PREFIX + "id~provider" to "No tracks found",
+            AutoBrowseTree.MEDIA_ID_MA_ALBUM_PREFIX + "id~provider" to "No tracks found",
+            AutoBrowseTree.MEDIA_ID_MA_ARTIST_PREFIX + "id~provider" to "No albums found",
+        )
+
+        categories.forEach { (parentId, expectedTitle) ->
+            val items = AutoBrowseTree.withEmptyState(parentId, emptyList())
+            assertEquals("$parentId should get exactly one message row", 1, items.size)
+            assertEquals(expectedTitle, items[0].mediaMetadata.title)
+            assertEquals(false, items[0].mediaMetadata.isPlayable)
+            assertEquals(false, items[0].mediaMetadata.isBrowsable)
+            assertTrue(items[0].mediaId.startsWith(AutoBrowseTree.MEDIA_ID_MESSAGE_PREFIX))
+        }
+    }
+
+    @Test
+    fun `withEmptyState passes non-empty lists through unchanged`() {
+        val item = AutoBrowseTree.playableServerItem("Test", "10.0.0.1:8927")
+
+        val items = AutoBrowseTree.withEmptyState(AutoBrowseTree.MEDIA_ID_MA_PLAYLISTS, listOf(item))
+
+        assertEquals(1, items.size)
+        assertEquals(item.mediaId, items[0].mediaId)
+        assertFalse(items[0].mediaId.startsWith(AutoBrowseTree.MEDIA_ID_MESSAGE_PREFIX))
     }
 }


### PR DESCRIPTION
## Why

Google Play rejected the 2.0.0-Beta14 update under the **Auto App Quality Guidelines**: *"App doesn't perform as expected... unable to load content in the Android Auto environment"* (automated enforcement, Jun 26).

Google's automated review browses the app in an Android Auto harness with **no SendSpin server reachable and no saved servers**. In that state the browse tree was:

- Root -> one node, "Connect"
- "Connect" -> `getDiscoveredServers()` returned whatever mDNS had cached at call time -> **empty list, forever**

Android Auto renders an empty children list as a blank "unable to load content" screen, which is exactly what the reviewer flagged.

## What changed

**New `AutoBrowseTree`** - the browse tree list building is extracted from `PlaybackService` into a unit-testable builder that enforces one invariant: **no browsable node ever resolves to an empty list.**

- The "Connect" node returns a non-interactive **"No servers found"** guidance row ("Open SendSpin Player on your phone to add a server") instead of an empty list.
- The "Connect" node now answers on the async path and **waits up to 3s for the first mDNS result** when nothing is known yet, so the first browse no longer races discovery - real users see their server on first tap, and Google's harness gets the guidance row after a bounded wait. Later discoveries still refresh the node via `notifyChildrenChanged`.
- Music Assistant category and drill-down nodes replace empty/failed fetch results with a "No playlists found" / "No tracks found" style message row.
- `onSearch` reports zero results instead of `ERROR_NOT_SUPPORTED` when MA is unavailable, consistent with the always-advertised `SEARCH_SUPPORTED` root hint.

No behavior changes when servers/content exist: item ordering, media IDs, content-style hints, and icons are unchanged (covered by tests).

## Test harness

`BrowseTreeTest` previously re-implemented the service logic and asserted against the copy; it now exercises the real `AutoBrowseTree` code with real Media3 `MediaItem`s (Robolectric), including regression tests for the rejection scenario:

- `empty server list returns No servers found guidance instead of empty` - the exact state Google's reviewer sees
- `guidance row is neither playable nor browsable`
- `server list waits for first mDNS discovery before answering` / `does not wait when a saved server exists` (virtual-time)
- `MA category nodes replace empty results with a message row`
- plus the pre-existing ordering/media-ID/flag assertions, ported to the real code

Also adds `.github/workflows/pr-tests.yml` so `testDebugUnitTest` runs on PRs touching `android/` - previously unit tests only ran on push to `main`, so a PR could not demonstrate green tests before merge. This PR's checks are the demonstration.

To demo interactively: Desktop Head Unit (DHU) with a fresh install and no server on the network -> open SendSpin Player -> "Connect" shows the guidance row instead of a blank screen.

## After merging

1. Build a release with these changes, upload to all tracks carrying the rejected bundle, and deactivate the noncompliant versions.
2. In Play Console, submit the appeal as "I believe I have fixed this issue" describing that the Android Auto browse tree now shows guidance when no server is available.
3. Recommended: fill in **App content -> App access** with a note that the app is a client for a self-hosted server, and what a reviewer sees without one.