### PR TITLE
fix(auto): give voice search user-facing feedback on every dead end

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/AutoVoiceSearch.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/AutoVoiceSearch.kt
@@ -1,0 +1,69 @@
+package com.sendspindroid.playback
+
+import com.sendspindroid.musicassistant.SearchResults
+
+/**
+ * Decision logic for Android Auto voice search ("OK Google, play X on
+ * SendSpin Player").
+ *
+ * Extracted from PlaybackService so the outcome selection and user-facing
+ * feedback messages are unit-testable. Companion to [AutoBrowseTree], which
+ * covers the browse side of the same Play Auto quality requirement: an
+ * external request must never end in a silent no-op. Voice searches that
+ * cannot play anything surface an actionable message on the car screen
+ * instead of doing nothing.
+ */
+object AutoVoiceSearch {
+
+    /** What a voice search should play, chosen from MA search results. */
+    sealed class Pick {
+        data class Track(val uri: String, val name: String) : Pick()
+        data class Playlist(val playlistId: String, val name: String) : Pick()
+        data class Album(val albumId: String, val name: String) : Pick()
+        object NoResults : Pick()
+    }
+
+    /**
+     * Chooses what to play from search results, preferring tracks, then
+     * playlists, then albums (matching in-app search ranking).
+     */
+    fun pickFromResults(results: SearchResults?): Pick {
+        if (results == null) return Pick.NoResults
+
+        val track = results.tracks.firstOrNull { it.uri != null }
+        if (track != null) return Pick.Track(track.uri!!, track.name)
+
+        val playlist = results.playlists.firstOrNull()
+        if (playlist != null) return Pick.Playlist(playlist.playlistId, playlist.name)
+
+        val album = results.albums.firstOrNull()
+        if (album != null) return Pick.Album(album.albumId, album.name)
+
+        return Pick.NoResults
+    }
+
+    /**
+     * Feedback when voice search cannot run at all because Music Assistant
+     * is not available. The disconnected variant tells the user how to fix
+     * it; the connected variant explains why search doesn't work on a plain
+     * SendSpin server.
+     */
+    fun unavailableMessage(isConnectedToServer: Boolean): String =
+        if (isConnectedToServer) {
+            "Search is not available on this server"
+        } else {
+            "No server connected. Open SendSpin Player on your phone to connect."
+        }
+
+    /** Feedback when a search ran but nothing playable matched. */
+    fun noResultsMessage(query: String): String =
+        "No results for \"$query\""
+
+    /** Feedback when "play music" (blank query) found nothing recently played. */
+    fun noRecentTracksMessage(): String =
+        "Nothing has been played recently. Pick something from the library."
+
+    /** Feedback when the search request itself failed. */
+    fun searchFailedMessage(): String =
+        "Search failed. Check the connection to your server."
+}

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -3709,75 +3709,84 @@ class PlaybackService : MediaLibraryService() {
     // ========================================================================
 
     /**
-     * Handles voice search from Android Auto ("OK Google, play X on SendSpinDroid").
+     * Handles voice search from Android Auto ("OK Google, play X on SendSpin Player").
      * In Media3, voice search arrives via onAddMediaItems with requestMetadata.searchQuery set.
      *
      * - Empty/blank query ("play music"): plays recently played tracks
-     * - Non-empty query: searches MA library and plays first track result
+     * - Non-empty query: searches MA library and plays the best result
+     *   (track > playlist > album, see AutoVoiceSearch.pickFromResults)
+     *
+     * Every dead end produces user-facing feedback instead of a silent no-op:
+     * disconnected requests set a player error with connect guidance; failures
+     * while connected send a transient session error so active playback is
+     * not disturbed.
      */
     private fun handleVoiceSearch(
         query: String,
         originalItems: List<MediaItem>
     ): ListenableFuture<List<MediaItem>> {
         if (MusicAssistant.connectionState.value !is TransportState.Ready) {
-            Log.w(TAG, "Voice search: MA not available, returning items as-is")
+            Log.w(TAG, "Voice search: MA not available")
+            val connected = isConnected()
+            val message = AutoVoiceSearch.unavailableMessage(connected)
+            if (!connected) {
+                // Nothing is playing and nothing can play. Surface actionable
+                // guidance on the car screen instead of a silent no-op (Play
+                // Auto quality: the app must respond to voice actions).
+                // Cleared automatically on the next successful connect.
+                sendSpinPlayer?.setError(message)
+            } else {
+                // Connected to a plain SendSpin server (no MA): playback may
+                // be active, so use a transient session error rather than
+                // putting the player into an error state.
+                notifyVoiceSearchError(message)
+            }
             return Futures.immediateFuture(originalItems)
         }
 
         return suspendToFuture {
             try {
                 if (query.isBlank()) {
-                    // "Play music on SendSpinDroid" - play recently played
+                    // "Play music on SendSpin Player" - play recently played
                     Log.d(TAG, "Voice search: empty query, playing recent")
                     val recent = MusicAssistant.getRecentlyPlayed(limit = 1)
-                    val firstTrack = recent.getOrNull()?.firstOrNull()
-                    val recentUri = firstTrack?.uri
+                    val recentUri = recent.getOrNull()?.firstOrNull()?.uri
                     if (recentUri != null) {
                         MusicAssistant.playMedia(recentUri, mediaType = "track")
                     } else {
                         Log.w(TAG, "Voice search: no recent tracks to play")
+                        notifyVoiceSearchError(AutoVoiceSearch.noRecentTracksMessage())
                     }
                 } else {
-                    // "Play Beatles on SendSpinDroid" - search and play first result
+                    // "Play Beatles on SendSpin Player" - search and play best result
                     Log.d(TAG, "Voice search: searching for '$query'")
                     val result = MusicAssistant.search(
                         query = query,
                         limit = 5,
                         libraryOnly = false
                     )
-                    val searchResults = result.getOrNull()
-                    val firstTrack = searchResults?.tracks?.firstOrNull()
-                    val trackUri = firstTrack?.uri
-                    if (trackUri != null) {
-                        Log.d(TAG, "Voice search: playing track '${firstTrack.name}'")
-                        MusicAssistant.playMedia(trackUri, mediaType = "track")
-                    } else {
-                        // Try playing first playlist or album if no tracks found
-                        val firstPlaylist = searchResults?.playlists?.firstOrNull()
-                        val firstAlbum = searchResults?.albums?.firstOrNull()
-                        when {
-                            firstPlaylist != null -> {
-                                Log.d(TAG, "Voice search: playing playlist '${firstPlaylist.name}'")
-                                MusicAssistant.playMedia(
-                                    firstPlaylist.playlistId,
-                                    mediaType = "playlist"
-                                )
-                            }
-                            firstAlbum != null -> {
-                                Log.d(TAG, "Voice search: playing album '${firstAlbum.name}'")
-                                MusicAssistant.playMedia(
-                                    firstAlbum.albumId,
-                                    mediaType = "album"
-                                )
-                            }
-                            else -> {
-                                Log.w(TAG, "Voice search: no results for '$query'")
-                            }
+                    when (val pick = AutoVoiceSearch.pickFromResults(result.getOrNull())) {
+                        is AutoVoiceSearch.Pick.Track -> {
+                            Log.d(TAG, "Voice search: playing track '${pick.name}'")
+                            MusicAssistant.playMedia(pick.uri, mediaType = "track")
+                        }
+                        is AutoVoiceSearch.Pick.Playlist -> {
+                            Log.d(TAG, "Voice search: playing playlist '${pick.name}'")
+                            MusicAssistant.playMedia(pick.playlistId, mediaType = "playlist")
+                        }
+                        is AutoVoiceSearch.Pick.Album -> {
+                            Log.d(TAG, "Voice search: playing album '${pick.name}'")
+                            MusicAssistant.playMedia(pick.albumId, mediaType = "album")
+                        }
+                        AutoVoiceSearch.Pick.NoResults -> {
+                            Log.w(TAG, "Voice search: no results for '$query'")
+                            notifyVoiceSearchError(AutoVoiceSearch.noResultsMessage(query))
                         }
                     }
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Voice search failed", e)
+                notifyVoiceSearchError(AutoVoiceSearch.searchFailedMessage())
             }
             // Return original items with a dummy URI so media3 framework doesn't error
             originalItems.map { item ->
@@ -3785,6 +3794,17 @@ class PlaybackService : MediaLibraryService() {
                     .setUri("sendspin://voice-search")
                     .build()
             }
+        }
+    }
+
+    /**
+     * Surfaces a non-fatal voice search failure to the car screen / media
+     * notification. Unlike SendSpinPlayer.setError this does not put the
+     * player into an error state, so active playback is unaffected.
+     */
+    private fun notifyVoiceSearchError(message: String) {
+        mainHandler.post {
+            mediaSession?.sendError(SessionError(SessionError.ERROR_INVALID_STATE, message))
         }
     }
 

--- a/android/app/src/test/java/com/sendspindroid/playback/AutoVoiceSearchTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/playback/AutoVoiceSearchTest.kt
@@ -1,0 +1,156 @@
+package com.sendspindroid.playback
+
+import com.sendspindroid.musicassistant.MaAlbum
+import com.sendspindroid.musicassistant.MaPlaylist
+import com.sendspindroid.musicassistant.MaTrack
+import com.sendspindroid.musicassistant.SearchResults
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [AutoVoiceSearch], the Android Auto voice search decision logic.
+ *
+ * Voice search is part of the surface Google's automated Auto quality review
+ * exercises. The invariant mirrors AutoBrowseTree's: a voice request must
+ * never end in a silent no-op - it either picks something to play or produces
+ * an actionable user-facing message.
+ */
+class AutoVoiceSearchTest {
+
+    private fun track(name: String, uri: String?) = MaTrack(
+        itemId = "track-$name",
+        name = name,
+        artist = "Artist",
+        album = "Album",
+        imageUri = null,
+        uri = uri,
+    )
+
+    private fun playlist(name: String) = MaPlaylist(
+        playlistId = "playlist-$name",
+        name = name,
+        imageUri = null,
+        trackCount = 10,
+        owner = null,
+        uri = null,
+    )
+
+    private fun album(name: String) = MaAlbum(
+        albumId = "album-$name",
+        name = name,
+        imageUri = null,
+        uri = null,
+        artist = "Artist",
+        year = 2020,
+        trackCount = 12,
+        albumType = "album",
+    )
+
+    // ========== Pick ordering ==========
+
+    @Test
+    fun `prefers first track with a uri`() {
+        val results = SearchResults(
+            tracks = listOf(track("Song A", uri = "library://track/1")),
+            playlists = listOf(playlist("Mix")),
+            albums = listOf(album("LP")),
+        )
+
+        val pick = AutoVoiceSearch.pickFromResults(results)
+
+        assertEquals(
+            AutoVoiceSearch.Pick.Track(uri = "library://track/1", name = "Song A"),
+            pick
+        )
+    }
+
+    @Test
+    fun `skips tracks without uri and picks the next playable one`() {
+        val results = SearchResults(
+            tracks = listOf(
+                track("Broken", uri = null),
+                track("Playable", uri = "library://track/2"),
+            ),
+        )
+
+        val pick = AutoVoiceSearch.pickFromResults(results)
+
+        assertEquals(
+            AutoVoiceSearch.Pick.Track(uri = "library://track/2", name = "Playable"),
+            pick
+        )
+    }
+
+    @Test
+    fun `falls back to playlist when no track is playable`() {
+        val results = SearchResults(
+            tracks = listOf(track("Broken", uri = null)),
+            playlists = listOf(playlist("Mix")),
+            albums = listOf(album("LP")),
+        )
+
+        val pick = AutoVoiceSearch.pickFromResults(results)
+
+        assertEquals(
+            AutoVoiceSearch.Pick.Playlist(playlistId = "playlist-Mix", name = "Mix"),
+            pick
+        )
+    }
+
+    @Test
+    fun `falls back to album when no track or playlist matches`() {
+        val results = SearchResults(albums = listOf(album("LP")))
+
+        val pick = AutoVoiceSearch.pickFromResults(results)
+
+        assertEquals(
+            AutoVoiceSearch.Pick.Album(albumId = "album-LP", name = "LP"),
+            pick
+        )
+    }
+
+    @Test
+    fun `empty results yield NoResults`() {
+        assertEquals(AutoVoiceSearch.Pick.NoResults, AutoVoiceSearch.pickFromResults(SearchResults()))
+    }
+
+    @Test
+    fun `null results yield NoResults`() {
+        assertEquals(AutoVoiceSearch.Pick.NoResults, AutoVoiceSearch.pickFromResults(null))
+    }
+
+    // ========== Feedback messages: every dead end has a user-facing message ==========
+
+    @Test
+    fun `disconnected message tells the user how to connect`() {
+        val message = AutoVoiceSearch.unavailableMessage(isConnectedToServer = false)
+
+        assertEquals("No server connected. Open SendSpin Player on your phone to connect.", message)
+    }
+
+    @Test
+    fun `connected without MA message explains search is unavailable`() {
+        val message = AutoVoiceSearch.unavailableMessage(isConnectedToServer = true)
+
+        assertEquals("Search is not available on this server", message)
+    }
+
+    @Test
+    fun `no results message includes the query`() {
+        val message = AutoVoiceSearch.noResultsMessage("obscure band")
+
+        assertTrue("Message should include the query", message.contains("obscure band"))
+    }
+
+    @Test
+    fun `all failure messages are non-blank`() {
+        listOf(
+            AutoVoiceSearch.unavailableMessage(true),
+            AutoVoiceSearch.unavailableMessage(false),
+            AutoVoiceSearch.noResultsMessage("x"),
+            AutoVoiceSearch.noRecentTracksMessage(),
+            AutoVoiceSearch.searchFailedMessage(),
+        ).forEach { assertTrue("Feedback message must not be blank", it.isNotBlank()) }
+    }
+}


### PR DESCRIPTION
## Why

Follow-up to #186, closing the last silent-no-op gap on the surface Google's automated Android Auto quality review exercises. A voice request ("OK Google, play X on SendSpin Player") previously did **nothing at all** when it couldn't play something:

- Music Assistant unavailable (including not connected to any server) -> items returned as-is, no feedback
- Search returned no results -> log line only
- "Play music" with nothing recently played -> log line only
- Search request threw -> log line only

The disconnected case is exactly what a reviewer would hit, and it falls under the same "app doesn't perform as expected" guideline as the empty browse list.

## What changed

**New `AutoVoiceSearch`** - the decision logic extracted from `PlaybackService`, companion to `AutoBrowseTree`, with the mirrored invariant: a voice request either picks something to play or produces an actionable user-facing message.

- **Disconnected**: sets a player error with connect guidance ("No server connected. Open SendSpin Player on your phone to connect.") via the existing `SendSpinPlayer.setError` mechanism - shown on the car screen, cleared automatically on the next successful connect. Nothing was playing anyway, so an error state is safe.
- **Connected but MA unavailable / no results / nothing recent / search failed**: sends a *transient* `MediaSession.sendError` (non-fatal), so active playback and the Now Playing screen are not disturbed.
- Result picking (track > playlist > album) is now explicit in `pickFromResults`, and it skips tracks without a URI instead of abandoning the whole track list when the first entry is unplayable - a small correctness win over the old code.

No behavior change on the happy path: same MA `playMedia` dispatch, same dummy-URI return shape to the Media3 framework.

## Test harness

`AutoVoiceSearchTest` (plain JUnit - the helper has no Android dependencies):

- pick ordering: track first, URI-less tracks skipped, playlist fallback, album fallback, `NoResults` for empty/null
- the disconnected message contains connect guidance; the connected variant explains search is unavailable
- every failure mode has a non-blank user-facing message

Runs in CI via the `pr-tests` workflow added in #186 - the green check on this PR is the demonstration. To demo interactively: DHU with no server connected -> "OK Google, play music on SendSpin Player" -> the car screen shows the connect guidance instead of nothing happening.