### PR TITLE
release: bump to 2.0.0-Beta15

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -74,11 +74,11 @@ android {
         // Ranges: MAJOR 0-9999, MINOR 0-99, PATCH 0-99
         // Example: 2.0.0 = 20000, 2.1.3 = 20103, 10.5.22 = 100522
         // Beta releases: increment by 1 from base (20001 = Beta2, 20002 = Beta3, etc.)
-        versionCode = 20014
+        versionCode = 20015
 
         // versionName: User-visible version string
         // Follows semantic versioning (major.minor.patch[-prerelease])
-        versionName = "2.0.0-Beta14"
+        versionName = "2.0.0-Beta15"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Version bump for the 2.0.0-Beta15 release: `versionCode` 20014 -> 20015, `versionName` 2.0.0-Beta14 -> 2.0.0-Beta15.

This release carries the Google Play rejection fixes:

- #186 - Android Auto browse tree never renders an empty list (guidance rows + bounded mDNS wait)
- #187 - voice search surfaces user-facing feedback on every dead end

Play requires a higher `versionCode` than the rejected Beta14 bundle (20014), so the fixed release ships as 20015, continuing the Beta-N -> 200NN pattern.

Once this merges, the `v2.0.0-Beta15` tag on the bump commit kicks off the Build and Release workflow. Upload the resulting bundle to every track that carries the rejected Beta14 bundle and mark Beta14 as "Not included", then submit the Play appeal as "I believe I have fixed this issue".