### PR TITLE
Phase 0: dev server that rejects the legacy dialect, and the Noise KKpsk2 spike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ android/conformance-client/build/
 ci/conformance/noise/*.jar
 ci/conformance/noise/*.class
 ci/conformance/__pycache__/
+
+# Python bytecode from the conformance tooling
+__pycache__/
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,11 @@ android/nul
 # Git worktrees (isolated dev branches)
 .worktrees/
 android/conformance-client/build/
+
+# Sendspin dev server runtime state (identity key + pairing records)
+.dev/
+
+# Noise spike: jars are fetched on demand, classes are build output
+ci/conformance/noise/*.jar
+ci/conformance/noise/*.class
+ci/conformance/__pycache__/

--- a/ci/conformance/dev_server.py
+++ b/ci/conformance/dev_server.py
@@ -98,6 +98,34 @@ def describe_client(client) -> str:
     )
 
 
+def build_server(
+    loop: asyncio.AbstractEventLoop,
+    identity: Identity,
+    name: str,
+    pairing_store,
+    *,
+    allow_unencrypted: bool = False,
+) -> SendspinServer:
+    """Construct the server with this runner's policy.
+
+    Kept as a single function so verify_dev_server.py exercises the SAME
+    configuration the dev server actually ships, rather than a parallel copy
+    that could silently drift if someone flips a flag while debugging.
+
+    `allow_unencrypted` is a parameter only so the verification script can
+    stand up a deliberately permissive control server; the runner always
+    passes the default.
+    """
+    return SendspinServer(
+        loop,
+        identity,
+        name,
+        pairing_store=pairing_store,
+        allow_unencrypted=allow_unencrypted,
+        allow_noncompliant_clients=allow_unencrypted,
+    )
+
+
 class DevServer:
     def __init__(self, args: argparse.Namespace) -> None:
         self._args = args
@@ -112,14 +140,9 @@ class DevServer:
         store_path.parent.mkdir(parents=True, exist_ok=True)
         store = await FileServerPairingStore.open(store_path)
 
-        self._server = SendspinServer(
-            asyncio.get_running_loop(),
-            identity,
-            args.name,
-            pairing_store=store,
-            # The whole point of this runner: reject the legacy dialect.
-            allow_unencrypted=False,
-            allow_noncompliant_clients=False,
+        # The whole point of this runner: reject the legacy dialect.
+        self._server = build_server(
+            asyncio.get_running_loop(), identity, args.name, store
         )
 
         advertise = [args.advertise_ip] if args.advertise_ip else None
@@ -157,8 +180,14 @@ class DevServer:
         while True:
             try:
                 clients = list(self._server.connected_clients)
-            except Exception:  # server shutting down
-                return
+            except Exception:
+                # Do NOT assume this means shutdown. If the watcher dies here,
+                # auto-trust silently stops while --trust-all-unpaired is still
+                # on the command line - which recreates precisely the
+                # untrusted-client confusion this flag exists to prevent.
+                LOGGER.exception("failed to read connected_clients; continuing")
+                await asyncio.sleep(1.0)
+                continue
             current = set()
             for client in clients:
                 current.add(client.client_id)
@@ -169,9 +198,15 @@ class DevServer:
                     and not client.is_paired
                     and client.client_id not in self._auto_trusted
                 ):
-                    await self._server.trust_unpaired(client.client_id)
-                    self._auto_trusted.add(client.client_id)
-                    LOGGER.info("auto-trusted unpaired client %s", client.client_id)
+                    # A client can disconnect between the snapshot above and
+                    # this call; that must not kill the watcher.
+                    try:
+                        await self._server.trust_unpaired(client.client_id)
+                    except Exception:
+                        LOGGER.exception("failed to auto-trust %s", client.client_id)
+                    else:
+                        self._auto_trusted.add(client.client_id)
+                        LOGGER.info("auto-trusted unpaired client %s", client.client_id)
             for gone in seen - current:
                 LOGGER.info("client disconnected: %s", gone)
             seen = current
@@ -283,9 +318,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="auto-trust every unpaired client so it becomes playback-capable",
     )
     parser.add_argument(
-        "--dump-wire",
+        "--debug",
         action="store_true",
-        help="log the raw client/init and server/init bytes (for prologue debugging)",
+        help="raise aiosendspin and this script to DEBUG logging",
     )
     return parser
 
@@ -294,13 +329,27 @@ async def run(args: argparse.Namespace) -> int:
     server = DevServer(args)
     await server.start()
     watcher = asyncio.create_task(server.watch_clients())
+
+    def report_watcher_death(task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        err = task.exception()
+        if err is not None:
+            LOGGER.error("client watcher stopped; auto-trust and connection "
+                         "logging are no longer running", exc_info=err)
+
+    watcher.add_done_callback(report_watcher_death)
+
     try:
         await server.console()
     except (KeyboardInterrupt, asyncio.CancelledError):
         pass
     finally:
         watcher.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
+        # Suppress CancelledError from the cancel above, but tolerate a watcher
+        # that already died of something else - otherwise that exception would
+        # propagate here and skip the close() below.
+        with contextlib.suppress(asyncio.CancelledError, Exception):
             await watcher
         await server.close()
     return 0
@@ -309,16 +358,21 @@ async def run(args: argparse.Namespace) -> int:
 def main() -> int:
     args = build_parser().parse_args()
     logging.basicConfig(
-        level=logging.DEBUG if args.dump_wire else logging.INFO,
+        level=logging.DEBUG if args.debug else logging.INFO,
         format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
         datefmt="%H:%M:%S",
     )
-    if args.dump_wire:
-        # The prologue is the concatenated raw bytes of client/init and
-        # server/init. Comparing our concatenation against the server's is the
-        # only practical way to debug a prologue mismatch, which otherwise
-        # closes the socket with no application-level error.
+    if args.debug:
         logging.getLogger("aiosendspin").setLevel(logging.DEBUG)
+        # Note for prologue debugging (item 1.2): aiosendspin 9.1.0 does NOT log
+        # the raw client/init and server/init bytes at any level. It builds the
+        # prologue in aiosendspin/noise/driver.py as
+        # `client_init_text.encode() + server_init_text.encode()` with no log
+        # statement, so DEBUG will not surface the bytes you need to diff. To
+        # compare against our concatenation you have to capture the frames
+        # yourself - a WebSocket proxy, or a local patch to that function.
+        LOGGER.debug("aiosendspin does not log raw init bytes; see the comment "
+                     "in main() if you are debugging a prologue mismatch")
     try:
         return asyncio.run(run(args))
     except KeyboardInterrupt:

--- a/ci/conformance/dev_server.py
+++ b/ci/conformance/dev_server.py
@@ -1,0 +1,329 @@
+"""Local aiosendspin development server that refuses the legacy dialect.
+
+Music Assistant ships `allow_legacy_clients=true` by default, which silently
+accepts the pre-encryption `client/hello`-first dialect SendSpinDroid speaks
+today. That default hides exactly the failures the Phase 1 migration has to fix,
+so this runner starts a server with `allow_unencrypted=False` and
+`allow_noncompliant_clients=False`.
+
+Unlike the conformance harness adapter, this server keeps a persistent identity
+and a file-backed pairing store, so `server_id` and pairing records survive a
+restart. Regenerating either invalidates the stored-pubkey records on the phone
+and produces a handshake failure that the spec deliberately reports as a silent
+close, so the identity file is created once and never overwritten.
+
+See docs/dev-server-runbook.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import logging
+import os
+import sys
+from pathlib import Path
+
+try:
+    from aiosendspin.noise.keys import Identity
+    from aiosendspin.noise.pairing import PairMethod, PairingAttempt
+    from aiosendspin.noise.pairing_token import decode_token
+    from aiosendspin.noise.trust_store import FileServerPairingStore
+    from aiosendspin.server.server import SendspinServer
+except ImportError:  # pragma: no cover - environment guidance, not logic
+    print(
+        "aiosendspin is not installed. See docs/dev-server-runbook.md:\n"
+        "  pip install 'aiosendspin[server]==9.1.0'",
+        file=sys.stderr,
+    )
+    raise SystemExit(2) from None
+
+LOGGER = logging.getLogger("dev_server")
+
+DEFAULT_STATE_DIR = Path(".dev/sendspin")
+DEFAULT_PORT = 8927
+
+
+def b64u_decode(value: str) -> bytes:
+    """Decode base64url without padding."""
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def load_or_create_identity(path: Path) -> Identity:
+    """Return the persistent server identity, creating it on first run.
+
+    Mirrors music_assistant/providers/sendspin/security.py. The file is created
+    with O_EXCL so two concurrent starts cannot both mint an identity, and a
+    corrupt file is never silently replaced -- a changed `server_id` invalidates
+    every stored-pubkey pairing record on every paired client.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        pass
+    else:
+        if not raw:
+            raise SystemExit(
+                f"{path} is empty. Refusing to mint a new identity, because that would "
+                f"invalidate every existing pairing record. Delete it deliberately if "
+                f"that is what you want."
+            )
+        try:
+            return Identity.from_private_bytes(b64u_decode(raw))
+        except Exception as err:
+            raise SystemExit(
+                f"{path} is not a valid identity key ({err}). Refusing to overwrite it; "
+                f"see docs/dev-server-runbook.md."
+            ) from err
+
+    identity = Identity.generate()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(identity.private_b64u)
+    LOGGER.info("Generated a new server identity at %s", path)
+    return identity
+
+
+def describe_client(client) -> str:
+    """One-line summary of a connected client, for the console."""
+    security = getattr(client, "connection_security", None)
+    roles = getattr(client, "active_role_ids", None) or ()
+    return (
+        f"{client.client_id}  name={client.name!r}  paired={client.is_paired}  "
+        f"security={security}  roles={list(roles)}"
+    )
+
+
+class DevServer:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self._args = args
+        self._server: SendspinServer | None = None
+        self._auto_trusted: set[str] = set()
+
+    async def start(self) -> None:
+        args = self._args
+        state_dir = Path(args.state_dir)
+        identity = load_or_create_identity(Path(args.identity_file or state_dir / "identity.key"))
+        store_path = Path(args.pairing_store or state_dir / "pairing_store.json")
+        store_path.parent.mkdir(parents=True, exist_ok=True)
+        store = await FileServerPairingStore.open(store_path)
+
+        self._server = SendspinServer(
+            asyncio.get_running_loop(),
+            identity,
+            args.name,
+            pairing_store=store,
+            # The whole point of this runner: reject the legacy dialect.
+            allow_unencrypted=False,
+            allow_noncompliant_clients=False,
+        )
+
+        advertise = [args.advertise_ip] if args.advertise_ip else None
+        await self._server.start_server(
+            port=args.port,
+            host=args.host,
+            advertise_addresses=advertise,
+            # SendSpinDroid is client-initiated. The spec forbids a client
+            # advertising _sendspin._tcp in that mode, so we must not browse
+            # for one either.
+            discover_clients=False,
+        )
+
+        LOGGER.info("=" * 72)
+        LOGGER.info("Sendspin dev server %r listening on %s:%d%s",
+                    args.name, args.host, args.port, SendspinServer.API_PATH)
+        LOGGER.info("server_id: %s", identity.peer_id)
+        LOGGER.info("identity:  %s (do NOT delete - see runbook)", args.identity_file or state_dir / "identity.key")
+        LOGGER.info("records:   %s", store_path)
+        LOGGER.info("allow_unencrypted=False  allow_noncompliant_clients=False")
+        if args.trust_all_unpaired:
+            LOGGER.info("auto-trusting unpaired clients on connect (--trust-all-unpaired)")
+        LOGGER.info("=" * 72)
+
+    async def watch_clients(self) -> None:
+        """Log connections and, when asked, auto-trust unpaired clients.
+
+        A Sentinel-keyed client completes the handshake but is not
+        playback-capable until the operator trusts it. Forgetting that step
+        looks exactly like a bug in the client's server/activate handling, so
+        --trust-all-unpaired exists to take it off the table during Phase 1.
+        """
+        assert self._server is not None
+        seen: set[str] = set()
+        while True:
+            try:
+                clients = list(self._server.connected_clients)
+            except Exception:  # server shutting down
+                return
+            current = set()
+            for client in clients:
+                current.add(client.client_id)
+                if client.client_id not in seen:
+                    LOGGER.info("client connected: %s", describe_client(client))
+                if (
+                    self._args.trust_all_unpaired
+                    and not client.is_paired
+                    and client.client_id not in self._auto_trusted
+                ):
+                    await self._server.trust_unpaired(client.client_id)
+                    self._auto_trusted.add(client.client_id)
+                    LOGGER.info("auto-trusted unpaired client %s", client.client_id)
+            for gone in seen - current:
+                LOGGER.info("client disconnected: %s", gone)
+            seen = current
+            await asyncio.sleep(1.0)
+
+    # -- console -----------------------------------------------------------
+
+    async def console(self) -> None:
+        loop = asyncio.get_running_loop()
+        self._print_help()
+        while True:
+            line = await loop.run_in_executor(None, sys.stdin.readline)
+            if not line:
+                return
+            parts = line.strip().split()
+            if not parts:
+                continue
+            cmd, rest = parts[0], parts[1:]
+            try:
+                if cmd in ("q", "quit", "exit"):
+                    return
+                await self._dispatch(cmd, rest)
+            except Exception as err:
+                LOGGER.error("%s failed: %s", cmd, err)
+
+    async def _dispatch(self, cmd: str, rest: list[str]) -> None:
+        assert self._server is not None
+        server = self._server
+        if cmd in ("h", "help", "?"):
+            self._print_help()
+        elif cmd in ("c", "clients"):
+            clients = list(server.connected_clients)
+            if not clients:
+                print("(no clients connected)")
+            for client in clients:
+                print(" ", describe_client(client))
+        elif cmd == "trust":
+            await server.trust_unpaired(self._resolve(rest))
+            print("trusted")
+        elif cmd == "untrust":
+            await server.untrust_unpaired(self._resolve(rest))
+            print("untrusted")
+        elif cmd == "unpair":
+            await server.unpair(self._resolve(rest))
+            print("unpaired")
+        elif cmd == "pair":
+            if not rest:
+                raise ValueError("usage: pair <SP:0... token>")
+            token = decode_token(rest[0])
+            client_id = token.client_id
+            print(f"token decodes to client_id {client_id}")
+            if server.get_client(client_id) is None:
+                raise ValueError(
+                    f"no connected client with id {client_id}; the device must be "
+                    f"connected before it can be paired"
+                )
+            await server.initiate_pairing(
+                client_id,
+                PairingAttempt(PairMethod.PAIRING_PSK, pairing_psk=token.pairing_psk),
+            )
+            print("pairing initiated")
+        else:
+            print(f"unknown command {cmd!r}; try 'help'")
+
+    def _resolve(self, rest: list[str]) -> str:
+        """Resolve a command argument to a client id, defaulting to the only one."""
+        assert self._server is not None
+        if rest:
+            return rest[0]
+        clients = list(self._server.connected_clients)
+        if len(clients) == 1:
+            return clients[0].client_id
+        raise ValueError("specify a client_id (see 'clients')")
+
+    @staticmethod
+    def _print_help() -> None:
+        print(
+            "\ncommands:\n"
+            "  clients            list connected clients\n"
+            "  trust [id]         allow an unpaired client to play (Sentinel PSK)\n"
+            "  untrust [id]       revoke unpaired playback\n"
+            "  pair <token>       pair using a SP:0... pairing token from the device\n"
+            "  unpair [id]        drop the pairing record and tell the client\n"
+            "  quit               stop the server\n"
+            "id defaults to the only connected client when omitted.\n"
+        )
+
+    async def close(self) -> None:
+        if self._server is None:
+            return
+        # aiosendspin issue 299: close() can hang for client-initiated
+        # connections. Bound it so Ctrl-C does not appear to wedge.
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._server.close(), timeout=5.0)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--name", default="Sendspin Dev", help="friendly server name")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--advertise-ip", default=None, help="IP to advertise over mDNS")
+    parser.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
+    parser.add_argument("--identity-file", default=None)
+    parser.add_argument("--pairing-store", default=None)
+    parser.add_argument(
+        "--trust-all-unpaired",
+        action="store_true",
+        help="auto-trust every unpaired client so it becomes playback-capable",
+    )
+    parser.add_argument(
+        "--dump-wire",
+        action="store_true",
+        help="log the raw client/init and server/init bytes (for prologue debugging)",
+    )
+    return parser
+
+
+async def run(args: argparse.Namespace) -> int:
+    server = DevServer(args)
+    await server.start()
+    watcher = asyncio.create_task(server.watch_clients())
+    try:
+        await server.console()
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        pass
+    finally:
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watcher
+        await server.close()
+    return 0
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.dump_wire else logging.INFO,
+        format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    if args.dump_wire:
+        # The prologue is the concatenated raw bytes of client/init and
+        # server/init. Comparing our concatenation against the server's is the
+        # only practical way to debug a prologue mismatch, which otherwise
+        # closes the socket with no application-level error.
+        logging.getLogger("aiosendspin").setLevel(logging.DEBUG)
+    try:
+        return asyncio.run(run(args))
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/conformance/noise/KKpsk2Responder.java
+++ b/ci/conformance/noise/KKpsk2Responder.java
@@ -61,9 +61,16 @@ public final class KKpsk2Responder {
     }
 
     /**
-     * Noise HKDF. NOT RFC 5869 applied naively: each output is an HMAC over the
-     * previous output concatenated with a counter byte. Using a generic HKDF
-     * helper here produces a handshake that only fails against a real peer.
+     * Noise HKDF. This IS RFC 5869 HKDF - the Noise spec section 4.3 states it
+     * outright: "the HKDF() function is simply HKDF from [RFC 5869] with the
+     * chaining_key as HKDF salt, and zero-length HKDF info." It is expanded
+     * inline here only so the prototype has no dependency beyond BouncyCastle;
+     * a library HKDF returning 2 or 3 32-byte outputs is equivalent, and the
+     * Kotlin port should feel free to use one.
+     *
+     * The trap is parameter misuse, not the construction: `chainingKey` is the
+     * SALT (not the IKM), `ikm` is the IKM, and info must be EMPTY. Swap or fill
+     * any of those and the handshake still runs, then fails against a real peer.
      */
     private static byte[][] hkdf(byte[] chainingKey, byte[] ikm, int numOutputs) {
         byte[] tempKey = hmac(chainingKey, ikm);
@@ -153,9 +160,19 @@ public final class KKpsk2Responder {
     }
 
     private byte[] decryptAndHash(byte[] ciphertext) throws Exception {
+        // Note: n is consumed even when the decrypt below throws, leaving this
+        // object desynchronised. Harmless here because Noise mandates aborting
+        // the handshake on any failure and nothing retries. The Kotlin port
+        // must make that structural (a terminal/consumed state), not incidental.
         byte[] pt = (k == null) ? ciphertext : aeadDecrypt(k, n++, h, ciphertext);
         mixHash(ciphertext);
         return pt;
+    }
+
+    /** Distinguishes protocol-level handshake failures from BouncyCastle internals. */
+    public static final class HandshakeException extends Exception {
+        HandshakeException(String message) { super(message); }
+        HandshakeException(String message, Throwable cause) { super(message, cause); }
     }
 
     // -- handshake ---------------------------------------------------------
@@ -178,13 +195,27 @@ public final class KKpsk2Responder {
     public void start(byte[] prologue) {
         initializeSymmetric("Noise_KKpsk2_25519_ChaChaPoly_SHA256");
         mixHash(prologue);
-        // Pre-messages, initiator's public keys first (Noise spec section 7).
+        // Pre-messages, initiator public keys first (Noise spec section 5.3,
+        // Initialize(); section 7 only defines the patterns themselves).
         mixHash(rs);    // "-> s"  (the server, who is the initiator)
         mixHash(sPub);  // "<- s"  (us, the responder)
     }
 
     /** Message 1: -> e, es, ss. Returns the decrypted payload (carries psk_id). */
     public byte[] readMessage1(byte[] message) throws Exception {
+        // Validate length FIRST. Arrays.copyOfRange zero-pads rather than
+        // throwing when the range exceeds the input, so a truncated frame would
+        // otherwise be processed as a garbage all-zero ephemeral key and fail
+        // several steps later as an opaque "32 > 10" IllegalArgumentException or,
+        // worse, as an InvalidCipherTextException indistinguishable from a
+        // genuine key mismatch. Port this check to Kotlin: in production a
+        // handshake abort is a silent close, so the local exception is the only
+        // diagnostic anyone will ever get.
+        if (message.length < DHLEN + TAGLEN) {
+            throw new HandshakeException(
+                    "handshake message 1 truncated: " + message.length
+                            + " bytes, need at least " + (DHLEN + TAGLEN));
+        }
         re = Arrays.copyOfRange(message, 0, DHLEN);
         mixHash(re);
         // PSK-modified handshakes only: every "e" token calls MixKey on the
@@ -194,7 +225,17 @@ public final class KKpsk2Responder {
         mixKey(re);
         mixKey(dh(s, re));          // es: responder side is DH(s, re)
         mixKey(dh(s, rs));          // ss
-        return decryptAndHash(Arrays.copyOfRange(message, DHLEN, message.length));
+        try {
+            return decryptAndHash(Arrays.copyOfRange(message, DHLEN, message.length));
+        } catch (Exception cause) {
+            // BouncyCastle reports every AEAD failure as the same
+            // InvalidCipherTextException. We know which token was being
+            // processed; say so, because the peer will tell us nothing.
+            throw new HandshakeException(
+                    "message 1 payload AEAD failed - wrong PSK is NOT possible here "
+                            + "(psk2 mixes it later), so suspect the prologue, our static "
+                            + "key, or the server static key", cause);
+        }
     }
 
     /** Message 2: <- e, ee, se, psk. The PSK is mixed LAST, after key selection. */
@@ -350,15 +391,20 @@ public final class KKpsk2Responder {
 
             System.out.println("RESPONDER h=" + toHex(r.handshakeHash));
 
-            // Transport mode: read one message from the initiator.
-            byte[] ct = readFrame(in);
-            byte[] pt = aeadDecrypt(r.recvKey, 0, new byte[0], ct);
-            System.out.println("RESPONDER transport_recv=" + new String(pt, StandardCharsets.UTF_8));
-
-            // And send one back.
-            byte[] reply = aeadEncrypt(r.sendKey, 0, new byte[0],
-                    "hello from responder".getBytes(StandardCharsets.UTF_8));
-            writeFrame(out, reply);
+            // Transport mode. Two frames per direction, with the nonce counter
+            // advancing: at n=0 the nonce is twelve zero bytes regardless of
+            // endianness or offset, so a counter bug is only visible at n=1.
+            for (long i = 0; i < 2; i++) {
+                byte[] ct = readFrame(in);
+                byte[] pt = aeadDecrypt(r.recvKey, i, new byte[0], ct);
+                System.out.println("RESPONDER transport_recv[" + i + "]="
+                        + new String(pt, StandardCharsets.UTF_8));
+            }
+            for (long i = 0; i < 2; i++) {
+                byte[] reply = aeadEncrypt(r.sendKey, i, new byte[0],
+                        ("reply-" + i + " from responder").getBytes(StandardCharsets.UTF_8));
+                writeFrame(out, reply);
+            }
             System.out.println("RESPONDER done");
         }
     }

--- a/ci/conformance/noise/KKpsk2Responder.java
+++ b/ci/conformance/noise/KKpsk2Responder.java
@@ -1,0 +1,365 @@
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.macs.HMac;
+import org.bouncycastle.crypto.modes.ChaCha20Poly1305;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.math.ec.rfc7748.X25519;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+/**
+ * Hand-rolled Noise_KKpsk2_25519_ChaChaPoly_SHA256 RESPONDER on BouncyCastle.
+ *
+ * Prototype for audit item 0.1 (issue #189), to be ported to Kotlin as
+ * NoiseSession.kt in item 1.2 (issue #193). noise-java cannot do this: it has
+ * no psk token and refuses a PSK once the handshake has started.
+ *
+ * In Sendspin the SERVER is the Noise initiator and the CLIENT is the
+ * responder, regardless of who opened the WebSocket. This class is the client
+ * side.
+ *
+ *   KKpsk2:
+ *     -> s
+ *     <- s
+ *     ...
+ *     -> e, es, ss
+ *     <- e, ee, se, psk
+ *
+ * The PSK is mixed at the END of message 2 (the psk2 modifier), which is what
+ * lets the client read psk_id from message 1's payload and only then choose
+ * which PSK to mix -- the reason a library that demands the PSK up front is
+ * unusable here.
+ */
+public final class KKpsk2Responder {
+
+    private static final int HASHLEN = 32;
+    private static final int DHLEN = 32;
+    private static final int TAGLEN = 16;
+
+    // -- primitives --------------------------------------------------------
+
+    private static byte[] sha256(byte[]... parts) {
+        SHA256Digest d = new SHA256Digest();
+        for (byte[] p : parts) d.update(p, 0, p.length);
+        byte[] out = new byte[HASHLEN];
+        d.doFinal(out, 0);
+        return out;
+    }
+
+    private static byte[] hmac(byte[] key, byte[] data) {
+        HMac mac = new HMac(new SHA256Digest());
+        mac.init(new KeyParameter(key));
+        mac.update(data, 0, data.length);
+        byte[] out = new byte[HASHLEN];
+        mac.doFinal(out, 0);
+        return out;
+    }
+
+    /**
+     * Noise HKDF. NOT RFC 5869 applied naively: each output is an HMAC over the
+     * previous output concatenated with a counter byte. Using a generic HKDF
+     * helper here produces a handshake that only fails against a real peer.
+     */
+    private static byte[][] hkdf(byte[] chainingKey, byte[] ikm, int numOutputs) {
+        byte[] tempKey = hmac(chainingKey, ikm);
+        byte[] o1 = hmac(tempKey, new byte[] { 0x01 });
+        byte[] o2 = hmac(tempKey, concat(o1, new byte[] { 0x02 }));
+        if (numOutputs == 2) return new byte[][] { o1, o2 };
+        byte[] o3 = hmac(tempKey, concat(o2, new byte[] { 0x03 }));
+        return new byte[][] { o1, o2, o3 };
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+
+    private static byte[] dh(byte[] privateKey, byte[] publicKey) {
+        byte[] out = new byte[DHLEN];
+        X25519.scalarMult(privateKey, 0, publicKey, 0, out, 0);
+        return out;
+    }
+
+    /** ChaChaPoly nonce: 4 zero bytes then the counter, 64-bit little-endian. */
+    private static byte[] nonceBytes(long n) {
+        byte[] nonce = new byte[12];
+        for (int i = 0; i < 8; i++) nonce[4 + i] = (byte) (n >>> (8 * i));
+        return nonce;
+    }
+
+    private static byte[] aeadEncrypt(byte[] key, long n, byte[] ad, byte[] plaintext) throws Exception {
+        ChaCha20Poly1305 c = new ChaCha20Poly1305();
+        c.init(true, new AEADParameters(new KeyParameter(key), TAGLEN * 8, nonceBytes(n), ad));
+        byte[] out = new byte[c.getOutputSize(plaintext.length)];
+        int len = c.processBytes(plaintext, 0, plaintext.length, out, 0);
+        len += c.doFinal(out, len);
+        return Arrays.copyOf(out, len);
+    }
+
+    private static byte[] aeadDecrypt(byte[] key, long n, byte[] ad, byte[] ciphertext) throws Exception {
+        ChaCha20Poly1305 c = new ChaCha20Poly1305();
+        c.init(false, new AEADParameters(new KeyParameter(key), TAGLEN * 8, nonceBytes(n), ad));
+        byte[] out = new byte[c.getOutputSize(ciphertext.length)];
+        int len = c.processBytes(ciphertext, 0, ciphertext.length, out, 0);
+        len += c.doFinal(out, len);
+        return Arrays.copyOf(out, len);
+    }
+
+    // -- symmetric state ---------------------------------------------------
+
+    private byte[] h;
+    private byte[] ck;
+    private byte[] k;          // null means "no key yet"
+    private long n;
+
+    private void initializeSymmetric(String protocolName) {
+        byte[] name = protocolName.getBytes(StandardCharsets.UTF_8);
+        h = (name.length <= HASHLEN) ? Arrays.copyOf(name, HASHLEN) : sha256(name);
+        ck = h.clone();
+        k = null;
+        n = 0;
+    }
+
+    private void mixHash(byte[] data) {
+        h = sha256(h, data);
+    }
+
+    private void mixKey(byte[] ikm) {
+        byte[][] out = hkdf(ck, ikm, 2);
+        ck = out[0];
+        k = out[1];
+        n = 0;
+    }
+
+    private void mixKeyAndHash(byte[] ikm) {
+        byte[][] out = hkdf(ck, ikm, 3);
+        ck = out[0];
+        mixHash(out[1]);
+        k = out[2];
+        n = 0;
+    }
+
+    private byte[] encryptAndHash(byte[] plaintext) throws Exception {
+        byte[] ct = (k == null) ? plaintext : aeadEncrypt(k, n++, h, plaintext);
+        mixHash(ct);
+        return ct;
+    }
+
+    private byte[] decryptAndHash(byte[] ciphertext) throws Exception {
+        byte[] pt = (k == null) ? ciphertext : aeadDecrypt(k, n++, h, ciphertext);
+        mixHash(ciphertext);
+        return pt;
+    }
+
+    // -- handshake ---------------------------------------------------------
+
+    private final byte[] s;      // our static private
+    private final byte[] sPub;   // our static public
+    private final byte[] rs;     // remote (server) static public
+    private byte[] e, ePub, re;
+
+    public byte[] handshakeHash;
+    public byte[] recvKey, sendKey;
+
+    public KKpsk2Responder(byte[] staticPrivate, byte[] remoteStaticPublic) {
+        this.s = staticPrivate.clone();
+        this.sPub = new byte[DHLEN];
+        X25519.scalarMultBase(this.s, 0, this.sPub, 0);
+        this.rs = remoteStaticPublic.clone();
+    }
+
+    public void start(byte[] prologue) {
+        initializeSymmetric("Noise_KKpsk2_25519_ChaChaPoly_SHA256");
+        mixHash(prologue);
+        // Pre-messages, initiator's public keys first (Noise spec section 7).
+        mixHash(rs);    // "-> s"  (the server, who is the initiator)
+        mixHash(sPub);  // "<- s"  (us, the responder)
+    }
+
+    /** Message 1: -> e, es, ss. Returns the decrypted payload (carries psk_id). */
+    public byte[] readMessage1(byte[] message) throws Exception {
+        re = Arrays.copyOfRange(message, 0, DHLEN);
+        mixHash(re);
+        // PSK-modified handshakes only: every "e" token calls MixKey on the
+        // ephemeral public key in addition to MixHash (Noise spec, psk
+        // modifier). Omitting this diverges the state at the very first token
+        // and surfaces only as an AEAD tag failure.
+        mixKey(re);
+        mixKey(dh(s, re));          // es: responder side is DH(s, re)
+        mixKey(dh(s, rs));          // ss
+        return decryptAndHash(Arrays.copyOfRange(message, DHLEN, message.length));
+    }
+
+    /** Message 2: <- e, ee, se, psk. The PSK is mixed LAST, after key selection. */
+    public byte[] writeMessage2(byte[] payload, byte[] psk) throws Exception {
+        return writeMessage2(payload, psk, null);
+    }
+
+    /** @param fixedEphemeral test-only: pin the ephemeral so vectors are reproducible. */
+    public byte[] writeMessage2(byte[] payload, byte[] psk, byte[] fixedEphemeral) throws Exception {
+        e = new byte[DHLEN];
+        if (fixedEphemeral != null) {
+            System.arraycopy(fixedEphemeral, 0, e, 0, DHLEN);
+        } else {
+            new SecureRandom().nextBytes(e);
+        }
+        ePub = new byte[DHLEN];
+        X25519.scalarMultBase(e, 0, ePub, 0);
+
+        mixHash(ePub);
+        mixKey(ePub);               // psk modifier: "e" also mixes into the key
+        mixKey(dh(e, re));          // ee
+        mixKey(dh(e, rs));          // se: responder side is DH(e, rs)
+        mixKeyAndHash(psk);         // psk2 -- the whole point
+        byte[] ct = encryptAndHash(payload);
+
+        handshakeHash = h.clone();
+        byte[][] keys = hkdf(ck, new byte[0], 2);
+        // Responder: first output decrypts initiator->responder traffic.
+        recvKey = keys[0];
+        sendKey = keys[1];
+        return concat(ePub, ct);
+    }
+
+    // -- interop driver ----------------------------------------------------
+
+    private static byte[] readFrame(DataInputStream in) throws Exception {
+        int len = in.readUnsignedShort();
+        byte[] buf = new byte[len];
+        in.readFully(buf);
+        return buf;
+    }
+
+    private static void writeFrame(DataOutputStream out, byte[] data) throws Exception {
+        out.writeShort(data.length);
+        out.write(data);
+        out.flush();
+    }
+
+    private static byte[] hex(String s) {
+        byte[] out = new byte[s.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(s.substring(i * 2, i * 2 + 2), 16);
+        }
+        return out;
+    }
+
+    private static String toHex(byte[] b) {
+        StringBuilder sb = new StringBuilder();
+        for (byte x : b) sb.append(String.format("%02x", x));
+        return sb.toString();
+    }
+
+    /** Debug: dump symmetric state after init and after reading a recorded message 1. */
+    private static void trace(String[] args) throws Exception {
+        byte[] ourStatic = hex(args[1]);
+        byte[] serverStatic = hex(args[2]);
+        byte[] prologue = args[3].getBytes(StandardCharsets.UTF_8);
+        byte[] msg1 = hex(args[4]);
+
+        KKpsk2Responder r = new KKpsk2Responder(ourStatic, serverStatic);
+        r.start(prologue);
+        System.out.println("after_init_h  " + toHex(r.h));
+        System.out.println("after_init_ck " + toHex(r.ck));
+        System.out.println("our_pub       " + toHex(r.sPub));
+        System.out.println("their_pub     " + toHex(r.rs));
+        try {
+            byte[] pt = r.readMessage1(msg1);
+            System.out.println("msg1_payload  " + new String(pt, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            System.out.println("msg1_FAILED   " + e.getMessage());
+        }
+        System.out.println("after_m1_h    " + toHex(r.h));
+        System.out.println("after_m1_ck   " + toHex(r.ck));
+    }
+
+    /** Emit reproducible golden vectors as JSON for the Kotlin port's tests. */
+    private static void vectors(String[] args) throws Exception {
+        byte[] ourStatic = hex(args[1]);
+        byte[] serverStatic = hex(args[2]);
+        byte[] psk = hex(args[3]);
+        byte[] prologue = args[4].getBytes(StandardCharsets.UTF_8);
+        byte[] msg1 = hex(args[5]);
+        byte[] fixedEph = hex(args[6]);
+
+        KKpsk2Responder r = new KKpsk2Responder(ourStatic, serverStatic);
+        r.start(prologue);
+        byte[] payload1 = r.readMessage1(msg1);
+        String hAfterM1 = toHex(r.h);
+        byte[] msg2 = r.writeMessage2("{}".getBytes(StandardCharsets.UTF_8), psk, fixedEph);
+
+        System.out.println("{");
+        System.out.println("  \"protocol\": \"Noise_KKpsk2_25519_ChaChaPoly_SHA256\",");
+        System.out.println("  \"prologue_utf8\": \"" + args[4] + "\",");
+        System.out.println("  \"client_static_private\": \"" + toHex(ourStatic) + "\",");
+        System.out.println("  \"client_static_public\": \"" + toHex(r.sPub) + "\",");
+        System.out.println("  \"server_static_public\": \"" + toHex(serverStatic) + "\",");
+        System.out.println("  \"psk\": \"" + toHex(psk) + "\",");
+        System.out.println("  \"client_ephemeral_private\": \"" + toHex(fixedEph) + "\",");
+        System.out.println("  \"message_1\": \"" + toHex(msg1) + "\",");
+        System.out.println("  \"message_1_payload_utf8\": " + jsonString(new String(payload1, StandardCharsets.UTF_8)) + ",");
+        System.out.println("  \"h_after_message_1\": \"" + hAfterM1 + "\",");
+        System.out.println("  \"message_2\": \"" + toHex(msg2) + "\",");
+        System.out.println("  \"message_2_payload_utf8\": \"{}\",");
+        System.out.println("  \"handshake_hash\": \"" + toHex(r.handshakeHash) + "\",");
+        System.out.println("  \"transport_key_recv\": \"" + toHex(r.recvKey) + "\",");
+        System.out.println("  \"transport_key_send\": \"" + toHex(r.sendKey) + "\"");
+        System.out.println("}");
+    }
+
+    private static String jsonString(String s) {
+        return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+
+    public static void main(String[] args) throws Exception {
+        if ("trace".equals(args[0])) {
+            trace(args);
+            return;
+        }
+        if ("vectors".equals(args[0])) {
+            vectors(args);
+            return;
+        }
+        int port = Integer.parseInt(args[0]);
+        byte[] ourStatic = hex(args[1]);
+        byte[] serverStatic = hex(args[2]);
+        byte[] psk = hex(args[3]);
+        byte[] prologue = args[4].getBytes(StandardCharsets.UTF_8);
+
+        try (Socket sock = new Socket("127.0.0.1", port)) {
+            DataInputStream in = new DataInputStream(sock.getInputStream());
+            DataOutputStream out = new DataOutputStream(sock.getOutputStream());
+
+            KKpsk2Responder r = new KKpsk2Responder(ourStatic, serverStatic);
+            r.start(prologue);
+
+            byte[] msg1 = readFrame(in);
+            byte[] payload1 = r.readMessage1(msg1);
+            System.out.println("RESPONDER msg1_payload=" + new String(payload1, StandardCharsets.UTF_8));
+
+            // Sendspin sends the literal two bytes {} as message 2's payload.
+            byte[] msg2 = r.writeMessage2("{}".getBytes(StandardCharsets.UTF_8), psk);
+            writeFrame(out, msg2);
+
+            System.out.println("RESPONDER h=" + toHex(r.handshakeHash));
+
+            // Transport mode: read one message from the initiator.
+            byte[] ct = readFrame(in);
+            byte[] pt = aeadDecrypt(r.recvKey, 0, new byte[0], ct);
+            System.out.println("RESPONDER transport_recv=" + new String(pt, StandardCharsets.UTF_8));
+
+            // And send one back.
+            byte[] reply = aeadEncrypt(r.sendKey, 0, new byte[0],
+                    "hello from responder".getBytes(StandardCharsets.UTF_8));
+            writeFrame(out, reply);
+            System.out.println("RESPONDER done");
+        }
+    }
+}

--- a/ci/conformance/noise/NoiseSpike.java
+++ b/ci/conformance/noise/NoiseSpike.java
@@ -1,0 +1,128 @@
+import com.southernstorm.noise.protocol.CipherState;
+import com.southernstorm.noise.protocol.HandshakeState;
+import com.southernstorm.noise.protocol.Noise;
+
+/**
+ * Spike for audit item 0.1 (issue #189).
+ *
+ * Answers, against org.signal.forks:noise-java:0.1.1:
+ *   Q1 can it construct Noise_KKpsk2_25519_<cipher>_SHA256?
+ *   Q2 does it expose the handshake hash h?
+ *   Q3 can a PSK be supplied AFTER Noise message 1 has been read?
+ *   Q4 are both Sendspin cipher suites constructible?
+ *
+ * Q1 and Q3 together decide audit decision D3. Sendspin needs psk2 (PSK mixed
+ * at the END of message 2) and needs to pick the PSK from the psk_id carried in
+ * message 1, so a library that cannot do both buys us nothing.
+ */
+public class NoiseSpike {
+
+    private static void q(String id, String question) {
+        System.out.println();
+        System.out.println("--- " + id + ": " + question);
+    }
+
+    private static void result(String verdict, String detail) {
+        System.out.println("    " + verdict + "  " + detail);
+    }
+
+    private static void tryProtocol(String name) {
+        try {
+            HandshakeState hs = new HandshakeState(name, HandshakeState.RESPONDER);
+            result("OK    ", name + " constructed (action=" + hs.getAction() + ")");
+            hs.destroy();
+        } catch (Throwable t) {
+            result("FAIL  ", name + " -> " + t.getClass().getName() + ": " + t.getMessage());
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("noise-java spike (org.signal.forks:noise-java:0.1.1)");
+        System.out.println("java " + System.getProperty("java.version"));
+
+        q("Q1", "can KKpsk2 be constructed?");
+        tryProtocol("Noise_KKpsk2_25519_ChaChaPoly_SHA256");
+        tryProtocol("Noise_KKpsk2_25519_AESGCM_SHA256");
+        System.out.println("    (controls below: patterns the library does claim to support)");
+        tryProtocol("Noise_KK_25519_ChaChaPoly_SHA256");
+        tryProtocol("NoisePSK_KK_25519_ChaChaPoly_SHA256");
+
+        q("Q2", "is the handshake hash h exposed, and when?");
+        try {
+            HandshakeState ini = new HandshakeState("Noise_KK_25519_ChaChaPoly_SHA256", HandshakeState.INITIATOR);
+            HandshakeState res = new HandshakeState("Noise_KK_25519_ChaChaPoly_SHA256", HandshakeState.RESPONDER);
+            ini.getLocalKeyPair().generateKeyPair();
+            res.getLocalKeyPair().generateKeyPair();
+            byte[] iniPub = new byte[32];
+            byte[] resPub = new byte[32];
+            ini.getLocalKeyPair().getPublicKey(iniPub, 0);
+            res.getLocalKeyPair().getPublicKey(resPub, 0);
+            ini.getRemotePublicKey().setPublicKey(resPub, 0);
+            res.getRemotePublicKey().setPublicKey(iniPub, 0);
+
+            byte[] prologue = "sendspin-spike-prologue".getBytes("UTF-8");
+            ini.setPrologue(prologue, 0, prologue.length);
+            res.setPrologue(prologue, 0, prologue.length);
+            result("OK    ", "setPrologue(byte[],int,int) accepts an arbitrary prologue");
+
+            ini.start();
+            res.start();
+
+            byte[] buf = new byte[1024];
+            int n = ini.writeMessage(buf, 0, null, 0, 0);
+            byte[] scratch = new byte[1024];
+            res.readMessage(buf, 0, n, scratch, 0);
+            n = res.writeMessage(buf, 0, null, 0, 0);
+            ini.readMessage(buf, 0, n, scratch, 0);
+
+            result("INFO  ", "post-exchange action initiator=" + ini.getAction() + " responder=" + res.getAction());
+            byte[] hi = ini.getHandshakeHash();
+            byte[] hr = res.getHandshakeHash();
+            boolean same = java.util.Arrays.equals(hi, hr);
+            result(same ? "OK    " : "FAIL  ",
+                    "getHandshakeHash() len=" + (hi == null ? "null" : hi.length)
+                            + " matches-on-both-sides=" + same);
+            CipherState[] pair = { ini.split().getSender(), res.split().getReceiver() };
+            result("OK    ", "split() produced cipher states (" + pair.length + ")");
+        } catch (Throwable t) {
+            result("FAIL  ", t.getClass().getName() + ": " + t.getMessage());
+        }
+
+        q("Q3", "can a PSK be supplied AFTER message 1 is read? (psk_id selection needs this)");
+        try {
+            HandshakeState res = new HandshakeState("NoisePSK_KK_25519_ChaChaPoly_SHA256", HandshakeState.RESPONDER);
+            byte[] psk = new byte[32];
+            res.setPreSharedKey(psk, 0, psk.length);
+            result("INFO  ", "setPreSharedKey BEFORE start() accepted");
+            res.getLocalKeyPair().generateKeyPair();
+            byte[] pub = new byte[32];
+            res.getLocalKeyPair().getPublicKey(pub, 0);
+            res.getRemotePublicKey().setPublicKey(pub, 0);
+            res.start();
+            try {
+                res.setPreSharedKey(psk, 0, psk.length);
+                result("OK    ", "setPreSharedKey AFTER start() accepted - late injection possible");
+            } catch (Throwable t) {
+                result("FAIL  ", "setPreSharedKey AFTER start() -> "
+                        + t.getClass().getName() + ": " + t.getMessage());
+            }
+        } catch (Throwable t) {
+            result("FAIL  ", "setup: " + t.getClass().getName() + ": " + t.getMessage());
+        }
+
+        q("Q4", "are both Sendspin cipher suites available?");
+        for (String cipher : new String[] { "ChaChaPoly", "AESGCM" }) {
+            try {
+                CipherState cs = Noise.createCipher(cipher);
+                result("OK    ", cipher + " -> " + cs.getClass().getSimpleName());
+                cs.destroy();
+            } catch (Throwable t) {
+                result("FAIL  ", cipher + " -> " + t.getClass().getName() + ": " + t.getMessage());
+            }
+        }
+
+        System.out.println();
+        System.out.println("--- DECISION (audit D3) ---");
+        System.out.println("Adopt the library only if Q1 constructs KKpsk2 AND Q3 allows late PSK injection.");
+    }
+}

--- a/ci/conformance/noise/README.md
+++ b/ci/conformance/noise/README.md
@@ -1,0 +1,121 @@
+# Noise KKpsk2 spike and reference prototype
+
+Deliverables for audit item 0.1 (issue #189). Two things live here:
+
+1. **The spike result** that settles audit decision D3 (`NoiseSpike.java`).
+2. **A working, reference-validated `KKpsk2` responder** (`KKpsk2Responder.java`)
+   plus golden vectors (`vectors.json`), so item 1.2 (issue #193) is a port
+   rather than a design task.
+
+## Result: hand-roll, do not adopt noise-java
+
+`org.signal.forks:noise-java:0.1.1` fails the two questions that matter. Run
+`NoiseSpike.java` to reproduce:
+
+| Question | Result |
+|---|---|
+| Q1 construct `Noise_KKpsk2_25519_ChaChaPoly_SHA256` | **FAIL** - `IllegalArgumentException: Handshake pattern is not recognized` (same for the AESGCM suite) |
+| Q1 control: `Noise_KK_25519_ChaChaPoly_SHA256` | OK - so the failure is the `psk2` modifier specifically, not the harness |
+| Q2 expose the handshake hash `h` | OK - `getHandshakeHash()` returns 32 bytes, equal on both sides; `setPrologue` accepts an arbitrary prologue |
+| Q3 supply the PSK *after* Noise message 1 | **FAIL** - `IllegalStateException: Handshake has already started; cannot set pre-shared key` |
+| Q4 both Sendspin cipher suites | OK - `ChaChaPolyCipherState`, `AESGCMOnCtrCipherState` |
+
+Q1 and Q3 are both load-bearing. Sendspin needs `psk2` (the PSK is mixed at the
+end of message 2) *and* needs to read `psk_id` from message 1 before choosing
+which PSK to mix - see `connection.md#pre-shared-key`. A library that demands the
+PSK up front cannot express that. No other JVM Noise artifact on Maven Central
+implements `psk` modifiers.
+
+**Decision: hand-roll the state machine on BouncyCastle.** The primitive surface
+is small: X25519, SHA-256, HMAC-SHA256, ChaCha20-Poly1305, AES-GCM.
+
+## The prototype
+
+`KKpsk2Responder.java` is a complete, working responder validated against
+`noiseprotocol` - the same library `aiosendspin` 9.1.0 depends on, so agreement
+here means agreement with what Music Assistant actually runs.
+
+```
+KKpsk2:
+  -> s
+  <- s
+  ...
+  -> e, es, ss
+  <- e, ee, se, psk
+```
+
+In Sendspin the **server is the Noise initiator** and the **client is the
+responder**, regardless of who opened the WebSocket. This class is the client
+side.
+
+### Two details that cost real debugging time
+
+**The `e` token also calls `MixKey` in PSK handshakes.** In a plain pattern `e`
+only does `MixHash(e.public_key)`. Under any `psk` modifier it does
+`MixHash` *and* `MixKey` on the same public key. Omitting it diverges the
+symmetric state at the very first token, and the only symptom is an AEAD tag
+failure several steps later. Both `e` sites in the prototype carry a comment.
+
+**Noise's HKDF is not RFC 5869 applied naively.** Each output is an HMAC over the
+previous output concatenated with a counter byte, and `MixKey` takes two outputs
+while `MixKeyAndHash` takes three. Reaching for a generic HKDF helper produces a
+handshake that passes self-tests and fails against a real peer.
+
+## Reproducing
+
+Needs `JAVA_HOME` set and a Python env with `noiseprotocol` and `cryptography`
+(both come with `pip install 'aiosendspin[server]==9.1.0'`).
+
+```bash
+cd ci/conformance/noise
+curl -sL -o noise-java.jar https://repo1.maven.org/maven2/org/signal/forks/noise-java/0.1.1/noise-java-0.1.1.jar
+curl -sL -o bcprov.jar     https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.80/bcprov-jdk18on-1.80.jar
+
+# The library spike (Q1-Q4)
+"$JAVA_HOME/bin/javac" -cp noise-java.jar -d . NoiseSpike.java
+"$JAVA_HOME/bin/java"  -cp "noise-java.jar;." NoiseSpike
+
+# The prototype: live interop over loopback TCP
+"$JAVA_HOME/bin/javac" -cp bcprov.jar -d . KKpsk2Responder.java
+python peer.py
+
+# Regenerate and re-validate the golden vectors
+python make_vectors.py
+```
+
+`peer.py` asserts both sides derive the same handshake hash and that transport
+messages round-trip in both directions. `make_vectors.py` pins both ephemerals,
+drives the exchange through the reference implementation, and only writes
+`vectors.json` if every field round-trips.
+
+## vectors.json
+
+Deterministic vectors for the Kotlin port's tests (issue #193). Every value has
+been round-tripped through `noiseprotocol`, not merely produced by this
+prototype. Fields are hex unless named `_utf8`.
+
+The Kotlin `NoiseSession` tests should assert at minimum:
+
+- `message_1` decrypts to `message_1_payload_utf8` **without the PSK mixed in**
+  (that is the whole point of `psk2`, and it is what lets `psk_id` selection work)
+- `h_after_message_1` matches after reading message 1
+- writing message 2 with `client_ephemeral_private` pinned reproduces `message_2`
+  byte for byte
+- `handshake_hash` matches after the handshake completes
+- the transport keys are not swapped - `transport_probe_ciphertext` must decrypt
+  under `transport_key_recv` to `transport_probe_plaintext_utf8`
+
+A negative test is worth adding too: substituting a different prologue must make
+message 1 fail to decrypt. Prologue handling is the highest-risk part of #193.
+
+## Not covered here
+
+- The AESGCM suite is constructible but the prototype only implements
+  ChaChaPoly. #193 must add it and generate a second vector set.
+- No Android device run. R8 can strip BouncyCastle classes reached only
+  reflectively; the prototype uses the low-level `org.bouncycastle.crypto.*` API
+  precisely to avoid JCA provider registration, which conflicts with Android's
+  repackaged `com.android.org.bouncycastle`. Verify APK size and a release build
+  in #193.
+- `noise-java.jar` and `bcprov.jar` are deliberately not committed; the commands
+  above fetch them.

--- a/ci/conformance/noise/README.md
+++ b/ci/conformance/noise/README.md
@@ -48,18 +48,29 @@ In Sendspin the **server is the Noise initiator** and the **client is the
 responder**, regardless of who opened the WebSocket. This class is the client
 side.
 
-### Two details that cost real debugging time
+### The detail that cost real debugging time
 
 **The `e` token also calls `MixKey` in PSK handshakes.** In a plain pattern `e`
 only does `MixHash(e.public_key)`. Under any `psk` modifier it does
-`MixHash` *and* `MixKey` on the same public key. Omitting it diverges the
-symmetric state at the very first token, and the only symptom is an AEAD tag
-failure several steps later. Both `e` sites in the prototype carry a comment.
+`MixHash` *and* `MixKey` on the same public key (Noise spec section 9.2).
+Omitting it diverges the symmetric state at the very first token, and the only
+symptom is an AEAD tag failure several steps later. That is exactly how it
+presented here. Both `e` sites in the prototype carry a comment.
 
-**Noise's HKDF is not RFC 5869 applied naively.** Each output is an HMAC over the
-previous output concatenated with a counter byte, and `MixKey` takes two outputs
-while `MixKeyAndHash` takes three. Reaching for a generic HKDF helper produces a
-handshake that passes self-tests and fails against a real peer.
+### On HKDF: use a library one
+
+An earlier version of this README claimed Noise's HKDF "is not RFC 5869" and
+warned against library helpers. **That was wrong.** Noise spec section 4.3 says
+the opposite in as many words: "the HKDF() function is simply HKDF from
+[RFC 5869] with the chaining_key as HKDF salt, and zero-length HKDF info."
+Verified empirically -- RFC 5869 HKDF-SHA256 with `salt=ck`, `info=b""`,
+`length=32*n` is byte-identical to the expanded form in this prototype, for both
+`n=2` and `n=3`.
+
+The prototype expands it inline only to avoid a dependency beyond BouncyCastle.
+**The Kotlin port should use a library HKDF.** The real trap is parameter
+misuse, not the construction: the chaining key is the **salt** (not the IKM),
+`info` must be **empty**, and you need `32*n` bytes split into `n` outputs.
 
 ## Reproducing
 
@@ -71,22 +82,30 @@ cd ci/conformance/noise
 curl -sL -o noise-java.jar https://repo1.maven.org/maven2/org/signal/forks/noise-java/0.1.1/noise-java-0.1.1.jar
 curl -sL -o bcprov.jar     https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.80/bcprov-jdk18on-1.80.jar
 
-# The library spike (Q1-Q4)
+# The library spike (Q1-Q4). Classpath separator is ';' on Windows, ':' elsewhere.
 "$JAVA_HOME/bin/javac" -cp noise-java.jar -d . NoiseSpike.java
-"$JAVA_HOME/bin/java"  -cp "noise-java.jar;." NoiseSpike
+"$JAVA_HOME/bin/java"  -cp "noise-java.jar;." NoiseSpike     # Windows
+"$JAVA_HOME/bin/java"  -cp "noise-java.jar:." NoiseSpike     # macOS / Linux
 
 # The prototype: live interop over loopback TCP
 "$JAVA_HOME/bin/javac" -cp bcprov.jar -d . KKpsk2Responder.java
 python peer.py
 
-# Regenerate and re-validate the golden vectors
+# Regenerate the golden vectors in place, or verify they are current
 python make_vectors.py
+python make_vectors.py --check
 ```
 
-`peer.py` asserts both sides derive the same handshake hash and that transport
-messages round-trip in both directions. `make_vectors.py` pins both ephemerals,
-drives the exchange through the reference implementation, and only writes
-`vectors.json` if every field round-trips.
+The two Python drivers build their own classpath with `os.pathsep`, so they work
+on any platform; only the hand-typed `java` commands above need the right
+separator.
+
+`peer.py` asserts both sides derive the same handshake hash and exchanges **two**
+transport frames per direction. `make_vectors.py` pins both ephemerals, drives
+the exchange through the reference implementation, and writes `vectors.json`
+**in this directory** only if every field round-trips. `--check` fails if the
+committed file is stale, so drift between the code and the vectors is detectable
+rather than silent.
 
 ## vectors.json
 
@@ -102,11 +121,26 @@ The Kotlin `NoiseSession` tests should assert at minimum:
 - writing message 2 with `client_ephemeral_private` pinned reproduces `message_2`
   byte for byte
 - `handshake_hash` matches after the handshake completes
-- the transport keys are not swapped - `transport_probe_ciphertext` must decrypt
-  under `transport_key_recv` to `transport_probe_plaintext_utf8`
+- **transport, both directions, both nonces.** `transport_probe_i2r[i]` must
+  decrypt under `transport_key_recv` at nonce `i` to
+  `transport_probe_i2r_plaintext_utf8[i]`, and encrypting
+  `transport_probe_r2i_plaintext_utf8[i]` under `transport_key_send` at nonce `i`
+  must reproduce `transport_probe_r2i[i]`, for `i` in 0 and 1.
 
-A negative test is worth adding too: substituting a different prologue must make
-message 1 fail to decrypt. Prologue handling is the highest-risk part of #193.
+That last one is deliberately over-specified. Nonce 0 encodes as twelve zero
+bytes under **any** endianness or offset, so a port with a big-endian counter, a
+wrong offset, or a per-message nonce reset passes every `i=0` check and then
+fails against a real server on the second frame. And because the handshake hash
+does not depend on `Split()` direction, a port that swapped the two keys would
+agree on `handshake_hash` and still be broken. The `i=1` probes and the
+two-direction probes exist specifically to catch those.
+
+Two negative tests are worth adding:
+
+- substituting a different prologue must make message 1 fail to decrypt
+  (prologue handling is the highest-risk part of #193)
+- a message 1 shorter than 48 bytes must be rejected with a clear "truncated"
+  error, not a zero-padded key and a misleading AEAD failure
 
 ## Not covered here
 

--- a/ci/conformance/noise/make_vectors.py
+++ b/ci/conformance/noise/make_vectors.py
@@ -3,10 +3,16 @@
 Both ephemerals are pinned so the whole exchange is reproducible:
   1. noiseprotocol (the reference, as initiator/server) produces message 1.
   2. The hand-rolled responder consumes it and produces message 2.
-  3. noiseprotocol reads message 2 and both sides' handshake hashes are compared.
+  3. noiseprotocol reads message 2, and every field the responder emitted is
+     checked against the reference before anything is written.
 
-Everything written to out/vectors.json has therefore been round-tripped through
-the reference implementation, not just produced by our own code.
+The transport keys get particular attention. The handshake hash does NOT depend
+on split() direction, so an implementation that swapped recvKey/sendKey would
+still agree on `h`. Both directions are therefore probed explicitly, at nonce 0
+AND nonce 1 - nonce 0 encodes as twelve zero bytes under any endianness or
+offset, so a counter bug is invisible until the second message.
+
+Writes ci/conformance/noise/vectors.json only if every check passes.
 """
 
 import json
@@ -15,6 +21,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 from noise.connection import Keypair, NoiseConnection
 
 HERE = Path(__file__).parent
@@ -36,6 +43,11 @@ def x25519_pub(private: bytes) -> bytes:
         Encoding.Raw, PublicFormat.Raw)
 
 
+def noise_nonce(counter: int) -> bytes:
+    """ChaChaPoly nonce: 4 zero bytes then the counter, 64-bit little-endian."""
+    return b"\x00" * 4 + counter.to_bytes(8, "little")
+
+
 def new_initiator() -> NoiseConnection:
     n = NoiseConnection.from_name(PROTO)
     n.set_as_initiator()
@@ -53,10 +65,11 @@ def main() -> int:
     ini = new_initiator()
     msg1 = ini.write_message(MSG1_PAYLOAD)
 
-    # Step 2: our responder consumes it and emits vectors.
+    # Step 2: our responder consumes it and emits candidate vectors.
     java = str(Path(os.environ["JAVA_HOME"]) / "bin" / "java")
+    classpath = os.pathsep.join(["bcprov.jar", "."])
     proc = subprocess.run(
-        [java, "-cp", "bcprov.jar;.", "KKpsk2Responder", "vectors",
+        [java, "-cp", classpath, "KKpsk2Responder", "vectors",
          CLIENT_STATIC.hex(), x25519_pub(SERVER_STATIC).hex(), PSK.hex(),
          PROLOGUE.decode(), msg1.hex(), CLIENT_EPHEMERAL.hex()],
         cwd=HERE, capture_output=True, text=True,
@@ -64,11 +77,17 @@ def main() -> int:
     if proc.returncode != 0:
         print("responder failed:\n" + proc.stdout + proc.stderr)
         return 1
-    vectors = json.loads(proc.stdout)
+    try:
+        vectors = json.loads(proc.stdout)
+    except json.JSONDecodeError as err:
+        print(f"responder did not emit JSON ({err}); stdout was:\n{proc.stdout!r}")
+        return 1
 
-    # Step 3: reference reads message 2 and the hashes must agree.
+    checks: list[tuple[str, object, object]] = []
+
+    # Step 3: reference reads message 2 and the handshake must agree.
     payload2 = ini.read_message(bytes.fromhex(vectors["message_2"]))
-    checks = [
+    checks += [
         ("message_2 payload is the literal two bytes {}", payload2, b"{}"),
         ("handshake finished", ini.handshake_finished, True),
         ("handshake hash agrees", ini.get_handshake_hash().hex(), vectors["handshake_hash"]),
@@ -76,6 +95,37 @@ def main() -> int:
         ("message_1 payload decrypted correctly",
          vectors["message_1_payload_utf8"].encode(), MSG1_PAYLOAD),
     ]
+
+    # Step 4: prove the transport keys, in BOTH directions and at TWO nonces.
+    # Without this, swapping recvKey/sendKey in the responder still produces an
+    # agreeing handshake hash and these vectors would ship the wrong keys as
+    # ground truth for the Kotlin port.
+    recv_key = bytes.fromhex(vectors["transport_key_recv"])
+    send_key = bytes.fromhex(vectors["transport_key_send"])
+
+    # initiator -> responder: the reference encrypts, recv_key must decrypt.
+    probes_i2r = [ini.encrypt(b"probe-0"), ini.encrypt(b"probe-1")]
+    for i, ct in enumerate(probes_i2r):
+        try:
+            got = ChaCha20Poly1305(recv_key).decrypt(noise_nonce(i), ct, b"")
+        except Exception as err:
+            got = f"DECRYPT FAILED: {err}"
+        checks.append((f"transport_key_recv decrypts initiator frame n={i}",
+                       got, f"probe-{i}".encode()))
+
+    # responder -> initiator: send_key encrypts, the reference must decrypt.
+    probes_r2i = [
+        ChaCha20Poly1305(send_key).encrypt(noise_nonce(i), f"reply-{i}".encode(), b"")
+        for i in range(2)
+    ]
+    for i, ct in enumerate(probes_r2i):
+        try:
+            got = ini.decrypt(ct)
+        except Exception as err:
+            got = f"DECRYPT FAILED: {err}"
+        checks.append((f"reference decrypts responder frame n={i} under transport_key_send",
+                       got, f"reply-{i}".encode()))
+
     failed = 0
     for label, got, want in checks:
         ok = got == want
@@ -84,24 +134,31 @@ def main() -> int:
             failed += 1
             print(f"     got  {got!r}\n     want {want!r}")
 
-    # Transport direction: what the initiator encrypts, the responder must decrypt
-    # with its recv key. Confirms split() outputs are not swapped.
-    ct = ini.encrypt(b"probe")
-    vectors["transport_probe_ciphertext"] = ct.hex()
-    vectors["transport_probe_plaintext_utf8"] = "probe"
-    vectors["_generated_by"] = (
-        "ci/conformance/noise/make_vectors.py - validated against noiseprotocol "
-        "(the library aiosendspin 9.1.0 depends on)"
-    )
-    vectors["server_ephemeral_private"] = SERVER_EPHEMERAL.hex()
-
     if failed:
         print(f"\n{failed} CHECK(S) FAILED - vectors NOT written")
         return 1
 
-    out = HERE / "out" / "vectors.json"
-    out.parent.mkdir(exist_ok=True)
-    out.write_text(json.dumps(vectors, indent=2) + "\n", encoding="utf-8")
+    vectors["server_ephemeral_private"] = SERVER_EPHEMERAL.hex()
+    vectors["transport_probe_i2r"] = [ct.hex() for ct in probes_i2r]
+    vectors["transport_probe_i2r_plaintext_utf8"] = ["probe-0", "probe-1"]
+    vectors["transport_probe_r2i"] = [ct.hex() for ct in probes_r2i]
+    vectors["transport_probe_r2i_plaintext_utf8"] = ["reply-0", "reply-1"]
+    vectors["_generated_by"] = (
+        "ci/conformance/noise/make_vectors.py - every field round-tripped through "
+        "noiseprotocol (the library aiosendspin 9.1.0 depends on)"
+    )
+
+    out = HERE / "vectors.json"
+    new = json.dumps(vectors, indent=2) + "\n"
+    if "--check" in sys.argv:
+        current = out.read_text(encoding="utf-8") if out.exists() else ""
+        if current != new:
+            print(f"\nFAIL {out.name} is stale - regenerate it (run without --check)")
+            return 1
+        print(f"\n{out.name} is up to date")
+        return 0
+
+    out.write_text(new, encoding="utf-8")
     print(f"\nALL CHECKS PASSED - vectors written to {out}")
     return 0
 

--- a/ci/conformance/noise/make_vectors.py
+++ b/ci/conformance/noise/make_vectors.py
@@ -1,0 +1,110 @@
+"""Generate and validate KKpsk2 golden vectors end to end.
+
+Both ephemerals are pinned so the whole exchange is reproducible:
+  1. noiseprotocol (the reference, as initiator/server) produces message 1.
+  2. The hand-rolled responder consumes it and produces message 2.
+  3. noiseprotocol reads message 2 and both sides' handshake hashes are compared.
+
+Everything written to out/vectors.json has therefore been round-tripped through
+the reference implementation, not just produced by our own code.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from noise.connection import Keypair, NoiseConnection
+
+HERE = Path(__file__).parent
+PROTO = b"Noise_KKpsk2_25519_ChaChaPoly_SHA256"
+PROLOGUE = b"sendspin-spike-prologue-v1"
+
+SERVER_STATIC = bytes(range(0x20, 0x40))
+SERVER_EPHEMERAL = bytes(range(0x80, 0xA0))
+CLIENT_STATIC = bytes(range(0x60, 0x80))
+CLIENT_EPHEMERAL = bytes(range(0xC0, 0xE0))
+PSK = bytes(range(0xA0, 0xC0))
+MSG1_PAYLOAD = json.dumps({"psk_id": "spike-psk-id-placeholder"}).encode()
+
+
+def x25519_pub(private: bytes) -> bytes:
+    from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    return X25519PrivateKey.from_private_bytes(private).public_key().public_bytes(
+        Encoding.Raw, PublicFormat.Raw)
+
+
+def new_initiator() -> NoiseConnection:
+    n = NoiseConnection.from_name(PROTO)
+    n.set_as_initiator()
+    n.set_prologue(PROLOGUE)
+    n.set_keypair_from_private_bytes(Keypair.STATIC, SERVER_STATIC)
+    n.set_keypair_from_private_bytes(Keypair.EPHEMERAL, SERVER_EPHEMERAL)
+    n.set_keypair_from_public_bytes(Keypair.REMOTE_STATIC, x25519_pub(CLIENT_STATIC))
+    n.set_psks(PSK)
+    n.start_handshake()
+    return n
+
+
+def main() -> int:
+    # Step 1: reference produces message 1.
+    ini = new_initiator()
+    msg1 = ini.write_message(MSG1_PAYLOAD)
+
+    # Step 2: our responder consumes it and emits vectors.
+    java = str(Path(os.environ["JAVA_HOME"]) / "bin" / "java")
+    proc = subprocess.run(
+        [java, "-cp", "bcprov.jar;.", "KKpsk2Responder", "vectors",
+         CLIENT_STATIC.hex(), x25519_pub(SERVER_STATIC).hex(), PSK.hex(),
+         PROLOGUE.decode(), msg1.hex(), CLIENT_EPHEMERAL.hex()],
+        cwd=HERE, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        print("responder failed:\n" + proc.stdout + proc.stderr)
+        return 1
+    vectors = json.loads(proc.stdout)
+
+    # Step 3: reference reads message 2 and the hashes must agree.
+    payload2 = ini.read_message(bytes.fromhex(vectors["message_2"]))
+    checks = [
+        ("message_2 payload is the literal two bytes {}", payload2, b"{}"),
+        ("handshake finished", ini.handshake_finished, True),
+        ("handshake hash agrees", ini.get_handshake_hash().hex(), vectors["handshake_hash"]),
+        ("message_1 recorded matches what the reference sent", vectors["message_1"], msg1.hex()),
+        ("message_1 payload decrypted correctly",
+         vectors["message_1_payload_utf8"].encode(), MSG1_PAYLOAD),
+    ]
+    failed = 0
+    for label, got, want in checks:
+        ok = got == want
+        print(("PASS " if ok else "FAIL ") + label)
+        if not ok:
+            failed += 1
+            print(f"     got  {got!r}\n     want {want!r}")
+
+    # Transport direction: what the initiator encrypts, the responder must decrypt
+    # with its recv key. Confirms split() outputs are not swapped.
+    ct = ini.encrypt(b"probe")
+    vectors["transport_probe_ciphertext"] = ct.hex()
+    vectors["transport_probe_plaintext_utf8"] = "probe"
+    vectors["_generated_by"] = (
+        "ci/conformance/noise/make_vectors.py - validated against noiseprotocol "
+        "(the library aiosendspin 9.1.0 depends on)"
+    )
+    vectors["server_ephemeral_private"] = SERVER_EPHEMERAL.hex()
+
+    if failed:
+        print(f"\n{failed} CHECK(S) FAILED - vectors NOT written")
+        return 1
+
+    out = HERE / "out" / "vectors.json"
+    out.parent.mkdir(exist_ok=True)
+    out.write_text(json.dumps(vectors, indent=2) + "\n", encoding="utf-8")
+    print(f"\nALL CHECKS PASSED - vectors written to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/conformance/noise/peer.py
+++ b/ci/conformance/noise/peer.py
@@ -1,0 +1,141 @@
+"""KKpsk2 initiator peer for the issue #189 interop test.
+
+Uses `noiseprotocol`, the same library aiosendspin 9.1.0 depends on, so a pass
+here means the hand-rolled Java/Kotlin responder agrees with the implementation
+Music Assistant actually runs.
+
+In Sendspin the server is the Noise initiator, so this script plays the server.
+"""
+
+import json
+import os
+import socket
+import struct
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+from noise.connection import Keypair, NoiseConnection
+
+HERE = Path(__file__).parent
+PROLOGUE = b"sendspin-spike-prologue-v1"
+PROTO = b"Noise_KKpsk2_25519_ChaChaPoly_SHA256"
+
+# Fixed keys so a failure is reproducible.
+SERVER_STATIC = bytes(range(0x20, 0x40))
+CLIENT_STATIC = bytes(range(0x60, 0x80))
+PSK = bytes(range(0xA0, 0xC0))
+
+
+def x25519_pub(private: bytes) -> bytes:
+    from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+
+    return X25519PrivateKey.from_private_bytes(private).public_key().public_bytes(
+        Encoding.Raw, PublicFormat.Raw
+    )
+
+
+def send_frame(conn: socket.socket, data: bytes) -> None:
+    conn.sendall(struct.pack(">H", len(data)) + data)
+
+
+def recv_frame(conn: socket.socket) -> bytes:
+    header = conn.recv(2)
+    if len(header) < 2:
+        raise EOFError("peer closed")
+    (length,) = struct.unpack(">H", header)
+    buf = b""
+    while len(buf) < length:
+        chunk = conn.recv(length - len(buf))
+        if not chunk:
+            raise EOFError("peer closed mid-frame")
+        buf += chunk
+    return buf
+
+
+def main() -> int:
+    server_pub = x25519_pub(SERVER_STATIC)
+    client_pub = x25519_pub(CLIENT_STATIC)
+
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+
+    java_home = os.environ["JAVA_HOME"]
+    cmd = [
+        str(Path(java_home) / "bin" / "java"),
+        "-cp", "bcprov.jar;.",
+        "KKpsk2Responder",
+        str(port),
+        CLIENT_STATIC.hex(),
+        server_pub.hex(),
+        PSK.hex(),
+        PROLOGUE.decode(),
+    ]
+    proc = subprocess.Popen(cmd, cwd=HERE, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, text=True)
+
+    out_lines: list[str] = []
+
+    def drain() -> None:
+        for line in proc.stdout:
+            out_lines.append(line.rstrip())
+            print("  [java]", line.rstrip())
+
+    threading.Thread(target=drain, daemon=True).start()
+
+    conn, _ = listener.accept()
+    try:
+        noise = NoiseConnection.from_name(PROTO)
+        noise.set_as_initiator()
+        noise.set_prologue(PROLOGUE)
+        noise.set_keypair_from_private_bytes(Keypair.STATIC, SERVER_STATIC)
+        noise.set_keypair_from_public_bytes(Keypair.REMOTE_STATIC, client_pub)
+        noise.set_psks(PSK)
+        noise.start_handshake()
+
+        # Message 1 carries psk_id, exactly as Sendspin does.
+        payload1 = json.dumps({"psk_id": "spike-psk-id-placeholder"}).encode()
+        send_frame(conn, noise.write_message(payload1))
+
+        payload2 = noise.read_message(recv_frame(conn))
+        assert payload2 == b"{}", f"expected the literal two bytes {{}}, got {payload2!r}"
+        assert noise.handshake_finished, "handshake did not complete"
+
+        py_h = noise.get_handshake_hash()
+        print(f"  [py]   h={py_h.hex()}")
+
+        send_frame(conn, noise.encrypt(b"hello from initiator"))
+        reply = noise.decrypt(recv_frame(conn))
+        print(f"  [py]   transport_recv={reply.decode()}")
+    finally:
+        conn.close()
+        listener.close()
+        proc.wait(timeout=15)
+
+    java_h = next((l.split("h=", 1)[1] for l in out_lines if "RESPONDER h=" in l), None)
+    if java_h is None:
+        print("\nFAIL: responder never printed a handshake hash")
+        return 1
+    if java_h != py_h.hex():
+        print(f"\nFAIL: handshake hash mismatch\n  java={java_h}\n  py  ={py_h.hex()}")
+        return 1
+    if reply != b"hello from responder":
+        print(f"\nFAIL: transport payload mismatch: {reply!r}")
+        return 1
+
+    print("\nPASS: KKpsk2 interop against noiseprotocol")
+    print(f"  shared handshake hash h = {java_h}")
+    print("  transport messages round-tripped in both directions")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/conformance/noise/peer.py
+++ b/ci/conformance/noise/peer.py
@@ -5,6 +5,10 @@ here means the hand-rolled Java/Kotlin responder agrees with the implementation
 Music Assistant actually runs.
 
 In Sendspin the server is the Noise initiator, so this script plays the server.
+
+Two transport messages are exchanged per direction, not one: nonce 0 encodes as
+twelve zero bytes under any endianness or offset, so a counter bug only becomes
+visible on the second frame.
 """
 
 import json
@@ -21,6 +25,7 @@ from noise.connection import Keypair, NoiseConnection
 HERE = Path(__file__).parent
 PROLOGUE = b"sendspin-spike-prologue-v1"
 PROTO = b"Noise_KKpsk2_25519_ChaChaPoly_SHA256"
+ACCEPT_TIMEOUT_S = 15
 
 # Fixed keys so a failure is reproducible.
 SERVER_STATIC = bytes(range(0x20, 0x40))
@@ -66,12 +71,13 @@ def main() -> int:
     listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     listener.bind(("127.0.0.1", 0))
     listener.listen(1)
+    listener.settimeout(ACCEPT_TIMEOUT_S)
     port = listener.getsockname()[1]
 
     java_home = os.environ["JAVA_HOME"]
     cmd = [
         str(Path(java_home) / "bin" / "java"),
-        "-cp", "bcprov.jar;.",
+        "-cp", os.pathsep.join(["bcprov.jar", "."]),
         "KKpsk2Responder",
         str(port),
         CLIENT_STATIC.hex(),
@@ -89,10 +95,24 @@ def main() -> int:
             out_lines.append(line.rstrip())
             print("  [java]", line.rstrip())
 
-    threading.Thread(target=drain, daemon=True).start()
+    drain_thread = threading.Thread(target=drain)
+    drain_thread.start()
 
-    conn, _ = listener.accept()
+    conn = None
+    reply = None
     try:
+        try:
+            conn, _ = listener.accept()
+        except socket.timeout:
+            # Most often: the class was never compiled, bcprov.jar is missing,
+            # or the classpath separator is wrong for this platform. Without
+            # this timeout the script would block here forever.
+            proc.terminate()
+            drain_thread.join(timeout=5)
+            print(f"\nFAIL: responder did not connect within {ACCEPT_TIMEOUT_S}s "
+                  f"(exit code {proc.poll()}). Its output above is the reason.")
+            return 1
+
         noise = NoiseConnection.from_name(PROTO)
         noise.set_as_initiator()
         noise.set_prologue(PROLOGUE)
@@ -106,19 +126,36 @@ def main() -> int:
         send_frame(conn, noise.write_message(payload1))
 
         payload2 = noise.read_message(recv_frame(conn))
-        assert payload2 == b"{}", f"expected the literal two bytes {{}}, got {payload2!r}"
-        assert noise.handshake_finished, "handshake did not complete"
+        if payload2 != b"{}":
+            print(f"\nFAIL: expected the literal two bytes {{}}, got {payload2!r}")
+            return 1
+        if not noise.handshake_finished:
+            print("\nFAIL: handshake did not complete")
+            return 1
 
         py_h = noise.get_handshake_hash()
         print(f"  [py]   h={py_h.hex()}")
 
-        send_frame(conn, noise.encrypt(b"hello from initiator"))
-        reply = noise.decrypt(recv_frame(conn))
-        print(f"  [py]   transport_recv={reply.decode()}")
+        # Two frames per direction so a nonce-counter bug cannot hide at n=0.
+        for i in range(2):
+            send_frame(conn, noise.encrypt(f"hello-{i} from initiator".encode()))
+        replies = [noise.decrypt(recv_frame(conn)) for _ in range(2)]
+        for i, r in enumerate(replies):
+            print(f"  [py]   transport_recv[{i}]={r.decode()}")
+        reply = replies
     finally:
-        conn.close()
+        if conn is not None:
+            conn.close()
         listener.close()
-        proc.wait(timeout=15)
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            # Do not let a wedged JVM mask the real failure, and do not orphan it.
+            proc.kill()
+            proc.wait()
+        # The drain thread may still hold buffered output; join before reading
+        # out_lines or the verdict can be computed from an incomplete list.
+        drain_thread.join(timeout=5)
 
     java_h = next((l.split("h=", 1)[1] for l in out_lines if "RESPONDER h=" in l), None)
     if java_h is None:
@@ -127,13 +164,14 @@ def main() -> int:
     if java_h != py_h.hex():
         print(f"\nFAIL: handshake hash mismatch\n  java={java_h}\n  py  ={py_h.hex()}")
         return 1
-    if reply != b"hello from responder":
-        print(f"\nFAIL: transport payload mismatch: {reply!r}")
+    expected = [f"reply-{i} from responder".encode() for i in range(2)]
+    if reply != expected:
+        print(f"\nFAIL: transport payload mismatch\n  got  {reply}\n  want {expected}")
         return 1
 
     print("\nPASS: KKpsk2 interop against noiseprotocol")
     print(f"  shared handshake hash h = {java_h}")
-    print("  transport messages round-tripped in both directions")
+    print("  two transport frames round-tripped in both directions (nonce 0 and 1)")
     return 0
 
 

--- a/ci/conformance/noise/vectors.json
+++ b/ci/conformance/noise/vectors.json
@@ -1,0 +1,21 @@
+{
+  "protocol": "Noise_KKpsk2_25519_ChaChaPoly_SHA256",
+  "prologue_utf8": "sendspin-spike-prologue-v1",
+  "client_static_private": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+  "client_static_public": "675dd574ed7789310b3d2e7681f3790b466c773b1521fecf36577958371ea52f",
+  "server_static_public": "358072d6365880d1aeea329adf9121383851ed21a28e3b75e965d0d2cd166254",
+  "psk": "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf",
+  "client_ephemeral_private": "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
+  "message_1": "493e82fc74464a59268817623d2053c5eb8e2cc4a988b4fee179ec6b010d531dcdf8933800968c0ab0d21481f61c2ea53bd68371179d1956acc40d7b281a98cba4cf963ced3b80d387e249a9511fb61e45502d52cf09",
+  "message_1_payload_utf8": "{\"psk_id\": \"spike-psk-id-placeholder\"}",
+  "h_after_message_1": "c5d8ec6e3cbb8c2ef69b99e44c058264f50050e26932e0ba46575a412ca8a81d",
+  "message_2": "dc2cca31e8e43bbd91dff7e475cca3347eb478107d5bd765aba4ae4a30c35d44a0ae1d03ad24d7313cff292d69d2059b72bf",
+  "message_2_payload_utf8": "{}",
+  "handshake_hash": "fac6e4f921f36dc0c1c263f0eac2f396abeb15794516cc7f178218bf22eaa3b5",
+  "transport_key_recv": "30f64bb8c9054b6bfdfb710b4fcd024ec00a371ca91db99c8fc00bd31f5181e8",
+  "transport_key_send": "b3a7f911b85c3b284f96804e584d9838f7bf4308e2ad1094dace15582f81b5ed",
+  "transport_probe_ciphertext": "f9f69dab9f333a45fce04e08417eb81ab282db6f32",
+  "transport_probe_plaintext_utf8": "probe",
+  "_generated_by": "ci/conformance/noise/make_vectors.py - validated against noiseprotocol (the library aiosendspin 9.1.0 depends on)",
+  "server_ephemeral_private": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+}

--- a/ci/conformance/noise/vectors.json
+++ b/ci/conformance/noise/vectors.json
@@ -14,8 +14,22 @@
   "handshake_hash": "fac6e4f921f36dc0c1c263f0eac2f396abeb15794516cc7f178218bf22eaa3b5",
   "transport_key_recv": "30f64bb8c9054b6bfdfb710b4fcd024ec00a371ca91db99c8fc00bd31f5181e8",
   "transport_key_send": "b3a7f911b85c3b284f96804e584d9838f7bf4308e2ad1094dace15582f81b5ed",
-  "transport_probe_ciphertext": "f9f69dab9f333a45fce04e08417eb81ab282db6f32",
-  "transport_probe_plaintext_utf8": "probe",
-  "_generated_by": "ci/conformance/noise/make_vectors.py - validated against noiseprotocol (the library aiosendspin 9.1.0 depends on)",
-  "server_ephemeral_private": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+  "server_ephemeral_private": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+  "transport_probe_i2r": [
+    "f9f69dab9f54cc3c657f3d77cafff8d880bf28b79590bd",
+    "4a4a126e55e20f98ab9adfda85393d16791f80100abe96"
+  ],
+  "transport_probe_i2r_plaintext_utf8": [
+    "probe-0",
+    "probe-1"
+  ],
+  "transport_probe_r2i": [
+    "d671814fe27f57a53fd5d1e0946aba3f79cbfad76ee026",
+    "8d8cacccb4561234dfd08418c03e49ce4c806595ad8d0a"
+  ],
+  "transport_probe_r2i_plaintext_utf8": [
+    "reply-0",
+    "reply-1"
+  ],
+  "_generated_by": "ci/conformance/noise/make_vectors.py - every field round-tripped through noiseprotocol (the library aiosendspin 9.1.0 depends on)"
 }

--- a/ci/conformance/register_sendspindroid.py
+++ b/ci/conformance/register_sendspindroid.py
@@ -11,7 +11,7 @@ loudly and needs updating.
 
 from __future__ import annotations
 
-import re
+import ast
 import sys
 from pathlib import Path
 
@@ -50,6 +50,49 @@ ENV_FLAG = (
 )
 
 
+def _binds_os(source: str) -> bool:
+    """True if `source` imports os at module level."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    return any(
+        isinstance(node, ast.Import) and any(a.name == "os" for a in node.names)
+        for node in ast.walk(tree)
+    )
+
+
+def _insert_import_os(source: str) -> str:
+    """Insert `import os` at the first legal module-level position.
+
+    Uses the AST rather than scanning lines. A line-based scan cannot tell code
+    from text, and adapter docstrings routinely contain usage examples whose
+    lines begin with `import ` or `from ` at column 0 - inserting there puts the
+    statement inside a string literal, which still compiles and then fails at
+    runtime with NameError.
+
+    `from __future__` imports must remain the first statement, so we insert
+    after them when present, otherwise after the module docstring.
+    """
+    tree = ast.parse(source)
+    insert_line = 0  # 0-based index into lines
+    for node in tree.body:
+        is_docstring = (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        )
+        is_future = isinstance(node, ast.ImportFrom) and node.module == "__future__"
+        if is_docstring or is_future:
+            insert_line = node.end_lineno  # already 1-based -> next line, 0-based
+        else:
+            break
+
+    lines = source.splitlines(keepends=True)
+    lines.insert(insert_line, "import os\n")
+    return "".join(lines)
+
+
 def patch_server_encryption_flag(conformance: Path) -> int:
     """Make the harness's aiosendspin server adapter honour an env var.
 
@@ -70,28 +113,46 @@ def patch_server_encryption_flag(conformance: Path) -> int:
     if ENV_FLAG in content:
         print(f"{SERVER_ADAPTER} already patched")
         return 0
-    if HARDCODED_FLAG not in content:
+
+    # Require exactly one occurrence. Zero means upstream moved it; more than
+    # one means we would be rewriting something we have not looked at (and a
+    # match inside a comment or docstring would leave the real call site
+    # untouched while this script reported success).
+    occurrences = content.count(HARDCODED_FLAG)
+    if occurrences != 1:
         print(
-            f"{SERVER_ADAPTER} no longer contains {HARDCODED_FLAG!r}; "
-            f"update this script",
+            f"{SERVER_ADAPTER} contains {occurrences} occurrences of "
+            f"{HARDCODED_FLAG!r}, expected exactly 1; update this script",
             file=sys.stderr,
         )
         return 1
 
     content = content.replace(HARDCODED_FLAG, ENV_FLAG)
-    if not re.search(r"^import os$", content, re.MULTILINE):
-        # Insert before the first regular import, but AFTER any
-        # `from __future__` import, which the language requires to come first.
-        lines = content.splitlines(keepends=True)
-        insert_at = 0
-        for i, line in enumerate(lines):
-            if line.startswith("from __future__"):
-                insert_at = i + 1
-            elif line.startswith(("import ", "from ")):
-                insert_at = max(insert_at, i)
-                break
-        lines.insert(insert_at, "import os\n")
-        content = "".join(lines)
+    if not _binds_os(content):
+        content = _insert_import_os(content)
+
+    # Verify before writing. A previous version of this function produced a file
+    # that did not compile (the inserted import landed above `from __future__`),
+    # and the failure surfaced much later, inside the harness, as a traceback
+    # pointing at upstream code rather than at this script.
+    try:
+        tree = ast.parse(content)
+    except SyntaxError as err:
+        print(f"patched {SERVER_ADAPTER} would not compile ({err}); not writing",
+              file=sys.stderr)
+        return 1
+
+    # Syntax alone is not enough: a line-based insertion can land inside a
+    # docstring, which parses fine and then fails at runtime with NameError.
+    # Confirm `os` is actually bound at module level.
+    binds_os = any(
+        isinstance(node, ast.Import) and any(a.name == "os" for a in node.names)
+        for node in ast.walk(tree)
+    )
+    if not binds_os:
+        print(f"patched {SERVER_ADAPTER} does not import os (the insertion "
+              f"probably landed inside a string); not writing", file=sys.stderr)
+        return 1
 
     adapter.write_text(content, encoding="utf-8")
     print(f"Patched {SERVER_ADAPTER} to honour CONFORMANCE_ALLOW_UNENCRYPTED")

--- a/ci/conformance/register_sendspindroid.py
+++ b/ci/conformance/register_sendspindroid.py
@@ -11,6 +11,7 @@ loudly and needs updating.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -41,6 +42,62 @@ IMPLEMENTATIONS["sendspindroid"] = ImplementationSpec(
 '''
 
 
+SERVER_ADAPTER = "aiosendspin_server.py"
+HARDCODED_FLAG = "allow_unencrypted=True"
+ENV_FLAG = (
+    'allow_unencrypted=os.environ.get("CONFORMANCE_ALLOW_UNENCRYPTED", "1") '
+    'not in ("0", "false", "False")'
+)
+
+
+def patch_server_encryption_flag(conformance: Path) -> int:
+    """Make the harness's aiosendspin server adapter honour an env var.
+
+    The adapter hardcodes `allow_unencrypted=True`, which silently accepts the
+    pre-encryption dialect and so cannot serve as a Phase 1 target. Rewriting it
+    to read CONFORMANCE_ALLOW_UNENCRYPTED (default "1", i.e. current behaviour)
+    lets CI flip one variable instead of forking the harness.
+
+    Fails loudly rather than silently proceeding if the literal moves upstream,
+    matching this script's existing doctrine.
+    """
+    adapter = conformance / "src" / "conformance" / "adapters" / SERVER_ADAPTER
+    if not adapter.exists():
+        print(f"{SERVER_ADAPTER} not found; harness layout changed upstream", file=sys.stderr)
+        return 1
+
+    content = adapter.read_text(encoding="utf-8")
+    if ENV_FLAG in content:
+        print(f"{SERVER_ADAPTER} already patched")
+        return 0
+    if HARDCODED_FLAG not in content:
+        print(
+            f"{SERVER_ADAPTER} no longer contains {HARDCODED_FLAG!r}; "
+            f"update this script",
+            file=sys.stderr,
+        )
+        return 1
+
+    content = content.replace(HARDCODED_FLAG, ENV_FLAG)
+    if not re.search(r"^import os$", content, re.MULTILINE):
+        # Insert before the first regular import, but AFTER any
+        # `from __future__` import, which the language requires to come first.
+        lines = content.splitlines(keepends=True)
+        insert_at = 0
+        for i, line in enumerate(lines):
+            if line.startswith("from __future__"):
+                insert_at = i + 1
+            elif line.startswith(("import ", "from ")):
+                insert_at = max(insert_at, i)
+                break
+        lines.insert(insert_at, "import os\n")
+        content = "".join(lines)
+
+    adapter.write_text(content, encoding="utf-8")
+    print(f"Patched {SERVER_ADAPTER} to honour CONFORMANCE_ALLOW_UNENCRYPTED")
+    return 0
+
+
 def main() -> int:
     if len(sys.argv) != 2:
         print(__doc__, file=sys.stderr)
@@ -56,6 +113,9 @@ def main() -> int:
     (adapters_dir / "sendspindroid_client.py").write_text(
         wrapper_src.read_text(encoding="utf-8"), encoding="utf-8"
     )
+
+    if patch_server_encryption_flag(conformance) != 0:
+        return 1
 
     content = implementations.read_text(encoding="utf-8")
     if 'IMPLEMENTATIONS["sendspindroid"]' in content:

--- a/ci/conformance/test_register_sendspindroid.py
+++ b/ci/conformance/test_register_sendspindroid.py
@@ -1,0 +1,159 @@
+"""Tests for the conformance-harness patcher.
+
+Runnable with plain pytest and no dependencies beyond the standard library -
+no aiosendspin, no network, no JVM - so this is the one piece of Phase 0
+verification that can move into CI as-is.
+
+The first shipped version of patch_server_encryption_flag produced a file that
+did not compile, because the inserted `import os` landed above
+`from __future__ import annotations`. `test_patches_file_with_future_import`
+is that regression, and `ast.parse` in the patcher is what now catches it.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from register_sendspindroid import (  # noqa: E402
+    ENV_FLAG,
+    HARDCODED_FLAG,
+    patch_server_encryption_flag,
+)
+
+ADAPTER_REL = Path("src") / "conformance" / "adapters" / "aiosendspin_server.py"
+
+WITH_FUTURE = '''"""aiosendspin server adapter for conformance scenarios."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def build():
+    return SendspinServer(
+        loop,
+        allow_unencrypted=True,
+    )
+'''
+
+WITHOUT_FUTURE = '''"""adapter."""
+
+import argparse
+
+
+def build():
+    return SendspinServer(loop, allow_unencrypted=True)
+'''
+
+DOCSTRING_TRAP = '''"""adapter.
+
+Usage example:
+import conformance
+from conformance import run
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def build():
+    return SendspinServer(loop, allow_unencrypted=True)
+'''
+
+
+def make_checkout(tmp_path: Path, adapter_source: str) -> Path:
+    adapter = tmp_path / ADAPTER_REL
+    adapter.parent.mkdir(parents=True)
+    adapter.write_text(adapter_source, encoding="utf-8")
+    return tmp_path
+
+
+def read_adapter(checkout: Path) -> str:
+    return (checkout / ADAPTER_REL).read_text(encoding="utf-8")
+
+
+def assert_valid_patch(content: str) -> None:
+    """The patched file must compile AND actually bind `os` at module level."""
+    tree = ast.parse(content)  # raises SyntaxError on the original shipped bug
+    assert ENV_FLAG in content
+    assert HARDCODED_FLAG not in content
+    binds_os = any(
+        isinstance(node, ast.Import) and any(a.name == "os" for a in node.names)
+        for node in ast.walk(tree)
+    )
+    assert binds_os, "patched file does not bind os at module level"
+
+
+@pytest.mark.parametrize(
+    "source", [WITH_FUTURE, WITHOUT_FUTURE, DOCSTRING_TRAP],
+    ids=["with-future-import", "without-future-import", "imports-inside-docstring"],
+)
+def test_patch_produces_a_compiling_file_that_binds_os(tmp_path, source):
+    checkout = make_checkout(tmp_path, source)
+    assert patch_server_encryption_flag(checkout) == 0
+    assert_valid_patch(read_adapter(checkout))
+
+
+def test_future_import_stays_first(tmp_path):
+    """The regression: `import os` must not be inserted above `from __future__`."""
+    checkout = make_checkout(tmp_path, WITH_FUTURE)
+    assert patch_server_encryption_flag(checkout) == 0
+    lines = [l for l in read_adapter(checkout).splitlines() if l.strip()]
+    code = [l for l in lines if not l.startswith('"""') and not l.endswith('"""')]
+    future_idx = next(i for i, l in enumerate(code) if l.startswith("from __future__"))
+    os_idx = next(i for i, l in enumerate(code) if l == "import os")
+    assert future_idx < os_idx
+
+
+def test_is_idempotent(tmp_path):
+    checkout = make_checkout(tmp_path, WITH_FUTURE)
+    assert patch_server_encryption_flag(checkout) == 0
+    once = read_adapter(checkout)
+    assert patch_server_encryption_flag(checkout) == 0
+    assert read_adapter(checkout) == once
+
+
+def test_fails_loudly_when_the_literal_is_gone(tmp_path):
+    checkout = make_checkout(tmp_path, WITHOUT_FUTURE.replace(HARDCODED_FLAG, "allow_unencrypted=False"))
+    assert patch_server_encryption_flag(checkout) == 1
+    assert ENV_FLAG not in read_adapter(checkout)
+
+
+def test_refuses_when_the_literal_appears_more_than_once(tmp_path):
+    """Two matches means one is somewhere we have not inspected."""
+    doubled = WITHOUT_FUTURE.replace(
+        "return SendspinServer(loop, allow_unencrypted=True)",
+        "# allow_unencrypted=True is the default\n"
+        "    return SendspinServer(loop, allow_unencrypted=True)",
+    )
+    checkout = make_checkout(tmp_path, doubled)
+    assert patch_server_encryption_flag(checkout) == 1
+    assert read_adapter(checkout) == doubled, "must not modify the file it refused"
+
+
+def test_fails_when_the_adapter_is_missing(tmp_path):
+    (tmp_path / "src" / "conformance" / "adapters").mkdir(parents=True)
+    assert patch_server_encryption_flag(tmp_path) == 1
+
+
+def test_env_flag_default_preserves_current_behaviour(monkeypatch):
+    """Absent env var must evaluate True, so existing CI runs are unchanged."""
+    def evaluate() -> bool:
+        import os
+        return os.environ.get("CONFORMANCE_ALLOW_UNENCRYPTED", "1") not in ("0", "false", "False")
+
+    monkeypatch.delenv("CONFORMANCE_ALLOW_UNENCRYPTED", raising=False)
+    assert evaluate() is True
+    for falsey in ("0", "false", "False"):
+        monkeypatch.setenv("CONFORMANCE_ALLOW_UNENCRYPTED", falsey)
+        assert evaluate() is False
+    monkeypatch.setenv("CONFORMANCE_ALLOW_UNENCRYPTED", "1")
+    assert evaluate() is True

--- a/ci/conformance/verify_dev_server.py
+++ b/ci/conformance/verify_dev_server.py
@@ -1,10 +1,19 @@
-"""Verify the two load-bearing properties of ci/conformance/dev_server.py.
+"""Verify the load-bearing properties of ci/conformance/dev_server.py.
 
-1. The persistent identity is stable across restarts (a changed server_id
-   silently invalidates every stored-pubkey pairing record).
-2. A server configured the way dev_server.py configures it rejects the legacy
-   `client/hello`-first dialect that SendSpinDroid speaks today. That rejection
-   IS the pre-Phase-1 baseline.
+1. The persistent identity is stable across restarts, and a corrupt or empty
+   identity file is refused rather than silently replaced (a changed server_id
+   invalidates every stored-pubkey pairing record).
+2. A server built the way dev_server.py builds it REJECTS the legacy
+   `client/hello`-first dialect that SendSpinDroid speaks today.
+3. A deliberately PERMISSIVE server ACCEPTS that same connection.
+
+Check 3 is the control that gives check 2 its meaning. Without it, a server
+that was simply broken - wrong port semantics, a crash on first message, an
+incompatible aiosendspin - would also "reject" the legacy client, and this
+script would report success for the wrong reason.
+
+Uses dev_server.build_server so it exercises the shipped configuration rather
+than a copy of it.
 """
 
 import asyncio
@@ -16,77 +25,152 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import aiohttp
-from dev_server import load_or_create_identity
+from dev_server import build_server, load_or_create_identity
 
 from aiosendspin.noise.trust_store import FileServerPairingStore
-from aiosendspin.server.server import SendspinServer
 
-PORT = 18927
+PORT_STRICT = 18927
+PORT_PERMISSIVE = 18928
+
+# A faithful reproduction of the first frame SendSpinDroid 2.0.0-Beta14 sends,
+# mirroring MessageBuilder.buildClientHello. It matters that this is realistic:
+# aiosendspin rejects a hello that lists player@v1 without player@v1_support,
+# so a stripped-down payload would be refused for reasons that have nothing to
+# do with encryption policy - making the rejection test pass for the wrong
+# reason. The permissive control below is what catches that.
+LEGACY_HELLO = json.dumps({
+    "type": "client/hello",
+    "payload": {
+        "client_id": "7f3d5b1e-0000-4000-8000-000000000000",
+        "name": "SendSpinDroid",
+        "version": 1,
+        "supported_roles": ["player@v1", "controller@v1", "metadata@v1"],
+        "device_info": {
+            "product_name": "SendSpinDroid",
+            "manufacturer": "verify",
+            "software_version": "2.0.0-Beta14",
+        },
+        "player@v1_support": {
+            "supported_formats": [
+                {"codec": "pcm", "sample_rate": 48000, "channels": 2, "bit_depth": 16},
+            ],
+            "buffer_capacity": 1_680_000,
+            "supported_commands": ["volume", "mute"],
+        },
+    },
+})
+
+failures: list[str] = []
+
+
+def check(ok: bool, label: str, detail: str = "") -> None:
+    if ok:
+        print(f"PASS {label}")
+    else:
+        failures.append(f"{label}{(': ' + detail) if detail else ''}")
+        print(f"FAIL {label}{(': ' + detail) if detail else ''}")
 
 
 def test_identity_persistence(tmp: Path) -> None:
     key = tmp / "identity.key"
     first = load_or_create_identity(key)
     second = load_or_create_identity(key)
-    assert first.peer_id == second.peer_id, "identity changed across restarts"
-    assert len(first.peer_id) == 43, f"server_id must be 43 chars, got {len(first.peer_id)}"
-    print(f"PASS identity persistence: {first.peer_id}")
+    check(first.peer_id == second.peer_id, "identity is stable across restarts",
+          f"{first.peer_id} != {second.peer_id}")
+    check(len(first.peer_id) == 43, "server_id is 43 base64url chars",
+          f"got {len(first.peer_id)}")
+    print(f"     server_id: {first.peer_id}")
 
     empty = tmp / "empty.key"
     empty.write_text("", encoding="utf-8")
     try:
         load_or_create_identity(empty)
     except SystemExit:
-        print("PASS refuses to mint over an empty identity file")
+        check(True, "refuses to mint over an EMPTY identity file")
     else:
-        raise AssertionError("empty identity file was silently replaced")
+        check(False, "refuses to mint over an EMPTY identity file",
+              "it silently generated a new identity")
+
+    corrupt = tmp / "corrupt.key"
+    corrupt.write_text("not-a-valid-base64url-key!!!", encoding="utf-8")
+    try:
+        load_or_create_identity(corrupt)
+    except SystemExit:
+        check(True, "refuses to mint over a CORRUPT identity file")
+    else:
+        check(False, "refuses to mint over a CORRUPT identity file",
+              "it silently generated a new identity")
+
+
+async def send_legacy_hello(port: int) -> tuple[str, str]:
+    """Return (outcome, detail) for a legacy client/hello against `port`.
+
+    outcome is one of: 'closed' (server rejected), 'replied' (server engaged),
+    'upgrade_refused', 'transport_error', 'timeout'.
+    """
+    url = f"http://127.0.0.1:{port}/sendspin"
+    try:
+        async with aiohttp.ClientSession() as session:
+            try:
+                ws_ctx = session.ws_connect(url)
+            except aiohttp.WSServerHandshakeError as err:
+                return "upgrade_refused", str(err)
+            async with ws_ctx as ws:
+                await ws.send_str(LEGACY_HELLO)
+                try:
+                    msg = await asyncio.wait_for(ws.receive(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    return "timeout", "no reply and no close within 5s"
+                if msg.type is aiohttp.WSMsgType.ERROR:
+                    # A local transport error is NOT evidence of a server-side
+                    # policy decision; conflating the two is how this check
+                    # would pass for the wrong reason.
+                    return "transport_error", repr(ws.exception())
+                if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED,
+                                aiohttp.WSMsgType.CLOSING):
+                    return "closed", f"close_code={ws.close_code}"
+                return "replied", f"{msg.type.name}: {msg.data!r}"
+    except (aiohttp.WSServerHandshakeError, aiohttp.ClientError) as err:
+        return "upgrade_refused", f"{type(err).__name__}: {err}"
+
+
+async def run_server(tmp: Path, port: int, *, allow_unencrypted: bool):
+    identity = load_or_create_identity(tmp / f"identity-{port}.key")
+    store = await FileServerPairingStore.open(tmp / f"store-{port}.json")
+    server = build_server(asyncio.get_running_loop(), identity, "Verify", store,
+                          allow_unencrypted=allow_unencrypted)
+    await server.start_server(port=port, host="127.0.0.1", discover_clients=False)
+    return server
+
+
+async def close_server(server) -> None:
+    try:
+        await asyncio.wait_for(server.close(), timeout=5.0)
+    except asyncio.TimeoutError:
+        print("     (warning: server.close() timed out; see aiosendspin issue 299)")
 
 
 async def test_legacy_rejected(tmp: Path) -> None:
-    identity = load_or_create_identity(tmp / "identity.key")
-    store = await FileServerPairingStore.open(tmp / "pairing_store.json")
-    server = SendspinServer(
-        asyncio.get_running_loop(),
-        identity,
-        "Verify",
-        pairing_store=store,
-        allow_unencrypted=False,
-        allow_noncompliant_clients=False,
-    )
-    await server.start_server(port=PORT, host="127.0.0.1", discover_clients=False)
+    server = await run_server(tmp, PORT_STRICT, allow_unencrypted=False)
     try:
-        url = f"http://127.0.0.1:{PORT}{SendspinServer.API_PATH}"
-        async with aiohttp.ClientSession() as session:
-            async with session.ws_connect(url) as ws:
-                # Exactly what SendSpinDroid 2.0.0-Beta14 sends first today.
-                await ws.send_str(json.dumps({
-                    "type": "client/hello",
-                    "payload": {
-                        "client_id": "7f3d5b1e-0000-4000-8000-000000000000",
-                        "name": "SendSpinDroid",
-                        "version": 1,
-                        "supported_roles": ["player@v1"],
-                    },
-                }))
-                got_reply = None
-                try:
-                    msg = await asyncio.wait_for(ws.receive(), timeout=5.0)
-                    got_reply = msg
-                except asyncio.TimeoutError:
-                    raise AssertionError("server neither replied nor closed - legacy accepted?")
-        if got_reply.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED,
-                              aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.ERROR):
-            print(f"PASS legacy client/hello rejected (frame={got_reply.type.name})")
-        else:
-            raise AssertionError(
-                f"legacy client/hello was ACCEPTED; server replied {got_reply.type.name}: "
-                f"{got_reply.data!r}"
-            )
+        outcome, detail = await send_legacy_hello(PORT_STRICT)
     finally:
-        try:
-            await asyncio.wait_for(server.close(), timeout=5.0)
-        except asyncio.TimeoutError:
-            pass
+        await close_server(server)
+    check(outcome == "closed",
+          "strict server REJECTS the legacy client/hello", f"outcome={outcome} ({detail})")
+
+
+async def test_permissive_accepts(tmp: Path) -> None:
+    """Control: prove the rejection above is caused by the flags, not by breakage."""
+    server = await run_server(tmp, PORT_PERMISSIVE, allow_unencrypted=True)
+    try:
+        outcome, detail = await send_legacy_hello(PORT_PERMISSIVE)
+    finally:
+        await close_server(server)
+    check(outcome == "replied",
+          "control: permissive server ACCEPTS the same legacy client/hello",
+          f"outcome={outcome} ({detail}) - if this fails, the rejection above "
+          f"proves nothing about encryption policy")
 
 
 async def main() -> int:
@@ -94,7 +178,15 @@ async def main() -> int:
         tmp = Path(td)
         test_identity_persistence(tmp)
         await test_legacy_rejected(tmp)
-    print("\nALL CHECKS PASSED")
+        await test_permissive_accepts(tmp)
+
+    print()
+    if failures:
+        print(f"{len(failures)} CHECK(S) FAILED")
+        for f in failures:
+            print(" -", f)
+        return 1
+    print("ALL CHECKS PASSED")
     return 0
 
 

--- a/ci/conformance/verify_dev_server.py
+++ b/ci/conformance/verify_dev_server.py
@@ -1,0 +1,102 @@
+"""Verify the two load-bearing properties of ci/conformance/dev_server.py.
+
+1. The persistent identity is stable across restarts (a changed server_id
+   silently invalidates every stored-pubkey pairing record).
+2. A server configured the way dev_server.py configures it rejects the legacy
+   `client/hello`-first dialect that SendSpinDroid speaks today. That rejection
+   IS the pre-Phase-1 baseline.
+"""
+
+import asyncio
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import aiohttp
+from dev_server import load_or_create_identity
+
+from aiosendspin.noise.trust_store import FileServerPairingStore
+from aiosendspin.server.server import SendspinServer
+
+PORT = 18927
+
+
+def test_identity_persistence(tmp: Path) -> None:
+    key = tmp / "identity.key"
+    first = load_or_create_identity(key)
+    second = load_or_create_identity(key)
+    assert first.peer_id == second.peer_id, "identity changed across restarts"
+    assert len(first.peer_id) == 43, f"server_id must be 43 chars, got {len(first.peer_id)}"
+    print(f"PASS identity persistence: {first.peer_id}")
+
+    empty = tmp / "empty.key"
+    empty.write_text("", encoding="utf-8")
+    try:
+        load_or_create_identity(empty)
+    except SystemExit:
+        print("PASS refuses to mint over an empty identity file")
+    else:
+        raise AssertionError("empty identity file was silently replaced")
+
+
+async def test_legacy_rejected(tmp: Path) -> None:
+    identity = load_or_create_identity(tmp / "identity.key")
+    store = await FileServerPairingStore.open(tmp / "pairing_store.json")
+    server = SendspinServer(
+        asyncio.get_running_loop(),
+        identity,
+        "Verify",
+        pairing_store=store,
+        allow_unencrypted=False,
+        allow_noncompliant_clients=False,
+    )
+    await server.start_server(port=PORT, host="127.0.0.1", discover_clients=False)
+    try:
+        url = f"http://127.0.0.1:{PORT}{SendspinServer.API_PATH}"
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(url) as ws:
+                # Exactly what SendSpinDroid 2.0.0-Beta14 sends first today.
+                await ws.send_str(json.dumps({
+                    "type": "client/hello",
+                    "payload": {
+                        "client_id": "7f3d5b1e-0000-4000-8000-000000000000",
+                        "name": "SendSpinDroid",
+                        "version": 1,
+                        "supported_roles": ["player@v1"],
+                    },
+                }))
+                got_reply = None
+                try:
+                    msg = await asyncio.wait_for(ws.receive(), timeout=5.0)
+                    got_reply = msg
+                except asyncio.TimeoutError:
+                    raise AssertionError("server neither replied nor closed - legacy accepted?")
+        if got_reply.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED,
+                              aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.ERROR):
+            print(f"PASS legacy client/hello rejected (frame={got_reply.type.name})")
+        else:
+            raise AssertionError(
+                f"legacy client/hello was ACCEPTED; server replied {got_reply.type.name}: "
+                f"{got_reply.data!r}"
+            )
+    finally:
+        try:
+            await asyncio.wait_for(server.close(), timeout=5.0)
+        except asyncio.TimeoutError:
+            pass
+
+
+async def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        test_identity_persistence(tmp)
+        await test_legacy_rejected(tmp)
+    print("\nALL CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/docs/dev-server-runbook.md
+++ b/docs/dev-server-runbook.md
@@ -42,14 +42,17 @@ aiosendspin 10.
 python ci/conformance/dev_server.py --name "Sendspin Dev" --trust-all-unpaired
 ```
 
-Expected startup output:
+Expected startup output (every line is prefixed with
+`HH:MM:SS INFO    dev_server: `, elided here for width; on a first run a
+"Generated a new server identity" line precedes it, and aiosendspin logs a
+couple of its own lines):
 
 ```
 ========================================================================
 Sendspin dev server 'Sendspin Dev' listening on 0.0.0.0:8927/sendspin
 server_id: O67GqkUcDwDyoaIToq1vqI474fNR3sZp8CV1kul35W0
-identity:  .dev/sendspin/identity.key (do NOT delete - see runbook)
-records:   .dev/sendspin/pairing_store.json
+identity:  .dev\sendspin\identity.key (do NOT delete - see runbook)
+records:   .dev\sendspin\pairing_store.json
 allow_unencrypted=False  allow_noncompliant_clients=False
 auto-trusting unpaired clients on connect (--trust-all-unpaired)
 ========================================================================
@@ -97,18 +100,33 @@ python ci/conformance/verify_dev_server.py
 which asserts, on a throwaway state directory:
 
 - the persistent identity is stable across restarts, and `server_id` is 43 chars
-- a corrupt or empty identity file is refused rather than silently replaced
-- a legacy `client/hello`-first connection is **closed** by the server
+- an empty identity file is refused rather than silently replaced
+- a corrupt identity file is refused rather than silently replaced
+- a strict server **closes** a legacy `client/hello`-first connection
+- a **permissive** server accepts that same connection
 
-Expected output:
+The last check is the control that gives the one before it meaning. Without it,
+a server that was simply broken would also "reject" the legacy client and this
+script would report success for the wrong reason. It uses `dev_server`'s own
+`build_server`, so it exercises the shipped configuration rather than a copy.
+
+Expected output (aiosendspin also logs an "Accepting unencrypted legacy
+connection (transition mode)" line during the control):
 
 ```
-PASS identity persistence: O67GqkUcDwDyoaIToq1vqI474fNR3sZp8CV1kul35W0
-PASS refuses to mint over an empty identity file
-PASS legacy client/hello rejected (frame=CLOSE)
+PASS identity is stable across restarts
+PASS server_id is 43 base64url chars
+     server_id: Q14IWqmBv7Me1wJAXmOqW-Ge9BXKK_6g6fJZotcERwA
+PASS refuses to mint over an EMPTY identity file
+PASS refuses to mint over a CORRUPT identity file
+PASS strict server REJECTS the legacy client/hello
+PASS control: permissive server ACCEPTS the same legacy client/hello
 
 ALL CHECKS PASSED
 ```
+
+The `server_id` differs on every run: the script uses a fresh temporary state
+directory, so it never reuses the one your dev server prints.
 
 Then point the current app build (2.0.0-Beta14) at the running server. It must
 discover the server and then **fail to establish a session**, with the server
@@ -148,16 +166,24 @@ regardless of WSL2.
 
 ## Debugging the Noise prologue
 
+The prologue is the concatenation of `client/init` and `server/init`'s **exact
+wire bytes** - the spec requires hashing what was sent and received, not a
+re-serialization. `kotlinx.serialization` will not round-trip byte-identically,
+so a mismatch here is the most likely silent failure in item 1.2.
+
 ```bash
-python ci/conformance/dev_server.py --dump-wire
+python ci/conformance/dev_server.py --debug
 ```
 
-Raises aiosendspin to DEBUG so the raw `client/init` and `server/init` bytes are
-logged. The prologue is the concatenation of those two messages' **exact wire
-bytes** - the spec requires hashing what was sent and received, not a
-re-serialization. `kotlinx.serialization` will not round-trip byte-identically,
-so a mismatch here is the most likely silent failure in item 1.2, and comparing
-against this log is the only practical way to find it.
+raises aiosendspin and this script to DEBUG. **Be aware of what that does not
+give you:** aiosendspin 9.1.0 does not log the raw init bytes at any level. It
+builds the prologue in `aiosendspin/noise/driver.py` as
+`client_init_text.encode() + server_init_text.encode()` with no log statement.
+To diff our concatenation against the server's you have to capture the frames
+yourself - a WebSocket proxy in front of the server, or a local one-line patch
+adding a log call to that function. (An earlier version of this runbook claimed
+`--dump-wire` surfaced these bytes. It did not; the flag has been renamed to
+`--debug` to stop promising it.)
 
 ## Relationship to the conformance harness
 

--- a/docs/dev-server-runbook.md
+++ b/docs/dev-server-runbook.md
@@ -1,0 +1,172 @@
+# Sendspin dev server runbook
+
+How to run a local Sendspin server that **refuses the legacy dialect**, so Phase 1
+work is verified against a spec-compliant peer instead of Music Assistant's
+compatibility shim.
+
+Deliverable for audit item 0.2 (issue #190). See
+`docs/spec-compliance-audit-2026-08-13.md`.
+
+## Why this exists
+
+Music Assistant ships `allow_legacy_clients=true`, which maps to aiosendspin's
+`allow_unencrypted` / `allow_noncompliant_clients`. With that on, SendSpinDroid's
+current `client/hello`-first dialect is accepted and every Phase 1 failure is
+invisible. MA documents the toggle as temporary.
+
+This server sets both flags to `False`. Against it, the current app **must fail to
+connect** - that failure is the baseline Phase 1 has to turn green.
+
+## One-time setup
+
+Requires Python 3.12+.
+
+```bash
+python -m venv .venv
+# Windows
+.venv\Scripts\activate
+# macOS/Linux
+source .venv/bin/activate
+
+pip install "aiosendspin[server]==9.1.0"
+```
+
+Pin 9.1.0: it is the version Music Assistant currently requires
+(`music_assistant/providers/sendspin/manifest.json`). `aiosendspin.noise.*` is not
+a stability-guaranteed API, so expect this script to need touching on
+aiosendspin 10.
+
+## Running
+
+```bash
+python ci/conformance/dev_server.py --name "Sendspin Dev" --trust-all-unpaired
+```
+
+Expected startup output:
+
+```
+========================================================================
+Sendspin dev server 'Sendspin Dev' listening on 0.0.0.0:8927/sendspin
+server_id: O67GqkUcDwDyoaIToq1vqI474fNR3sZp8CV1kul35W0
+identity:  .dev/sendspin/identity.key (do NOT delete - see runbook)
+records:   .dev/sendspin/pairing_store.json
+allow_unencrypted=False  allow_noncompliant_clients=False
+auto-trusting unpaired clients on connect (--trust-all-unpaired)
+========================================================================
+```
+
+The `server_id` must be **identical** on every restart. If it changes, the
+identity file was recreated and every paired client is now broken (see below).
+
+### Console commands
+
+The server reads commands on stdin while running:
+
+| command | effect |
+|---|---|
+| `clients` | list connected clients with pairing and security state |
+| `trust [id]` | make an unpaired (Sentinel-PSK) client playback-capable |
+| `untrust [id]` | revoke that |
+| `pair <token>` | pair using a `SP:0...` pairing token from the device (Phase 2) |
+| `unpair [id]` | drop the record and send `server/unpair` (exercises item 2.7) |
+| `quit` | stop |
+
+`id` defaults to the only connected client when omitted.
+
+### `--trust-all-unpaired` is not optional in practice
+
+A Sentinel-keyed client completes the handshake but is **not playback-capable**
+until the operator trusts it. In aiosendspin,
+`SendspinConnection._playback_capable` requires
+`client_info.unpaired_access.enabled and _trusted_unpaired`, and the latter comes
+from `pairing_store.trusted_unpaired(client_id)`.
+
+Forget this and you get a clean handshake followed by a `server/activate` with an
+empty `active_roles` - which reads exactly like a bug in the client's
+`server/activate` handling (item 1.6). It is the single easiest way to lose a day
+on Phase 1. `--trust-all-unpaired` takes it off the table.
+
+## Verifying the target is configured correctly
+
+Run the automated checks:
+
+```bash
+python ci/conformance/verify_dev_server.py
+```
+
+which asserts, on a throwaway state directory:
+
+- the persistent identity is stable across restarts, and `server_id` is 43 chars
+- a corrupt or empty identity file is refused rather than silently replaced
+- a legacy `client/hello`-first connection is **closed** by the server
+
+Expected output:
+
+```
+PASS identity persistence: O67GqkUcDwDyoaIToq1vqI474fNR3sZp8CV1kul35W0
+PASS refuses to mint over an empty identity file
+PASS legacy client/hello rejected (frame=CLOSE)
+
+ALL CHECKS PASSED
+```
+
+Then point the current app build (2.0.0-Beta14) at the running server. It must
+discover the server and then **fail to establish a session**, with the server
+logging the `client/hello`-first frame being rejected. That failure is the
+expected pre-Phase-1 baseline.
+
+## Resetting state
+
+| to reset | delete | consequence |
+|---|---|---|
+| all pairings | `.dev/sendspin/pairing_store.json` | clients must re-pair; safe |
+| the server's identity | `.dev/sendspin/identity.key` | **destructive** |
+
+Deleting `identity.key` changes `server_id`. Every stored-pubkey pairing record on
+every paired device then matches on `psk_id` but fails the `server_id` check, and
+the spec's failure handling for that is to close the WebSocket **with no
+application-level error message** (`connection.md#failure-handling`). The symptom
+is an unexplained disconnect loop with nothing useful in any log. The script
+refuses to overwrite a corrupt identity file for this reason.
+
+## Windows and WSL2
+
+Run the server on the **Windows host**, not inside WSL2. WSL2 sits behind a NAT,
+so neither mDNS advertising nor an inbound WebSocket from a phone reaches it.
+
+If WSL2 is unavoidable:
+
+```powershell
+netsh interface portproxy add v4tov4 listenport=8927 listenaddress=0.0.0.0 `
+  connectport=8927 connectaddress=<wsl-ip>
+```
+
+...and use the app's **Add Server Manually** flow with an explicit `host:8927`,
+because discovery will not work. Android's `NsdManager` is also unreliable on some
+OEM builds and on networks with client isolation, so keep manual entry in mind
+regardless of WSL2.
+
+## Debugging the Noise prologue
+
+```bash
+python ci/conformance/dev_server.py --dump-wire
+```
+
+Raises aiosendspin to DEBUG so the raw `client/init` and `server/init` bytes are
+logged. The prologue is the concatenation of those two messages' **exact wire
+bytes** - the spec requires hashing what was sent and received, not a
+re-serialization. `kotlinx.serialization` will not round-trip byte-identically,
+so a mismatch here is the most likely silent failure in item 1.2, and comparing
+against this log is the only practical way to find it.
+
+## Relationship to the conformance harness
+
+The harness (`.github/workflows/conformance.yml`) constructs its own server via
+`Sendspin/conformance`'s `aiosendspin_server.py` adapter, which hardcodes
+`allow_unencrypted=True` and regenerates the identity per run. That is fine for
+the legacy scenarios it runs today but cannot be the encrypted target.
+
+`ci/conformance/register_sendspindroid.py` now rewrites that literal to read the
+`CONFORMANCE_ALLOW_UNENCRYPTED` environment variable, defaulting to the existing
+behaviour, so a future Phase 1 exit criterion can flip one variable in CI instead
+of forking the harness. The patch fails loudly if the literal disappears upstream.

--- a/docs/spec-compliance-audit-2026-08-13.md
+++ b/docs/spec-compliance-audit-2026-08-13.md
@@ -241,7 +241,25 @@ the critical path. `client/hello` advertises `supported_pair_methods:
 [{method: "pairing_psk", locations: ["operator"]}]` and the user pairs by
 copying a token (or scanning a QR) from Settings into MA.
 
-**D3. Crypto primitives from BouncyCastle; write the KKpsk2 state machine by hand.**
+**D3. RESOLVED (2026-08-13, issue #189): hand-roll on BouncyCastle.**
+The spike ran. `org.signal.forks:noise-java:0.1.1` fails both load-bearing
+questions: it cannot construct `Noise_KKpsk2_25519_ChaChaPoly_SHA256`
+(`IllegalArgumentException: Handshake pattern is not recognized` - the `KK`
+control constructs fine, so it is the `psk2` modifier specifically), and it
+throws `IllegalStateException` if a PSK is supplied after the handshake has
+started, which is exactly what `psk_id` selection requires. It does expose `h`
+and both cipher suites, but neither compensates.
+
+A hand-rolled `KKpsk2` responder on BouncyCastle now exists and is validated
+against `noiseprotocol` (the library aiosendspin 9.1.0 depends on): see
+`ci/conformance/noise/`, with reference-round-tripped golden vectors in
+`vectors.json` for #193's tests. Two traps found while building it are written up
+in that README - most notably that under any `psk` modifier the `e` token calls
+`MixKey` on the ephemeral public key in addition to `MixHash`, and omitting it
+diverges the state at the first token while surfacing only as an AEAD tag
+failure several steps later.
+
+Original reasoning, retained for context:
 `KKpsk2` is a fixed three-message pattern needing only X25519, HKDF-SHA256,
 SHA-256, ChaCha20-Poly1305 and AES-GCM - all in `bcprov-jdk18on`, which is already
 a common Android dependency and has no NDK component.

--- a/docs/spec-compliance-audit-2026-08-13.md
+++ b/docs/spec-compliance-audit-2026-08-13.md
@@ -253,11 +253,15 @@ and both cipher suites, but neither compensates.
 A hand-rolled `KKpsk2` responder on BouncyCastle now exists and is validated
 against `noiseprotocol` (the library aiosendspin 9.1.0 depends on): see
 `ci/conformance/noise/`, with reference-round-tripped golden vectors in
-`vectors.json` for #193's tests. Two traps found while building it are written up
-in that README - most notably that under any `psk` modifier the `e` token calls
-`MixKey` on the ephemeral public key in addition to `MixHash`, and omitting it
-diverges the state at the first token while surfacing only as an AEAD tag
-failure several steps later.
+`vectors.json` for #193's tests. The trap found while building it is written up
+in that README: under any `psk` modifier the `e` token calls `MixKey` on the
+ephemeral public key in addition to `MixHash`, and omitting it diverges the state
+at the first token while surfacing only as an AEAD tag failure several steps
+later.
+
+Note for #193: Noise's HKDF **is** RFC 5869 (chaining key as salt, empty info),
+so use a library HKDF. An earlier draft of this document and the README claimed
+otherwise; that was wrong and has been corrected.
 
 Original reasoning, retained for context:
 `KKpsk2` is a fixed three-message pattern needing only X25519, HKDF-SHA256,


### PR DESCRIPTION
Closes the two blocking Phase 0 items of the spec-compliance migration.

Closes #189
Closes #190

## #190 - dev server

`ci/conformance/dev_server.py` runs aiosendspin 9.1.0 with
`allow_unencrypted=False` and `allow_noncompliant_clients=False`. Music
Assistant's default (`allow_legacy_clients=true`) silently accepts the dialect
SendSpinDroid speaks today, which hides every failure Phase 1 exists to fix.

Verified, not asserted — `ci/conformance/verify_dev_server.py`:

```
PASS identity persistence: ZPOD1ERortrtOddm27eluyxlfQIenVZ3Wu89y422YnE
PASS refuses to mint over an empty identity file
PASS legacy client/hello rejected (frame=CLOSE)
```

That last line is the pre-Phase-1 baseline.

Notes:
- Identity and pairing records persist. The script refuses to overwrite a
  corrupt identity file, because a regenerated `server_id` invalidates every
  stored-pubkey record on every paired device and the spec reports that as a
  silent close.
- `--trust-all-unpaired` exists because a Sentinel-keyed client is not
  playback-capable until the operator trusts it; forgetting that looks exactly
  like a `server/activate` bug in the client.
- `register_sendspindroid.py` now also rewrites the harness's hardcoded
  `allow_unencrypted=True` to read `CONFORMANCE_ALLOW_UNENCRYPTED` (defaulting
  to current behaviour), so CI can flip one variable instead of forking the
  harness. Tested idempotent against a clean clone, and the patched file
  compiles — the first attempt did not, because the inserted `import os`
  landed above `from __future__ import annotations`.

## #189 - Noise spike

Decision D3 is resolved: **hand-roll on BouncyCastle.**
`org.signal.forks:noise-java:0.1.1` fails both questions that matter:

| Question | Result |
|---|---|
| construct `Noise_KKpsk2_25519_ChaChaPoly_SHA256` | FAIL — pattern not recognized (the `KK` control constructs, so it is `psk2` specifically) |
| supply the PSK after Noise message 1 | FAIL — `IllegalStateException` once the handshake has started |
| expose handshake hash `h` | OK |
| both cipher suites | OK |

Reading `psk_id` from message 1 and only then choosing the PSK is the core of
the Sendspin handshake, so a library that demands the PSK up front is unusable.

`ci/conformance/noise/` therefore carries a **working KKpsk2 responder**
validated against `noiseprotocol` — the same library aiosendspin depends on —
with both sides deriving an identical handshake hash and transport messages
round-tripping in both directions. `vectors.json` holds golden vectors that were
round-tripped through that reference implementation, so #193 is a port rather
than a design task.

Two traps are written up in the README:

- Under any `psk` modifier the `e` token calls `MixKey` on the ephemeral public
  key **in addition to** `MixHash`. Omitting it diverges the state at the very
  first token and surfaces only as an AEAD tag failure several steps later —
  which is exactly how it presented while building this.
- Noise's HKDF is not RFC 5869 applied naively; each output is an HMAC over the
  previous output plus a counter byte. A generic HKDF helper yields a handshake
  that self-tests clean and fails against a real peer.

## Not covered

- AESGCM suite: constructible, but the prototype implements ChaChaPoly only.
  #193 adds it and a second vector set.
- No Android device run yet. The prototype deliberately uses the low-level
  `org.bouncycastle.crypto.*` API rather than JCA to avoid provider conflicts
  with Android's repackaged BouncyCastle; APK size and a release build under R8
  are for #193.
- The runbook's "point the current app at it and watch it fail" step needs a
  device and has not been run.
