### PR TITLE
1.4: wire the app onto the encrypted path

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -9,6 +9,7 @@ import androidx.preference.PreferenceManager
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import java.util.UUID
+import com.sendspindroid.sendspin.crypto.ClientIdentity
 
 /**
  * Centralized access to user settings stored in SharedPreferences.
@@ -178,6 +179,63 @@ object UserSettings {
      * in memory. The cached ID is persisted when initialize() runs.
      * Double-checked locking ensures only one UUID is ever generated.
      */
+    // ========== Sendspin identity (Curve25519) ==========
+
+    private const val KEY_NOISE_IDENTITY = "sendspin_noise_identity"
+
+    @Volatile
+    private var cachedIdentity: ClientIdentity? = null
+
+    /**
+     * The client's persistent Sendspin identity.
+     *
+     * Its public half is the `client_id` on the wire, and it is a pre-message
+     * input to every Noise handshake, so losing it makes this device a stranger
+     * to every server it has paired with - and the failure mode the spec
+     * prescribes is a silent socket close.
+     *
+     * Stored in [sensitivePrefs] with `commit()` rather than `apply()`: an
+     * async write that loses a race with process death would mint a different
+     * identity on next launch, breaking pairings with nothing to point at.
+     *
+     * A stored value that will not decode is NOT silently replaced. That state
+     * means something went wrong, and quietly generating a new identity would
+     * convert a recoverable problem into permanent, invisible unpairing.
+     */
+    fun getOrCreateClientIdentity(): ClientIdentity {
+        cachedIdentity?.let { return it }
+        synchronized(this) {
+            cachedIdentity?.let { return it }
+
+            val stored = sensitivePrefs?.getString(KEY_NOISE_IDENTITY, null)
+            if (!stored.isNullOrBlank()) {
+                val restored = ClientIdentity.fromStoredKey(stored)
+                if (restored != null) {
+                    cachedIdentity = restored
+                    return restored
+                }
+                Log.e(
+                    TAG,
+                    "Stored Sendspin identity is unreadable. Refusing to overwrite it: " +
+                        "minting a new one would silently unpair this device from every " +
+                        "server. Clear app data deliberately if that is what you want."
+                )
+                error("stored Sendspin identity is corrupt")
+            }
+
+            val fresh = ClientIdentity.generate()
+            val ok = sensitivePrefs?.edit()
+                ?.putString(KEY_NOISE_IDENTITY, ClientIdentity.encodeForStorage(fresh))
+                ?.commit() ?: false
+            if (!ok) {
+                Log.w(TAG, "Could not persist the Sendspin identity; it will not survive restart")
+            }
+            cachedIdentity = fresh
+            Log.i(TAG, "Generated Sendspin identity ${fresh.clientId}")
+            return fresh
+        }
+    }
+
     fun getPlayerId(): String {
         // Fast path: prefs available and ID already stored
         val p = prefs

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -10,6 +10,8 @@ import com.sendspindroid.sendspin.transport.ProxyWebSocketTransport
 import com.sendspindroid.sendspin.protocol.ControllerState
 import com.sendspindroid.sendspin.protocol.GroupInfo
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+import com.sendspindroid.sendspin.crypto.PskCandidateSet
+import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
 import com.sendspindroid.sendspin.protocol.SendSpinProtocolHandler
 import com.sendspindroid.sendspin.protocol.StreamConfig
 import com.sendspindroid.sendspin.protocol.TrackMetadata
@@ -314,11 +316,83 @@ class SendSpin(
 
     // ========== SendSpinProtocolHandler Implementation ==========
 
+    // ========== Encrypted handshake (spec) ==========
+
+    /**
+     * Whether to attempt the spec's encrypted handshake.
+     *
+     * Defaults to off. Music Assistant still accepts the legacy dialect behind
+     * its `allow_legacy_clients` toggle, and flipping this default before the
+     * encrypted path has run against a real server would strand every user on a
+     * stable MA build. Automatic negotiation - try encrypted, fall back once on
+     * a handshake-phase close - is item 1.10 (#201); until then this is an
+     * explicit opt-in so the path can be exercised against the dev server.
+     */
+    @Volatile
+    var useEncryption: Boolean = false
+
+    private var handshakeDriver: SendSpinHandshakeDriver? = null
+
+    private fun startEncryptedHandshake() {
+        // The wire client_id for an encrypted session is the base64url public
+        // key, NOT the legacy UUID player id - the two are different
+        // identifiers and the server rejects a non-43-character value.
+        val identity = UserSettings.getOrCreateClientIdentity()
+        val driver = SendSpinHandshakeDriver(
+            identity = identity,
+            candidates = pskCandidates(),
+            onEvent = ::onHandshakeEvent,
+        )
+        handshakeDriver = driver
+        driver.start()
+    }
+
+    private fun onHandshakeEvent(event: SendSpinHandshakeDriver.Event) {
+        when (event) {
+            is SendSpinHandshakeDriver.Event.SendCleartext ->
+                // Cleartext handshake frames are the only text frames the spec
+                // permits; everything after transport mode is binary.
+                sendTextMessage(event.text)
+
+            is SendSpinHandshakeDriver.Event.TransportReady -> {
+                Log.i(TAG, "Noise handshake complete with ${event.serverInit.serverId} " +
+                    "(psk=${event.matchedPsk.category})")
+                installEncryptedTransport(event.transport)
+                // client/hello is the first ENCRYPTED message, not the first
+                // frame on the socket. It now rides the codec like everything
+                // else.
+                sendClientHello()
+            }
+
+            is SendSpinHandshakeDriver.Event.Fail -> {
+                // The spec allows no application-level error message here, so
+                // this log line is the only diagnostic that will ever exist.
+                Log.e(TAG, "Noise handshake failed: ${event.reason} - ${event.detail}")
+                handshakeDriver = null
+                _connectionState.value = TransportState.Failed(FailureReason.HandshakeFailed)
+                transport?.close(1002, "handshake failed")
+            }
+        }
+    }
+
+    /**
+     * Phase 1 candidate set: the Sentinel alone, which is what an unpaired
+     * client presents. Pairing records join it in Phase 2 (#202).
+     */
+    private fun pskCandidates(): PskCandidateSet = PskCandidateSet.sentinelOnly()
+
     override fun sendTextMessage(text: String) {
         val t = transport ?: return  // Silently drop if transport is gone (e.g. post-disconnect race)
         val success = t.send(text)
         if (!success) {
             Log.w(TAG, "Failed to send message")
+        }
+    }
+
+    override fun sendBinaryFrame(bytes: ByteArray) {
+        val t = transport ?: return
+        if (!t.send(bytes)) {
+            Log.w(TAG, "Failed to send binary frame (${bytes.size} bytes)")
         }
     }
 
@@ -1346,10 +1420,28 @@ class SendSpin(
                 Log.e(TAG, "Proxy connection has no auth token - server will reject")
                 _connectionState.value = TransportState.Failed(FailureReason.AuthRejected)
                 disconnect()
+            } else if (useEncryption) {
+                // Spec order: client/init is the FIRST frame on the socket.
+                // client/hello moves after the Noise handshake and travels
+                // encrypted like every other application message.
+                Log.d(TAG, "Starting encrypted handshake")
+                startEncryptedHandshake()
             } else {
                 // Local/Remote mode: proceed directly with hello
                 sendClientHello()
             }
+        }
+
+        override fun onMessage(text: String, rawUtf8: ByteArray) {
+            // The Noise prologue is built from the EXACT bytes of server/init as
+            // received, so the driver gets rawUtf8 and never a re-encoding.
+            val driver = handshakeDriver
+            if (driver != null && driver.phase != SendSpinHandshakeDriver.Phase.Transport) {
+                lastByteReceivedAtMs.set(System.currentTimeMillis())
+                driver.onCleartextFrame(rawUtf8)
+                return
+            }
+            onMessage(text)
         }
 
         override fun onMessage(text: String) {

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -3,11 +3,13 @@ package com.sendspindroid.sendspin.protocol
 import android.util.Log
 import com.sendspindroid.sendspin.AdaptiveBufferPolicy
 import com.sendspindroid.sendspin.SendspinTimeFilter
+import com.sendspindroid.sendspin.crypto.NoiseTransport
 import com.sendspindroid.sendspin.protocol.message.BinaryMessageParser
 import com.sendspindroid.sendspin.protocol.message.MessageBuilder
 import com.sendspindroid.sendspin.protocol.message.MessageParser
 import com.sendspindroid.sendspin.protocol.timesync.TimeSyncManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -78,9 +80,17 @@ abstract class SendSpinProtocolHandler(
     // ========== Abstract Transport Methods ==========
 
     /**
-     * Send a text message over the WebSocket.
+     * Send a raw WebSocket TEXT frame.
+     *
+     * After the Noise handshake this is a protocol violation - "all messages
+     * are sent as WebSocket binary frames carrying Noise transport ciphertexts".
+     * Only the handshake driver and the legacy path may call it; everything else
+     * goes through [sendProtocolMessage].
      */
     protected abstract fun sendTextMessage(text: String)
+
+    /** Send a raw WebSocket BINARY frame. */
+    protected abstract fun sendBinaryFrame(bytes: ByteArray)
 
     /**
      * Get the coroutine scope for async operations.
@@ -226,7 +236,7 @@ abstract class SendSpinProtocolHandler(
             supportedFormats = formats,
             softwareVersion = getSoftwareVersion()
         )
-        sendTextMessage(text)
+        sendProtocolMessage(text)
         Log.d(tag, "Sent client/hello: ${text.take(500)}")
     }
 
@@ -235,7 +245,7 @@ abstract class SendSpinProtocolHandler(
      */
     protected fun sendClientTime() {
         val clientTransmitted = System.nanoTime() / 1000 // Convert to microseconds
-        sendTextMessage(MessageBuilder.buildClientTime(clientTransmitted))
+        sendProtocolMessage(MessageBuilder.buildClientTime(clientTransmitted))
     }
 
     /**
@@ -243,7 +253,7 @@ abstract class SendSpinProtocolHandler(
      */
     protected fun sendGoodbye(reason: String) {
         if (!handshakeComplete) return
-        sendTextMessage(MessageBuilder.buildGoodbye(reason))
+        sendProtocolMessage(MessageBuilder.buildGoodbye(reason))
     }
 
     /**
@@ -256,7 +266,7 @@ abstract class SendSpinProtocolHandler(
             lastReportedMinBufferMs = target
             target
         }
-        sendTextMessage(
+        sendProtocolMessage(
             MessageBuilder.buildPlayerState(
                 currentVolume, currentMuted, currentSyncState, delayMs,
                 minBufferMs = minBufferMs
@@ -439,7 +449,7 @@ abstract class SendSpinProtocolHandler(
             Log.w(tag, "Dropping controller command '$command': not in server supported_commands $supported")
             return
         }
-        sendTextMessage(MessageBuilder.buildCommand(command, volume, mute))
+        sendProtocolMessage(MessageBuilder.buildCommand(command, volume, mute))
     }
 
     /**
@@ -456,7 +466,7 @@ abstract class SendSpinProtocolHandler(
     ) {
         if (!handshakeComplete) return
         Log.i(tag, "Requesting stream format: codec=$codec, rate=$sampleRate, ch=$channels, bits=$bitDepth")
-        sendTextMessage(MessageBuilder.buildStreamRequestFormat(codec, sampleRate, channels, bitDepth))
+        sendProtocolMessage(MessageBuilder.buildStreamRequestFormat(codec, sampleRate, channels, bitDepth))
     }
 
     // ========== Player State Methods ==========
@@ -530,6 +540,70 @@ abstract class SendSpinProtocolHandler(
             onMeasurementApplied = { rttMicros -> onTimeMeasurement(rttMicros) },
             tag = tag
         )
+    }
+
+    // ========== Encrypted channel ==========
+
+    /**
+     * Set once the Noise handshake completes. Null means the legacy
+     * (unencrypted) dialect, which Music Assistant still accepts today behind
+     * its `allow_legacy_clients` toggle but has documented as temporary.
+     *
+     * This one field is what switches the whole protocol layer between the two
+     * wire formats: every existing caller of [sendProtocolMessage] becomes
+     * encrypted with no further edits, and [handleBinaryMessage] routes through
+     * the codec instead of parsing a bare frame.
+     */
+    @Volatile
+    private var wireCodec: NoiseWireCodec? = null
+
+    /** True once the connection is carrying Noise ciphertexts. */
+    val isEncrypted: Boolean get() = wireCodec != null
+
+    /** Install the transport produced by the handshake driver. */
+    fun installEncryptedTransport(transport: NoiseTransport) {
+        wireCodec = NoiseWireCodec(transport)
+        Log.i(tag, "Encrypted channel established")
+    }
+
+    /** Drop the encrypted channel (disconnect, or falling back to legacy). */
+    fun clearEncryptedTransport() {
+        wireCodec = null
+    }
+
+    /**
+     * Send an application protocol message.
+     *
+     * Encrypted when a Noise transport is installed, a plain text frame
+     * otherwise. Callers do not need to know which.
+     */
+    protected fun sendProtocolMessage(text: String) {
+        val codec = wireCodec
+        if (codec == null) {
+            // Legacy dialect: a plain text frame.
+            sendTextMessage(text)
+            return
+        }
+        // encodeJson takes the send mutex, so this has to be in a coroutine.
+        getCoroutineScope().launch {
+            try {
+                codec.encodeJson(text).forEach { sendBinaryFrame(it) }
+            } catch (e: Exception) {
+                Log.e(tag, "Failed to encrypt outbound message", e)
+                onProtocolFailure("outbound encryption failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * A protocol-level failure that requires closing the socket.
+     *
+     * The spec allows no application-level error message for these, so the only
+     * thing to do is close - and the only diagnostic anyone will ever have is
+     * the log line the implementation writes here.
+     */
+    protected open fun onProtocolFailure(reason: String) {
+        Log.e(tag, "Protocol failure: $reason")
     }
 
     // ========== Message Handling ==========
@@ -728,9 +802,24 @@ abstract class SendSpinProtocolHandler(
      * Handle binary message from the transport.
      */
     protected fun handleBinaryMessage(bytes: ByteArray) {
-        val message = BinaryMessageParser.parse(bytes)
-        if (message != null) {
-            dispatchBinaryMessage(message)
+        val codec = wireCodec
+        if (codec == null) {
+            // Legacy path: the frame is a bare SendSpin binary message.
+            BinaryMessageParser.parse(bytes)?.let { dispatchBinaryMessage(it) }
+            return
+        }
+        when (val decoded = codec.decode(bytes)) {
+            is NoiseWireCodec.Decoded.Json -> handleTextMessage(decoded.text)
+            is NoiseWireCodec.Decoded.Typed ->
+                BinaryMessageParser.parse(decoded.type, decoded.body)
+                    ?.let { dispatchBinaryMessage(it) }
+            is NoiseWireCodec.Decoded.Fragment ->
+                // Reassembly lands in item 1.5. Until then a fragmented message
+                // is unreadable, and silently ignoring it would strand the
+                // stream; the spec's answer to an unhandleable frame is to close.
+                onProtocolFailure("fragmentation is not implemented yet (item 1.5)")
+            is NoiseWireCodec.Decoded.ProtocolError ->
+                onProtocolFailure(decoded.reason)
         }
     }
 

--- a/android/app/src/test/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandlerTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandlerTest.kt
@@ -472,6 +472,13 @@ class TestProtocolHandler : SendSpinProtocolHandler("TestHandler") {
         sentMessages.add(text)
     }
 
+    /** Frames sent on the encrypted path, in order. */
+    val sentBinaryFrames = mutableListOf<ByteArray>()
+
+    override fun sendBinaryFrame(bytes: ByteArray) {
+        sentBinaryFrames.add(bytes)
+    }
+
     override fun getCoroutineScope(): CoroutineScope = testScope
 
     override fun getTimeFilter(): SendspinTimeFilter = timeFilter

--- a/android/conformance-client/build.gradle.kts
+++ b/android/conformance-client/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
 dependencies {
     implementation(project(":shared"))
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
 }
 
@@ -31,4 +32,13 @@ tasks.register<Jar>("fatJar") {
     from({
         configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) }
     })
+}
+
+// End-to-end check of the encrypted wire layer against a live server.
+// See ci/conformance/dev_server.py.
+tasks.register<JavaExec>("noiseCheck") {
+    group = "verification"
+    mainClass.set("com.sendspindroid.conformance.NoiseHandshakeCheck")
+    classpath = sourceSets["main"].runtimeClasspath
+    args = (project.findProperty("url") as String?)?.let { listOf(it) } ?: emptyList()
 }

--- a/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
+++ b/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
@@ -1,0 +1,158 @@
+package com.sendspindroid.conformance
+
+import com.sendspindroid.sendspin.crypto.ClientIdentity
+import com.sendspindroid.sendspin.crypto.PskCandidateSet
+import com.sendspindroid.sendspin.protocol.NoiseWireCodec
+import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end check of the encrypted wire layer against a real server.
+ *
+ * Drives the same [SendSpinHandshakeDriver] and [NoiseWireCodec] the Android app
+ * uses, over a real WebSocket, against an aiosendspin server running with
+ * `allow_unencrypted=False`. Host tests prove the layer against recorded
+ * transcripts; this proves it against a server that will refuse anything it does
+ * not like.
+ *
+ * Usage: `NoiseHandshakeCheck <ws://host:port/sendspin>`
+ */
+object NoiseHandshakeCheck {
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val url = args.firstOrNull() ?: "ws://127.0.0.1:8927/sendspin"
+        val identity = ClientIdentity.generate()
+        println("client_id: ${identity.clientId}")
+        println("connecting: $url")
+
+        val done = CountDownLatch(1)
+        var failure: String? = null
+        var codec: NoiseWireCodec? = null
+        var sawServerHello = false
+
+        val client = OkHttpClient.Builder()
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+
+        lateinit var socket: WebSocket
+        lateinit var driver: SendSpinHandshakeDriver
+
+        fun fail(reason: String) {
+            if (failure == null) failure = reason
+            done.countDown()
+        }
+
+        driver = SendSpinHandshakeDriver(
+            identity = identity,
+            candidates = PskCandidateSet.sentinelOnly(),
+            onEvent = { event ->
+                when (event) {
+                    is SendSpinHandshakeDriver.Event.SendCleartext -> {
+                        println("-> text  ${event.text.take(120)}")
+                        socket.send(event.text)
+                    }
+                    is SendSpinHandshakeDriver.Event.TransportReady -> {
+                        println("HANDSHAKE OK")
+                        println("   server_id : ${event.serverInit.serverId}")
+                        println("   matched   : ${event.matchedPsk.category} ${event.matchedPsk.pskId}")
+                        println("   h         : ${event.transport.handshakeHash.toHex().take(32)}...")
+                        val c = NoiseWireCodec(event.transport)
+                        codec = c
+                        // First encrypted message: client/hello.
+                        val hello = """{"type":"client/hello","payload":{"name":"NoiseHandshakeCheck",""" +
+                            """"trust_level":"none","supported_roles":["player@v1"],""" +
+                            """"player@v1_support":{"supported_formats":[{"codec":"pcm",""" +
+                            """"sample_rate":48000,"channels":2,"bit_depth":16}],""" +
+                            """"buffer_capacity":1680000,"supported_commands":["volume","mute"]},""" +
+                            """"supported_pair_methods":[],"unpaired_access":{"enabled":true}}}"""
+                        runBlocking {
+                            c.encodeJson(hello).forEach { socket.send(ByteString.of(*it)) }
+                        }
+                        println("-> enc   client/hello (${hello.length} bytes plaintext)")
+                    }
+                    is SendSpinHandshakeDriver.Event.Fail ->
+                        fail("${event.reason}: ${event.detail}")
+                }
+            },
+        )
+
+        socket = client.newWebSocket(Request.Builder().url(url).build(), object : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                println("socket open")
+                driver.start()
+            }
+
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                // Cleartext handshake frames. okhttp hands us a String; the raw
+                // bytes are its UTF-8 encoding, which for a frame okhttp itself
+                // decoded is byte-identical.
+                driver.onCleartextFrame(text.toByteArray(Charsets.UTF_8))
+            }
+
+            override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+                val c = codec
+                if (c == null) {
+                    fail("binary frame before transport mode")
+                    return
+                }
+                when (val decoded = c.decode(bytes.toByteArray())) {
+                    is NoiseWireCodec.Decoded.Json -> {
+                        println("<- enc   ${decoded.text.take(160)}")
+                        if (decoded.text.contains("server/hello")) sawServerHello = true
+                        // server/activate means the server accepted us.
+                        if (decoded.text.contains("server/activate")) done.countDown()
+                    }
+                    is NoiseWireCodec.Decoded.Typed ->
+                        println("<- enc   binary type=${decoded.type} ${decoded.body.size} bytes")
+                    is NoiseWireCodec.Decoded.Fragment ->
+                        println("<- enc   fragment type=${decoded.type}")
+                    is NoiseWireCodec.Decoded.ProtocolError ->
+                        fail("decode failed: ${decoded.reason}")
+                }
+            }
+
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                fail("socket failure: ${t.message}")
+            }
+
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                println("socket closed: $code $reason")
+                done.countDown()
+            }
+        })
+
+        val finished = done.await(30, TimeUnit.SECONDS)
+        socket.close(1000, "done")
+        client.dispatcher.executorService.shutdown()
+
+        println()
+        val err = failure
+        when {
+            err != null -> {
+                println("FAIL: $err")
+                kotlin.system.exitProcess(1)
+            }
+            !finished -> {
+                println("FAIL: timed out before server/activate")
+                kotlin.system.exitProcess(1)
+            }
+            !sawServerHello -> {
+                println("FAIL: handshake completed but no encrypted server/hello arrived")
+                kotlin.system.exitProcess(1)
+            }
+            else -> println("PASS: encrypted handshake and application traffic verified")
+        }
+    }
+
+    private fun ByteArray.toHex(): String =
+        joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/ClientIdentity.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/ClientIdentity.kt
@@ -1,0 +1,63 @@
+package com.sendspindroid.sendspin.crypto
+
+/**
+ * The client's Sendspin identity: a long-lived Curve25519 keypair whose public
+ * half IS the `client_id`.
+ *
+ * `README.md#definitions`: "A Curve25519 keypair used to identify a client or
+ * server in the Noise handshake. The base64url-encoded public key (43
+ * characters, no padding) serves as the `client_id` or `server_id`. Persistent
+ * across reboots."
+ *
+ * That persistence is not cosmetic. The key is a pre-message input to every
+ * KKpsk2 handshake, and it is half of the pairing token. Regenerating it makes
+ * the client a different device to every server it has ever paired with, and
+ * the resulting failure is a silent socket close.
+ *
+ * The private key never leaves this object; [toString] renders only the public
+ * identifier so a stray log line cannot leak it.
+ */
+class ClientIdentity(privateKey: ByteArray) {
+
+    init {
+        require(privateKey.size == KEY_SIZE) {
+            "a Curve25519 private key is $KEY_SIZE bytes, got ${privateKey.size}"
+        }
+    }
+
+    private val secret = privateKey.copyOf()
+
+    /** The raw 32-byte public key, as the Noise handshake needs it. */
+    val publicKey: ByteArray = x25519PublicKey(secret)
+
+    /** The 43-character base64url `client_id` that goes on the wire. */
+    val clientId: String = Base64Url.encode(publicKey)
+
+    /** A copy. The caller must not retain it longer than the handshake. */
+    internal fun privateKeyBytes(): ByteArray = secret.copyOf()
+
+    override fun toString(): String = "ClientIdentity($clientId)"
+
+    companion object {
+        const val KEY_SIZE = 32
+
+        /** Mint a new identity from the platform CSPRNG. */
+        fun generate(): ClientIdentity = ClientIdentity(secureRandomBytes(KEY_SIZE))
+
+        /**
+         * Rebuild from a stored private key.
+         *
+         * @return null if [base64Url] is not a 32-byte base64url value. The
+         *   caller must treat that as "no identity stored" rather than silently
+         *   minting a new one over the top - see the storage layer.
+         */
+        fun fromStoredKey(base64Url: String): ClientIdentity? {
+            val bytes = Base64Url.decodeOrNull(base64Url) ?: return null
+            return if (bytes.size == KEY_SIZE) ClientIdentity(bytes) else null
+        }
+
+        /** Encode a private key for storage. */
+        fun encodeForStorage(identity: ClientIdentity): String =
+            Base64Url.encode(identity.secret)
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriver.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriver.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid.sendspin.protocol
 
 import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.crypto.ClientIdentity
 import com.sendspindroid.sendspin.crypto.NoiseCipherSuite
 import com.sendspindroid.sendspin.crypto.NoiseHandshake
 import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
@@ -40,8 +41,7 @@ import kotlinx.serialization.json.jsonPrimitive
  * (`connection.md#failure-handling`).
  */
 class SendSpinHandshakeDriver(
-    private val clientId: String,
-    private val clientStaticPrivateKey: ByteArray,
+    private val identity: ClientIdentity,
     private val candidates: PskCandidateSet,
     private val suite: NoiseCipherSuite = DEFAULT_SUITE,
     private val onEvent: (Event) -> Unit = {},
@@ -89,7 +89,7 @@ class SendSpinHandshakeDriver(
         if (phase != Phase.New) return fail(
             NoiseHandshakeException.Cause.WrongPhase, "start() called in $phase"
         )
-        val text = InitMessages.buildClientInit(clientId, suite.wireName)
+        val text = InitMessages.buildClientInit(identity.clientId, suite.wireName)
         clientInitSent = text
         phase = Phase.AwaitingServerInit
         onEvent(Event.SendCleartext(text))
@@ -157,7 +157,7 @@ class SendSpinHandshakeDriver(
         val override = ephemeralOverrideForTest
         handshake = if (override == null) {
             NoiseHandshake.responder(
-                staticPrivateKey = clientStaticPrivateKey,
+                staticPrivateKey = identity.privateKeyBytes(),
                 remoteStaticPublicKey = parsed.serverStaticKey,
                 suite = suite,
                 prologue = prologue,
@@ -165,7 +165,7 @@ class SendSpinHandshakeDriver(
         } else {
             NoiseHandshake(
                 suite = suite,
-                staticPrivateKey = clientStaticPrivateKey,
+                staticPrivateKey = identity.privateKeyBytes(),
                 remoteStaticPublicKey = parsed.serverStaticKey,
                 prologue = prologue,
                 generateEphemeral = override,

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/BinaryMessageParser.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/BinaryMessageParser.kt
@@ -92,7 +92,39 @@ object BinaryMessageParser {
     }
 
     /**
-     * Parse binary message from a ByteArray.
+     * Parse a binary message whose type byte has already been stripped.
+     *
+     * This is the encrypted path: [com.sendspindroid.sendspin.protocol.NoiseWireCodec]
+     * removes the type byte when it decrypts, so re-deriving it here would mean
+     * stripping it twice. [body] is the remainder, still
+     * `[8-byte big-endian timestamp][payload]`.
+     */
+    fun parse(type: Int, body: ByteArray): BinaryMessage? {
+        if (body.size < TIMESTAMP_SIZE) {
+            Log.w(TAG, "Binary message body too short: ${body.size} bytes")
+            return null
+        }
+        val timestampMicros = readTimestamp(body, 0)
+        return createMessage(type, timestampMicros, body.copyOfRange(TIMESTAMP_SIZE, body.size))
+    }
+
+    private const val TIMESTAMP_SIZE = 8
+
+    private fun readTimestamp(bytes: ByteArray, offset: Int): Long =
+        ((bytes[offset].toLong() and 0xFF) shl 56) or
+            ((bytes[offset + 1].toLong() and 0xFF) shl 48) or
+            ((bytes[offset + 2].toLong() and 0xFF) shl 40) or
+            ((bytes[offset + 3].toLong() and 0xFF) shl 32) or
+            ((bytes[offset + 4].toLong() and 0xFF) shl 24) or
+            ((bytes[offset + 5].toLong() and 0xFF) shl 16) or
+            ((bytes[offset + 6].toLong() and 0xFF) shl 8) or
+            (bytes[offset + 7].toLong() and 0xFF)
+
+    /**
+     * Parse a whole binary frame, type byte included.
+     *
+     * The legacy (unencrypted) path and the conformance client still receive
+     * frames this way.
      */
     fun parse(bytes: ByteArray): BinaryMessage? {
         if (bytes.size < HEADER_SIZE) {
@@ -101,18 +133,7 @@ object BinaryMessageParser {
         }
 
         val msgType = bytes[0].toInt() and 0xFF
-
-        // Extract timestamp (big-endian int64) from bytes 1-8
-        val timestampMicros = ((bytes[1].toLong() and 0xFF) shl 56) or
-                ((bytes[2].toLong() and 0xFF) shl 48) or
-                ((bytes[3].toLong() and 0xFF) shl 40) or
-                ((bytes[4].toLong() and 0xFF) shl 32) or
-                ((bytes[5].toLong() and 0xFF) shl 24) or
-                ((bytes[6].toLong() and 0xFF) shl 16) or
-                ((bytes[7].toLong() and 0xFF) shl 8) or
-                (bytes[8].toLong() and 0xFF)
-
-        // Get payload (everything after header)
+        val timestampMicros = readTimestamp(bytes, 1)
         val payload = bytes.copyOfRange(HEADER_SIZE, bytes.size)
 
         return createMessage(msgType, timestampMicros, payload)

--- a/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriverTest.kt
+++ b/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriverTest.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid.sendspin.protocol
 
 import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.crypto.ClientIdentity
 import com.sendspindroid.sendspin.crypto.NoiseHandshake
 import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
 import com.sendspindroid.sendspin.crypto.Psk
@@ -58,8 +59,7 @@ class SendSpinHandshakeDriverTest {
      */
     private fun driverWith(recorder: Recorder): SendSpinHandshakeDriver =
         SendSpinHandshakeDriver(
-            clientId = WireTestVectors.clientId,
-            clientStaticPrivateKey = hex(WireTestVectors.clientStaticPrivate),
+            identity = ClientIdentity(hex(WireTestVectors.clientStaticPrivate)),
             candidates = candidates,
             onEvent = recorder::handle,
             ephemeralOverrideForTest = { hex(WireTestVectors.clientEphemeralPrivate) },
@@ -158,8 +158,7 @@ class SendSpinHandshakeDriverTest {
     fun anUnknownPskIdFailsAsALookupMiss() {
         val r = Recorder()
         val driver = SendSpinHandshakeDriver(
-            clientId = WireTestVectors.clientId,
-            clientStaticPrivateKey = hex(WireTestVectors.clientStaticPrivate),
+            identity = ClientIdentity(hex(WireTestVectors.clientStaticPrivate)),
             // Sentinel only: the transcript's PSK is not a candidate.
             candidates = PskCandidateSet.sentinelOnly(),
             onEvent = r::handle,
@@ -177,8 +176,7 @@ class SendSpinHandshakeDriverTest {
         val wrongBinding = Psk(hex(WireTestVectors.psk), PskCategory.LONG_TERM, "some-other-server")
         val r = Recorder()
         val driver = SendSpinHandshakeDriver(
-            clientId = WireTestVectors.clientId,
-            clientStaticPrivateKey = hex(WireTestVectors.clientStaticPrivate),
+            identity = ClientIdentity(hex(WireTestVectors.clientStaticPrivate)),
             candidates = PskCandidateSet.of(listOf(wrongBinding)).getOrThrow(),
             onEvent = r::handle,
             ephemeralOverrideForTest = { hex(WireTestVectors.clientEphemeralPrivate) },

--- a/ci/conformance/dev_server.py
+++ b/ci/conformance/dev_server.py
@@ -215,6 +215,16 @@ class DevServer:
     # -- console -----------------------------------------------------------
 
     async def console(self) -> None:
+        if self._args.no_console or not sys.stdin.isatty():
+            # Started from a script, nohup, or CI. Without this the first
+            # readline() returns EOF immediately and the server shuts down a
+            # moment after reporting that it started successfully - which looks
+            # exactly like a crash on connect. isatty() is not reliable on
+            # Windows shells, hence the explicit flag.
+            LOGGER.info("stdin is not a terminal; console disabled, serving until killed")
+            while True:
+                await asyncio.sleep(3600)
+
         loop = asyncio.get_running_loop()
         self._print_help()
         while True:
@@ -316,6 +326,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--trust-all-unpaired",
         action="store_true",
         help="auto-trust every unpaired client so it becomes playback-capable",
+    )
+    parser.add_argument(
+        "--no-console",
+        action="store_true",
+        help="do not read commands from stdin; serve until killed",
     )
     parser.add_argument(
         "--debug",


### PR DESCRIPTION
Completes the rewiring half of #195, and lands #192's identity keypair because
the handshake cannot reach a real server without it.

Closes #192. Closes #195.

## It actually talks to a server now

A live encrypted handshake against aiosendspin with `allow_unencrypted=False`,
driving the same driver and codec the app uses:

```
-> text  {"type":"client/init","payload":{"client_id":"RA-Sv-QAf5mnmsBjfeGUvL7I_6yzVZlZTB1QOrFp1kQ",...
-> text  {"type":"noise/handshake","payload":{"data":"vETe3BcPsEJFtV5WTU83bEsDn63j..."}}
HANDSHAKE OK
   server_id : 27y1gs7PQrYzngkl7Sn5ba8G5CWvqSvJ41smt14r0Qg
   matched   : SENTINEL GFsV9tLaSQm9HcFWpKsgYQOr7wFTvNUtkmFwuVz3zoo
-> enc   client/hello
<- enc   {"payload":{"name":"Dev Encrypted"},"type":"server/hello"}
<- enc   {"payload":{"activities":[],"active_roles":[]},"type":"server/activate"}
```

First time this client has spoken the current protocol to a server that refuses
the old one. The matched PSK is the published Sentinel `psk_id` from #194 —
derived independently and agreed on by both sides. Reproduce with
`:conformance-client:noiseCheck -Purl=...` against the #190 dev server.

## How the switch works

One field on the protocol handler decides the wire format. With a Noise
transport installed, `sendProtocolMessage` encrypts through the codec and
`handleBinaryMessage` decrypts through it; with none, both take the legacy path.
Every existing sender — `client/time`, `client/state`, goodbye, commands,
request-format — became encrypted by changing **where it routes, not what it
sends**.

## Identity (#192)

An encrypted session's `client_id` is the base64url Curve25519 public key, not
the legacy UUID player id — a server rejects anything that isn't 43 characters.
`ClientIdentity` persists with `commit()` not `apply()`, and **refuses to replace
a stored key it cannot read**: quietly minting a new one would unpair the device
from every server it knows, and the spec reports that as a silent close.

The private key never leaves `:shared` — the driver takes a `ClientIdentity`
rather than raw bytes, because `internal` visibility doesn't cross module
boundaries and the alternative was a public getter for a secret.

## Off by default

`useEncryption` defaults to **false**. MA still accepts the legacy dialect behind
`allow_legacy_clients`, and flipping this before the path has run against a real
MA build would strand every user on a stable server. Automatic negotiation —
try encrypted, fall back once on a handshake-phase close — is #201, and that's
the item that should flip the default.

## Two bugs worth noting

I introduced infinite recursion doing a bulk rename: the edit rewrote
`sendProtocolMessage`'s own legacy branch into a self-call. Caught before
compiling, but it's the hazard of scripted edits over line numbers.

`dev_server.py` grew `--no-console`. `isatty()` is unreliable on Windows shells,
so the server was exiting immediately after logging that it started
successfully — which reads exactly like a crash on connect, and cost me two
debug cycles before I checked whether anything was listening.

```
shared : 511 tests, 0 failed
app    : 722 tests, 0 failed
```

## Not in this PR

- `useEncryption` is not surfaced in Settings — it's a programmatic flag until
  #201 makes the choice automatic.
- No on-device encrypted connection. The handshake is verified over a real
  socket from the JVM, and the crypto is verified on-device by #231's suite, but
  the two haven't been combined.
- Fragmentation (#196) still throws on an oversized payload rather than
  splitting; a decoded fragment frame is treated as a protocol failure.
