### PR TITLE
1.6 + 1.7: enforce the server/activate admissibility table, gate output on it

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -9,6 +9,7 @@ import androidx.preference.PreferenceManager
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import java.util.UUID
+import com.sendspindroid.sendspin.crypto.ClientIdentity
 
 /**
  * Centralized access to user settings stored in SharedPreferences.
@@ -178,6 +179,63 @@ object UserSettings {
      * in memory. The cached ID is persisted when initialize() runs.
      * Double-checked locking ensures only one UUID is ever generated.
      */
+    // ========== Sendspin identity (Curve25519) ==========
+
+    private const val KEY_NOISE_IDENTITY = "sendspin_noise_identity"
+
+    @Volatile
+    private var cachedIdentity: ClientIdentity? = null
+
+    /**
+     * The client's persistent Sendspin identity.
+     *
+     * Its public half is the `client_id` on the wire, and it is a pre-message
+     * input to every Noise handshake, so losing it makes this device a stranger
+     * to every server it has paired with - and the failure mode the spec
+     * prescribes is a silent socket close.
+     *
+     * Stored in [sensitivePrefs] with `commit()` rather than `apply()`: an
+     * async write that loses a race with process death would mint a different
+     * identity on next launch, breaking pairings with nothing to point at.
+     *
+     * A stored value that will not decode is NOT silently replaced. That state
+     * means something went wrong, and quietly generating a new identity would
+     * convert a recoverable problem into permanent, invisible unpairing.
+     */
+    fun getOrCreateClientIdentity(): ClientIdentity {
+        cachedIdentity?.let { return it }
+        synchronized(this) {
+            cachedIdentity?.let { return it }
+
+            val stored = sensitivePrefs?.getString(KEY_NOISE_IDENTITY, null)
+            if (!stored.isNullOrBlank()) {
+                val restored = ClientIdentity.fromStoredKey(stored)
+                if (restored != null) {
+                    cachedIdentity = restored
+                    return restored
+                }
+                Log.e(
+                    TAG,
+                    "Stored Sendspin identity is unreadable. Refusing to overwrite it: " +
+                        "minting a new one would silently unpair this device from every " +
+                        "server. Clear app data deliberately if that is what you want."
+                )
+                error("stored Sendspin identity is corrupt")
+            }
+
+            val fresh = ClientIdentity.generate()
+            val ok = sensitivePrefs?.edit()
+                ?.putString(KEY_NOISE_IDENTITY, ClientIdentity.encodeForStorage(fresh))
+                ?.commit() ?: false
+            if (!ok) {
+                Log.w(TAG, "Could not persist the Sendspin identity; it will not survive restart")
+            }
+            cachedIdentity = fresh
+            Log.i(TAG, "Generated Sendspin identity ${fresh.clientId}")
+            return fresh
+        }
+    }
+
     fun getPlayerId(): String {
         // Fast path: prefs available and ID already stored
         val p = prefs

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -10,6 +10,8 @@ import com.sendspindroid.sendspin.transport.ProxyWebSocketTransport
 import com.sendspindroid.sendspin.protocol.ControllerState
 import com.sendspindroid.sendspin.protocol.GroupInfo
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+import com.sendspindroid.sendspin.crypto.PskCandidateSet
+import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
 import com.sendspindroid.sendspin.protocol.SendSpinProtocolHandler
 import com.sendspindroid.sendspin.protocol.StreamConfig
 import com.sendspindroid.sendspin.protocol.TrackMetadata
@@ -314,11 +316,83 @@ class SendSpin(
 
     // ========== SendSpinProtocolHandler Implementation ==========
 
+    // ========== Encrypted handshake (spec) ==========
+
+    /**
+     * Whether to attempt the spec's encrypted handshake.
+     *
+     * Defaults to off. Music Assistant still accepts the legacy dialect behind
+     * its `allow_legacy_clients` toggle, and flipping this default before the
+     * encrypted path has run against a real server would strand every user on a
+     * stable MA build. Automatic negotiation - try encrypted, fall back once on
+     * a handshake-phase close - is item 1.10 (#201); until then this is an
+     * explicit opt-in so the path can be exercised against the dev server.
+     */
+    @Volatile
+    var useEncryption: Boolean = false
+
+    private var handshakeDriver: SendSpinHandshakeDriver? = null
+
+    private fun startEncryptedHandshake() {
+        // The wire client_id for an encrypted session is the base64url public
+        // key, NOT the legacy UUID player id - the two are different
+        // identifiers and the server rejects a non-43-character value.
+        val identity = UserSettings.getOrCreateClientIdentity()
+        val driver = SendSpinHandshakeDriver(
+            identity = identity,
+            candidates = pskCandidates(),
+            onEvent = ::onHandshakeEvent,
+        )
+        handshakeDriver = driver
+        driver.start()
+    }
+
+    private fun onHandshakeEvent(event: SendSpinHandshakeDriver.Event) {
+        when (event) {
+            is SendSpinHandshakeDriver.Event.SendCleartext ->
+                // Cleartext handshake frames are the only text frames the spec
+                // permits; everything after transport mode is binary.
+                sendTextMessage(event.text)
+
+            is SendSpinHandshakeDriver.Event.TransportReady -> {
+                Log.i(TAG, "Noise handshake complete with ${event.serverInit.serverId} " +
+                    "(psk=${event.matchedPsk.category})")
+                installEncryptedTransport(event.transport)
+                // client/hello is the first ENCRYPTED message, not the first
+                // frame on the socket. It now rides the codec like everything
+                // else.
+                sendClientHello()
+            }
+
+            is SendSpinHandshakeDriver.Event.Fail -> {
+                // The spec allows no application-level error message here, so
+                // this log line is the only diagnostic that will ever exist.
+                Log.e(TAG, "Noise handshake failed: ${event.reason} - ${event.detail}")
+                handshakeDriver = null
+                _connectionState.value = TransportState.Failed(FailureReason.HandshakeFailed)
+                transport?.close(1002, "handshake failed")
+            }
+        }
+    }
+
+    /**
+     * Phase 1 candidate set: the Sentinel alone, which is what an unpaired
+     * client presents. Pairing records join it in Phase 2 (#202).
+     */
+    private fun pskCandidates(): PskCandidateSet = PskCandidateSet.sentinelOnly()
+
     override fun sendTextMessage(text: String) {
         val t = transport ?: return  // Silently drop if transport is gone (e.g. post-disconnect race)
         val success = t.send(text)
         if (!success) {
             Log.w(TAG, "Failed to send message")
+        }
+    }
+
+    override fun sendBinaryFrame(bytes: ByteArray) {
+        val t = transport ?: return
+        if (!t.send(bytes)) {
+            Log.w(TAG, "Failed to send binary frame (${bytes.size} bytes)")
         }
     }
 
@@ -1346,10 +1420,28 @@ class SendSpin(
                 Log.e(TAG, "Proxy connection has no auth token - server will reject")
                 _connectionState.value = TransportState.Failed(FailureReason.AuthRejected)
                 disconnect()
+            } else if (useEncryption) {
+                // Spec order: client/init is the FIRST frame on the socket.
+                // client/hello moves after the Noise handshake and travels
+                // encrypted like every other application message.
+                Log.d(TAG, "Starting encrypted handshake")
+                startEncryptedHandshake()
             } else {
                 // Local/Remote mode: proceed directly with hello
                 sendClientHello()
             }
+        }
+
+        override fun onMessage(text: String, rawUtf8: ByteArray) {
+            // The Noise prologue is built from the EXACT bytes of server/init as
+            // received, so the driver gets rawUtf8 and never a re-encoding.
+            val driver = handshakeDriver
+            if (driver != null && driver.phase != SendSpinHandshakeDriver.Phase.Transport) {
+                lastByteReceivedAtMs.set(System.currentTimeMillis())
+                driver.onCleartextFrame(rawUtf8)
+                return
+            }
+            onMessage(text)
         }
 
         override fun onMessage(text: String) {

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.sendspindroid.sendspin.AdaptiveBufferPolicy
 import com.sendspindroid.sendspin.SendspinTimeFilter
 import com.sendspindroid.sendspin.crypto.NoiseTransport
+import com.sendspindroid.sendspin.crypto.PskCategory
 import com.sendspindroid.sendspin.protocol.message.BinaryMessageParser
 import com.sendspindroid.sendspin.protocol.message.MessageBuilder
 import com.sendspindroid.sendspin.protocol.message.MessageParser
@@ -671,6 +672,7 @@ abstract class SendSpinProtocolHandler(
 
             when (type) {
                 SendSpinProtocol.MessageType.SERVER_HELLO -> handleServerHello(payload)
+                SendSpinProtocol.MessageType.SERVER_ACTIVATE -> handleServerActivate(payload)
                 SendSpinProtocol.MessageType.SERVER_TIME -> handleServerTime(payload)
                 SendSpinProtocol.MessageType.SERVER_STATE -> handleServerState(payload)
                 SendSpinProtocol.MessageType.SERVER_COMMAND -> handleServerCommand(payload)
@@ -693,8 +695,11 @@ abstract class SendSpinProtocolHandler(
             return
         }
 
-        Log.i(tag, "server/hello: name=${result.serverName}, id=${result.serverId}, reason=${result.connectionReason}")
-        Log.d(tag, "Active roles: ${result.activeRoles}")
+        // server/hello carries only `name` in the current spec. active_roles
+        // moved to server/activate and connection_reason was an aiosendspin
+        // legacy-mode invention; both are still parsed for the legacy dialect
+        // but must not be acted on here.
+        Log.i(tag, "server/hello: name=${result.serverName}")
 
         handshakeComplete = true
 
@@ -705,11 +710,107 @@ abstract class SendSpinProtocolHandler(
         lastPlaybackState = null
         lastGroupInfo = null
         currentControllerState = null
+        activationSeen = false
+        activeRoles = emptyList()
 
         onHandshakeComplete(result.serverName, result.serverId)
 
-        sendPlayerStateUpdate()
-        startTimeSync()
+        if (isEncrypted) {
+            // "Only after receiving the initial server/activate should the
+            // client send any other messages (including client/time and the
+            // initial client/state)." Starting either here would put frames on
+            // the wire before the server has told us what this connection is
+            // for.
+            Log.d(tag, "Waiting for server/activate before sending state or time")
+        } else {
+            sendPlayerStateUpdate()
+            startTimeSync()
+        }
+    }
+
+    /** True once the first server/activate has been accepted on this connection. */
+    @Volatile
+    protected var activationSeen = false
+        private set
+
+    /** Roles the server has activated, persisted across activations that omit them. */
+    @Volatile
+    protected var activeRoles: List<String> = emptyList()
+        private set
+
+    /** Activities currently declared on this connection. */
+    @Volatile
+    protected var activities: Set<Activity> = emptySet()
+        private set
+
+    /**
+     * The PSK category that admitted this connection. Drives the admissibility
+     * table; item 2.3 (#204) makes it follow the real handshake result.
+     */
+    protected open fun matchedPskCategory(): PskCategory = PskCategory.SENTINEL
+
+    /** Pairing methods this client currently offers, as live configuration. */
+    protected open fun offeredPairMethods(): Set<String> = setOf("pairing_psk")
+
+    protected fun handleServerActivate(payload: JsonObject?) {
+        val activate = ServerActivateRules.parse(payload)
+        if (activate == null) {
+            Log.e(tag, "server/activate missing required activities")
+            onProtocolFailure("malformed server/activate")
+            return
+        }
+        if (activate.unknownActivities.isNotEmpty()) {
+            // Forward compatibility: ignore, but say so - an unknown activity
+            // usually means the server is newer than we are.
+            Log.i(tag, "Ignoring unknown activities: ${activate.unknownActivities}")
+        }
+
+        val outcome = ServerActivateRules.evaluate(
+            activate = activate,
+            category = matchedPskCategory(),
+            unpairedAccessEnabled = isUnpairedAccessEnabled(),
+            previousRoles = activeRoles,
+            isFirstActivation = !activationSeen,
+            offeredPairMethods = offeredPairMethods(),
+        )
+
+        when (outcome) {
+            is ActivationOutcome.Close -> {
+                Log.w(tag, "Rejecting server/activate: ${outcome.goodbyeReason} " +
+                    "(activities=${activate.activities}, roles=${activate.activeRoles})")
+                sendGoodbye(outcome.goodbyeReason)
+                onProtocolFailure("server/activate not admissible: ${outcome.goodbyeReason}")
+            }
+
+            is ActivationOutcome.AbortPairing -> {
+                // Connection stays open; the server may re-activate with a
+                // method we do offer.
+                Log.w(tag, "Aborting pairing: ${outcome.reason}")
+                onPairAbort(outcome.reason)
+            }
+
+            is ActivationOutcome.Accept -> {
+                val first = !activationSeen
+                activities = activate.activities
+                activeRoles = outcome.activeRoles
+                activationSeen = true
+                Log.i(tag, "server/activate accepted: activities=${activate.activities} " +
+                    "roles=${outcome.activeRoles}")
+                if (first) {
+                    // Now, and only now, may we speak.
+                    sendPlayerStateUpdate()
+                    startTimeSync()
+                }
+            }
+        }
+    }
+
+    /**
+     * Send `pair/abort`. Item 2.9 (#226) owns the full reason enum and the
+     * attempt state machine; this is the one path 1.6 can already reach.
+     */
+    protected open fun onPairAbort(reason: String) {
+        sendProtocolMessage(MessageBuilder.buildPairAbort(reason))
     }
 
     protected fun handleServerTime(payload: JsonObject?) {

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -229,12 +229,17 @@ abstract class SendSpinProtocolHandler(
         }
         val bufferCapacity = MessageBuilder.calculateBufferCapacity(formats, bufferDuration)
         val text = MessageBuilder.buildClientHello(
-            clientId = getClientId(),
+            // On an encrypted session client_id and version live in
+            // client/init; repeating them here would be sending fields the
+            // spec does not define for this message.
+            clientId = if (isEncrypted) null else getClientId(),
             deviceName = getDeviceName(),
             bufferCapacity = bufferCapacity,
             manufacturer = getManufacturer(),
             supportedFormats = formats,
-            softwareVersion = getSoftwareVersion()
+            softwareVersion = getSoftwareVersion(),
+            trustLevel = getTrustLevel(),
+            unpairedAccessEnabled = isUnpairedAccessEnabled(),
         )
         sendProtocolMessage(text)
         Log.d(tag, "Sent client/hello: ${text.take(500)}")
@@ -257,7 +262,51 @@ abstract class SendSpinProtocolHandler(
     }
 
     /**
-     * Send player state update (volume/muted/sync state).
+     * Whether this client can currently participate in playback.
+     *
+     * Two conditions, and they mean different things:
+     *
+     * - The time filter must have converged. "A player MUST NOT report
+     *   `available: true` until its time filter has converged enough to begin
+     *   scheduling playback." Reporting availability early invites the server to
+     *   schedule audio against a clock estimate we do not trust yet.
+     * - The output must not be held by an external system. That is the ONLY
+     *   other meaning `available: false` carries since the spec replaced the old
+     *   `state` string (#115) - it is not a way to signal a sync problem.
+     *
+     * Note the asymmetry with the old tri-state: there is no longer any way to
+     * tell the server "I am here but unhealthy". A client that loses sync mid
+     * stream stays `available: true` and mutes its own output; going
+     * `available: false` would make the server move us to a solo group and
+     * require an explicit `switch` to get back, which is much more disruptive
+     * than a brief mute.
+     */
+    protected fun isAvailable(): Boolean {
+        if (externalSourceActive) return false
+        return getTimeFilter().isConverged
+    }
+
+    /**
+     * `'user'` when a pairing record exists for this server, `'none'` otherwise.
+     *
+     * Phase 1 has no record store, so this is always `'none'`. Item 2.1 (#202)
+     * gives it a real answer; 2.3 (#204) makes it follow the matched PSK.
+     */
+    protected open fun getTrustLevel(): String = MessageBuilder.TRUST_NONE
+
+    /**
+     * Whether this client admits a server holding no pairing record.
+     *
+     * This is what decides whether an unpaired connection can carry audio at
+     * all: the spec allows `['playback']` on a Sentinel-keyed session "only when
+     * the client has unpaired access enabled". Default on, so a fresh install
+     * plays before anyone has paired anything; item 3.2 (#228) lets a paired
+     * server toggle it.
+     */
+    protected open fun isUnpairedAccessEnabled(): Boolean = true
+
+    /**
+     * Send player state update (volume/muted/availability).
      */
     protected fun sendPlayerStateUpdate() {
         val delayMs = getTimeFilter().staticDelayMs
@@ -268,7 +317,7 @@ abstract class SendSpinProtocolHandler(
         }
         sendProtocolMessage(
             MessageBuilder.buildPlayerState(
-                currentVolume, currentMuted, currentSyncState, delayMs,
+                currentVolume, currentMuted, isAvailable(), delayMs,
                 minBufferMs = minBufferMs
             )
         )

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -3,11 +3,13 @@ package com.sendspindroid.sendspin.protocol
 import android.util.Log
 import com.sendspindroid.sendspin.AdaptiveBufferPolicy
 import com.sendspindroid.sendspin.SendspinTimeFilter
+import com.sendspindroid.sendspin.crypto.NoiseTransport
 import com.sendspindroid.sendspin.protocol.message.BinaryMessageParser
 import com.sendspindroid.sendspin.protocol.message.MessageBuilder
 import com.sendspindroid.sendspin.protocol.message.MessageParser
 import com.sendspindroid.sendspin.protocol.timesync.TimeSyncManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -78,9 +80,17 @@ abstract class SendSpinProtocolHandler(
     // ========== Abstract Transport Methods ==========
 
     /**
-     * Send a text message over the WebSocket.
+     * Send a raw WebSocket TEXT frame.
+     *
+     * After the Noise handshake this is a protocol violation - "all messages
+     * are sent as WebSocket binary frames carrying Noise transport ciphertexts".
+     * Only the handshake driver and the legacy path may call it; everything else
+     * goes through [sendProtocolMessage].
      */
     protected abstract fun sendTextMessage(text: String)
+
+    /** Send a raw WebSocket BINARY frame. */
+    protected abstract fun sendBinaryFrame(bytes: ByteArray)
 
     /**
      * Get the coroutine scope for async operations.
@@ -226,7 +236,7 @@ abstract class SendSpinProtocolHandler(
             supportedFormats = formats,
             softwareVersion = getSoftwareVersion()
         )
-        sendTextMessage(text)
+        sendProtocolMessage(text)
         Log.d(tag, "Sent client/hello: ${text.take(500)}")
     }
 
@@ -235,7 +245,7 @@ abstract class SendSpinProtocolHandler(
      */
     protected fun sendClientTime() {
         val clientTransmitted = System.nanoTime() / 1000 // Convert to microseconds
-        sendTextMessage(MessageBuilder.buildClientTime(clientTransmitted))
+        sendProtocolMessage(MessageBuilder.buildClientTime(clientTransmitted))
     }
 
     /**
@@ -243,7 +253,7 @@ abstract class SendSpinProtocolHandler(
      */
     protected fun sendGoodbye(reason: String) {
         if (!handshakeComplete) return
-        sendTextMessage(MessageBuilder.buildGoodbye(reason))
+        sendProtocolMessage(MessageBuilder.buildGoodbye(reason))
     }
 
     /**
@@ -256,7 +266,7 @@ abstract class SendSpinProtocolHandler(
             lastReportedMinBufferMs = target
             target
         }
-        sendTextMessage(
+        sendProtocolMessage(
             MessageBuilder.buildPlayerState(
                 currentVolume, currentMuted, currentSyncState, delayMs,
                 minBufferMs = minBufferMs
@@ -439,7 +449,7 @@ abstract class SendSpinProtocolHandler(
             Log.w(tag, "Dropping controller command '$command': not in server supported_commands $supported")
             return
         }
-        sendTextMessage(MessageBuilder.buildCommand(command, volume, mute))
+        sendProtocolMessage(MessageBuilder.buildCommand(command, volume, mute))
     }
 
     /**
@@ -456,7 +466,7 @@ abstract class SendSpinProtocolHandler(
     ) {
         if (!handshakeComplete) return
         Log.i(tag, "Requesting stream format: codec=$codec, rate=$sampleRate, ch=$channels, bits=$bitDepth")
-        sendTextMessage(MessageBuilder.buildStreamRequestFormat(codec, sampleRate, channels, bitDepth))
+        sendProtocolMessage(MessageBuilder.buildStreamRequestFormat(codec, sampleRate, channels, bitDepth))
     }
 
     // ========== Player State Methods ==========
@@ -530,6 +540,70 @@ abstract class SendSpinProtocolHandler(
             onMeasurementApplied = { rttMicros -> onTimeMeasurement(rttMicros) },
             tag = tag
         )
+    }
+
+    // ========== Encrypted channel ==========
+
+    /**
+     * Set once the Noise handshake completes. Null means the legacy
+     * (unencrypted) dialect, which Music Assistant still accepts today behind
+     * its `allow_legacy_clients` toggle but has documented as temporary.
+     *
+     * This one field is what switches the whole protocol layer between the two
+     * wire formats: every existing caller of [sendProtocolMessage] becomes
+     * encrypted with no further edits, and [handleBinaryMessage] routes through
+     * the codec instead of parsing a bare frame.
+     */
+    @Volatile
+    private var wireCodec: NoiseWireCodec? = null
+
+    /** True once the connection is carrying Noise ciphertexts. */
+    val isEncrypted: Boolean get() = wireCodec != null
+
+    /** Install the transport produced by the handshake driver. */
+    fun installEncryptedTransport(transport: NoiseTransport) {
+        wireCodec = NoiseWireCodec(transport)
+        Log.i(tag, "Encrypted channel established")
+    }
+
+    /** Drop the encrypted channel (disconnect, or falling back to legacy). */
+    fun clearEncryptedTransport() {
+        wireCodec = null
+    }
+
+    /**
+     * Send an application protocol message.
+     *
+     * Encrypted when a Noise transport is installed, a plain text frame
+     * otherwise. Callers do not need to know which.
+     */
+    protected fun sendProtocolMessage(text: String) {
+        val codec = wireCodec
+        if (codec == null) {
+            // Legacy dialect: a plain text frame.
+            sendTextMessage(text)
+            return
+        }
+        // encodeJson takes the send mutex, so this has to be in a coroutine.
+        getCoroutineScope().launch {
+            try {
+                codec.encodeJson(text).forEach { sendBinaryFrame(it) }
+            } catch (e: Exception) {
+                Log.e(tag, "Failed to encrypt outbound message", e)
+                onProtocolFailure("outbound encryption failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * A protocol-level failure that requires closing the socket.
+     *
+     * The spec allows no application-level error message for these, so the only
+     * thing to do is close - and the only diagnostic anyone will ever have is
+     * the log line the implementation writes here.
+     */
+    protected open fun onProtocolFailure(reason: String) {
+        Log.e(tag, "Protocol failure: $reason")
     }
 
     // ========== Message Handling ==========
@@ -728,9 +802,24 @@ abstract class SendSpinProtocolHandler(
      * Handle binary message from the transport.
      */
     protected fun handleBinaryMessage(bytes: ByteArray) {
-        val message = BinaryMessageParser.parse(bytes)
-        if (message != null) {
-            dispatchBinaryMessage(message)
+        val codec = wireCodec
+        if (codec == null) {
+            // Legacy path: the frame is a bare SendSpin binary message.
+            BinaryMessageParser.parse(bytes)?.let { dispatchBinaryMessage(it) }
+            return
+        }
+        when (val decoded = codec.decode(bytes)) {
+            is NoiseWireCodec.Decoded.Json -> handleTextMessage(decoded.text)
+            is NoiseWireCodec.Decoded.Typed ->
+                BinaryMessageParser.parse(decoded.type, decoded.body)
+                    ?.let { dispatchBinaryMessage(it) }
+            is NoiseWireCodec.Decoded.Fragment ->
+                // Reassembly lands in item 1.5. Until then a fragmented message
+                // is unreadable, and silently ignoring it would strand the
+                // stream; the spec's answer to an unhandleable frame is to close.
+                onProtocolFailure("fragmentation is not implemented yet (item 1.5)")
+            is NoiseWireCodec.Decoded.ProtocolError ->
+                onProtocolFailure(decoded.reason)
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -319,7 +319,11 @@ abstract class SendSpinProtocolHandler(
         sendProtocolMessage(
             MessageBuilder.buildPlayerState(
                 currentVolume, currentMuted, isAvailable(), delayMs,
-                minBufferMs = minBufferMs
+                minBufferMs = minBufferMs,
+                // On the legacy dialect there is no server/activate, so the
+                // player object always ships; on the spec path it may only
+                // appear once the role is actually active.
+                playerRoleActive = !isEncrypted || activeRoles.contains(ROLE_PLAYER_V1),
             )
         )
     }
@@ -727,6 +731,9 @@ abstract class SendSpinProtocolHandler(
             startTimeSync()
         }
     }
+
+    /** The versioned player role, as it appears in active_roles. */
+    protected val ROLE_PLAYER_V1 = SendSpinProtocol.Roles.PLAYER
 
     /** True once the first server/activate has been accepted on this connection. */
     @Volatile

--- a/android/app/src/test/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandlerTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandlerTest.kt
@@ -109,13 +109,20 @@ class SendSpinProtocolHandlerTest {
     // ========== External Source Tests ==========
 
     @Test
-    fun `setExternalSource true reports external_source state`() {
+    fun `setExternalSource true reports available false`() {
         handler.sentMessages.clear()
         handler.setExternalSource(true)
 
+        // The spec replaced the tri-state `state` string with a boolean (#115).
+        // External-source takeover is now the ONLY thing available:false means,
+        // so the wire assertion is on the boolean, not on a removed enum value.
         assertEquals("external_source", handler.exposedSyncState())
         assertEquals(1, handler.sentMessages.size)
-        assertTrue(handler.sentMessages[0].contains("\"state\":\"external_source\""))
+        assertTrue(handler.sentMessages[0].contains("\"available\":false"))
+        assertTrue(
+            "the removed state string must not appear on the wire",
+            !handler.sentMessages[0].contains("external_source"),
+        )
     }
 
     @Test

--- a/android/app/src/test/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandlerTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandlerTest.kt
@@ -472,6 +472,13 @@ class TestProtocolHandler : SendSpinProtocolHandler("TestHandler") {
         sentMessages.add(text)
     }
 
+    /** Frames sent on the encrypted path, in order. */
+    val sentBinaryFrames = mutableListOf<ByteArray>()
+
+    override fun sendBinaryFrame(bytes: ByteArray) {
+        sentBinaryFrames.add(bytes)
+    }
+
     override fun getCoroutineScope(): CoroutineScope = testScope
 
     override fun getTimeFilter(): SendspinTimeFilter = timeFilter

--- a/android/conformance-client/build.gradle.kts
+++ b/android/conformance-client/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
 dependencies {
     implementation(project(":shared"))
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
 }
 
@@ -31,4 +32,13 @@ tasks.register<Jar>("fatJar") {
     from({
         configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) }
     })
+}
+
+// End-to-end check of the encrypted wire layer against a live server.
+// See ci/conformance/dev_server.py.
+tasks.register<JavaExec>("noiseCheck") {
+    group = "verification"
+    mainClass.set("com.sendspindroid.conformance.NoiseHandshakeCheck")
+    classpath = sourceSets["main"].runtimeClasspath
+    args = (project.findProperty("url") as String?)?.let { listOf(it) } ?: emptyList()
 }

--- a/android/conformance-client/build.gradle.kts
+++ b/android/conformance-client/build.gradle.kts
@@ -40,5 +40,5 @@ tasks.register<JavaExec>("noiseCheck") {
     group = "verification"
     mainClass.set("com.sendspindroid.conformance.NoiseHandshakeCheck")
     classpath = sourceSets["main"].runtimeClasspath
-    args = (project.findProperty("url") as String?)?.let { listOf(it) } ?: emptyList()
+    args = listOfNotNull(project.findProperty("url") as String?, if (project.hasProperty("hold")) "--hold" else null)
 }

--- a/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/Main.kt
+++ b/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/Main.kt
@@ -200,7 +200,7 @@ fun main(argv: Array<String>) {
                 SendSpinProtocol.MessageType.SERVER_HELLO -> {
                     serverHelloPayload = payload
                     // Initial client/state per spec, built by the app's real builder.
-                    webSocket.send(MessageBuilder.buildPlayerState(100, false, "synchronized", 0.0))
+                    webSocket.send(MessageBuilder.buildPlayerState(100, false, available = true, staticDelayMs = 0.0))
                     // Exercise the clock-sync path with a short burst.
                     thread(isDaemon = true) {
                         repeat(5) {

--- a/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
+++ b/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
@@ -45,8 +45,16 @@ object NoiseHandshakeCheck {
 
     @JvmStatic
     fun main(args: Array<String>) {
-        val url = args.getOrNull(0) ?: "ws://127.0.0.1:8927/sendspin"
-        val identityFile = File(args.getOrNull(1) ?: ".dev/noisecheck-identity.key")
+        // Positional args only - a flag landing in the identity-file slot would
+        // silently mint a new identity, and the server would see a client it has
+        // never been told to trust.
+        val positional = args.filterNot { it.startsWith("--") }
+        val url = positional.getOrNull(0) ?: "ws://127.0.0.1:8927/sendspin"
+        // Music Assistant only offers player setup for a client that is
+        // currently online, and a 4-second connection is gone before anyone
+        // can click anything. --hold keeps it up until interrupted.
+        val hold = args.contains("--hold") || System.getenv("NOISECHECK_HOLD") != null
+        val identityFile = File(positional.getOrNull(1) ?: ".dev/noisecheck-identity.key")
         val identity = loadOrCreateIdentity(identityFile)
 
         println("client_id : ${identity.clientId}")
@@ -169,11 +177,11 @@ object NoiseHandshakeCheck {
                                             ),
                                             "client/time",
                                         )
-                                        if (Activity.PLAYBACK in activate.activities) {
-                                            // Give the server a moment to stream.
-                                            Thread {
-                                                Thread.sleep(4000); done.countDown()
-                                            }.start()
+                                        if (hold) {
+                                            println("         holding connection open - " +
+                                                "configure this player in Music Assistant now")
+                                        } else if (Activity.PLAYBACK in activate.activities) {
+                                            Thread { Thread.sleep(4000); done.countDown() }.start()
                                         } else {
                                             done.countDown()
                                         }
@@ -205,6 +213,25 @@ object NoiseHandshakeCheck {
                 done.countDown()
             }
         })
+
+        if (hold) {
+            println()
+            println("HOLDING. Configure the player in Music Assistant, then watch for a new")
+            println("server/activate below. Ctrl-C to stop.")
+            println()
+            // A real client keeps clock sync running; without it MA may treat
+            // the session as idle.
+            while (true) {
+                Thread.sleep(2000)
+                if (codec != null && failure == null) {
+                    sendEncrypted(
+                        MessageBuilder.buildClientTime(System.nanoTime() / 1000),
+                        "client/time",
+                    )
+                }
+                if (done.count == 0L && failure != null) break
+            }
+        }
 
         val finished = done.await(40, TimeUnit.SECONDS)
         socket.close(1000, "done")

--- a/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
+++ b/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
@@ -2,46 +2,68 @@ package com.sendspindroid.conformance
 
 import com.sendspindroid.sendspin.crypto.ClientIdentity
 import com.sendspindroid.sendspin.crypto.PskCandidateSet
+import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.protocol.ActivationOutcome
+import com.sendspindroid.sendspin.protocol.Activity
 import com.sendspindroid.sendspin.protocol.NoiseWireCodec
 import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
+import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+import com.sendspindroid.sendspin.protocol.ServerActivateRules
+import com.sendspindroid.sendspin.protocol.message.MessageBuilder
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
+import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 /**
- * End-to-end check of the encrypted wire layer against a real server.
+ * End-to-end check of the encrypted path against a real server.
  *
- * Drives the same [SendSpinHandshakeDriver] and [NoiseWireCodec] the Android app
- * uses, over a real WebSocket, against an aiosendspin server running with
- * `allow_unencrypted=False`. Host tests prove the layer against recorded
- * transcripts; this proves it against a server that will refuse anything it does
- * not like.
+ * Drives the SAME code the Android app uses - `SendSpinHandshakeDriver`,
+ * `NoiseWireCodec`, `ServerActivateRules`, and the real `MessageBuilder` - over
+ * a real WebSocket against an aiosendspin server running with
+ * `allow_unencrypted=False`.
  *
- * Usage: `NoiseHandshakeCheck <ws://host:port/sendspin>`
+ * The identity is **persisted** rather than generated per run. That matters:
+ * an unpaired client only becomes playback-capable once the operator trusts its
+ * `client_id`, so a tool that mints a fresh identity every run can never be
+ * granted playback and will report empty activities forever - which is exactly
+ * what earlier versions of this check did.
+ *
+ * Usage: `NoiseHandshakeCheck <ws://host:port/sendspin> [identity-file]`
  */
 object NoiseHandshakeCheck {
 
     @JvmStatic
     fun main(args: Array<String>) {
-        val url = args.firstOrNull() ?: "ws://127.0.0.1:8927/sendspin"
-        val identity = ClientIdentity.generate()
-        println("client_id: ${identity.clientId}")
+        val url = args.getOrNull(0) ?: "ws://127.0.0.1:8927/sendspin"
+        val identityFile = File(args.getOrNull(1) ?: ".dev/noisecheck-identity.key")
+        val identity = loadOrCreateIdentity(identityFile)
+
+        println("client_id : ${identity.clientId}")
+        println("identity  : ${identityFile.path} (stable across runs)")
         println("connecting: $url")
+        println()
 
         val done = CountDownLatch(1)
         var failure: String? = null
         var codec: NoiseWireCodec? = null
         var sawServerHello = false
+        var grantedActivities: Set<Activity> = emptySet()
+        var grantedRoles: List<String> = emptyList()
+        var audioFrames = 0
 
-        val client = OkHttpClient.Builder()
-            .readTimeout(30, TimeUnit.SECONDS)
-            .build()
+        val json = Json { ignoreUnknownKeys = true }
+        val client = OkHttpClient.Builder().readTimeout(30, TimeUnit.SECONDS).build()
 
         lateinit var socket: WebSocket
         lateinit var driver: SendSpinHandshakeDriver
@@ -51,33 +73,41 @@ object NoiseHandshakeCheck {
             done.countDown()
         }
 
+        fun sendEncrypted(text: String, label: String) {
+            val c = codec ?: return fail("no transport for $label")
+            runBlocking { c.encodeJson(text).forEach { socket.send(ByteString.of(*it)) } }
+            println("-> enc   $label")
+        }
+
         driver = SendSpinHandshakeDriver(
             identity = identity,
             candidates = PskCandidateSet.sentinelOnly(),
             onEvent = { event ->
                 when (event) {
                     is SendSpinHandshakeDriver.Event.SendCleartext -> {
-                        println("-> text  ${event.text.take(120)}")
+                        println("-> text  ${event.text.take(90)}")
                         socket.send(event.text)
                     }
                     is SendSpinHandshakeDriver.Event.TransportReady -> {
-                        println("HANDSHAKE OK")
-                        println("   server_id : ${event.serverInit.serverId}")
-                        println("   matched   : ${event.matchedPsk.category} ${event.matchedPsk.pskId}")
-                        println("   h         : ${event.transport.handshakeHash.toHex().take(32)}...")
-                        val c = NoiseWireCodec(event.transport)
-                        codec = c
-                        // First encrypted message: client/hello.
-                        val hello = """{"type":"client/hello","payload":{"name":"NoiseHandshakeCheck",""" +
-                            """"trust_level":"none","supported_roles":["player@v1"],""" +
-                            """"player@v1_support":{"supported_formats":[{"codec":"pcm",""" +
-                            """"sample_rate":48000,"channels":2,"bit_depth":16}],""" +
-                            """"buffer_capacity":1680000,"supported_commands":["volume","mute"]},""" +
-                            """"supported_pair_methods":[],"unpaired_access":{"enabled":true}}}"""
-                        runBlocking {
-                            c.encodeJson(hello).forEach { socket.send(ByteString.of(*it)) }
-                        }
-                        println("-> enc   client/hello (${hello.length} bytes plaintext)")
+                        println("HANDSHAKE OK  server=${event.serverInit.serverId} " +
+                            "psk=${event.matchedPsk.category}")
+                        codec = NoiseWireCodec(event.transport)
+                        // The real builder, so this exercises what the app sends.
+                        sendEncrypted(
+                            MessageBuilder.buildClientHello(
+                                clientId = null,          // encrypted: lives in client/init
+                                deviceName = "NoiseHandshakeCheck",
+                                bufferCapacity = 1_680_000,
+                                manufacturer = "conformance",
+                                supportedFormats = listOf(
+                                    MessageBuilder.FormatEntry("pcm", 48000, 2, 16)
+                                ),
+                                softwareVersion = "check",
+                                trustLevel = MessageBuilder.TRUST_NONE,
+                                unpairedAccessEnabled = true,
+                            ),
+                            "client/hello",
+                        )
                     }
                     is SendSpinHandshakeDriver.Event.Fail ->
                         fail("${event.reason}: ${event.detail}")
@@ -86,33 +116,80 @@ object NoiseHandshakeCheck {
         )
 
         socket = client.newWebSocket(Request.Builder().url(url).build(), object : WebSocketListener() {
-            override fun onOpen(webSocket: WebSocket, response: Response) {
-                println("socket open")
-                driver.start()
-            }
+            override fun onOpen(webSocket: WebSocket, response: Response) = driver.start()
 
-            override fun onMessage(webSocket: WebSocket, text: String) {
-                // Cleartext handshake frames. okhttp hands us a String; the raw
-                // bytes are its UTF-8 encoding, which for a frame okhttp itself
-                // decoded is byte-identical.
+            override fun onMessage(webSocket: WebSocket, text: String) =
                 driver.onCleartextFrame(text.toByteArray(Charsets.UTF_8))
-            }
 
             override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
-                val c = codec
-                if (c == null) {
-                    fail("binary frame before transport mode")
-                    return
-                }
+                val c = codec ?: return fail("binary frame before transport mode")
                 when (val decoded = c.decode(bytes.toByteArray())) {
                     is NoiseWireCodec.Decoded.Json -> {
-                        println("<- enc   ${decoded.text.take(160)}")
-                        if (decoded.text.contains("server/hello")) sawServerHello = true
-                        // server/activate means the server accepted us.
-                        if (decoded.text.contains("server/activate")) done.countDown()
+                        val obj = runCatching {
+                            json.parseToJsonElement(decoded.text).jsonObject
+                        }.getOrNull() ?: return
+                        val type = obj["type"]?.jsonPrimitive?.contentOrNull
+                        val payload = obj["payload"] as? kotlinx.serialization.json.JsonObject
+                        println("<- enc   ${decoded.text.take(140)}")
+
+                        when (type) {
+                            SendSpinProtocol.MessageType.SERVER_HELLO -> sawServerHello = true
+
+                            SendSpinProtocol.MessageType.SERVER_ACTIVATE -> {
+                                val activate = ServerActivateRules.parse(payload)
+                                    ?: return fail("malformed server/activate")
+                                // Same rules the app applies.
+                                val outcome = ServerActivateRules.evaluate(
+                                    activate = activate,
+                                    category = PskCategory.SENTINEL,
+                                    unpairedAccessEnabled = true,
+                                    previousRoles = grantedRoles,
+                                    isFirstActivation = grantedActivities.isEmpty() &&
+                                        grantedRoles.isEmpty(),
+                                    offeredPairMethods = setOf("pairing_psk"),
+                                )
+                                when (outcome) {
+                                    is ActivationOutcome.Accept -> {
+                                        grantedActivities = activate.activities
+                                        grantedRoles = outcome.activeRoles
+                                        println("         activation accepted: " +
+                                            "activities=${activate.activities} roles=${outcome.activeRoles}")
+                                        // Only now may we speak.
+                                        sendEncrypted(
+                                            MessageBuilder.buildPlayerState(
+                                                volume = 100, muted = false, available = true,
+                                                playerRoleActive = outcome.activeRoles
+                                                    .contains("player@v1"),
+                                            ),
+                                            "client/state available=true",
+                                        )
+                                        sendEncrypted(
+                                            MessageBuilder.buildClientTime(
+                                                System.nanoTime() / 1000
+                                            ),
+                                            "client/time",
+                                        )
+                                        if (Activity.PLAYBACK in activate.activities) {
+                                            // Give the server a moment to stream.
+                                            Thread {
+                                                Thread.sleep(4000); done.countDown()
+                                            }.start()
+                                        } else {
+                                            done.countDown()
+                                        }
+                                    }
+                                    is ActivationOutcome.Close ->
+                                        fail("activation rejected: ${outcome.goodbyeReason}")
+                                    is ActivationOutcome.AbortPairing ->
+                                        fail("pairing aborted: ${outcome.reason}")
+                                }
+                            }
+                        }
                     }
-                    is NoiseWireCodec.Decoded.Typed ->
-                        println("<- enc   binary type=${decoded.type} ${decoded.body.size} bytes")
+                    is NoiseWireCodec.Decoded.Typed -> {
+                        if (decoded.type == SendSpinProtocol.BinaryType.AUDIO) audioFrames++
+                        else println("<- enc   binary type=${decoded.type} ${decoded.body.size}B")
+                    }
                     is NoiseWireCodec.Decoded.Fragment ->
                         println("<- enc   fragment type=${decoded.type}")
                     is NoiseWireCodec.Decoded.ProtocolError ->
@@ -120,9 +197,8 @@ object NoiseHandshakeCheck {
                 }
             }
 
-            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) =
                 fail("socket failure: ${t.message}")
-            }
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 println("socket closed: $code $reason")
@@ -130,29 +206,56 @@ object NoiseHandshakeCheck {
             }
         })
 
-        val finished = done.await(30, TimeUnit.SECONDS)
+        val finished = done.await(40, TimeUnit.SECONDS)
         socket.close(1000, "done")
         client.dispatcher.executorService.shutdown()
 
         println()
+        println("RESULT")
+        println("  handshake      : ${if (codec != null) "OK" else "FAILED"}")
+        println("  server/hello   : ${if (sawServerHello) "received" else "MISSING"}")
+        println("  activities     : ${grantedActivities.map { it.wireName }}")
+        println("  active_roles   : $grantedRoles")
+        println("  audio frames   : $audioFrames")
+        println()
+
         val err = failure
         when {
-            err != null -> {
-                println("FAIL: $err")
-                kotlin.system.exitProcess(1)
+            err != null -> exitFail(err)
+            !finished -> exitFail("timed out")
+            !sawServerHello -> exitFail("no encrypted server/hello")
+            Activity.PLAYBACK !in grantedActivities -> {
+                // Not a client bug: an unpaired client is only playback-capable
+                // once the operator trusts this client_id. Say so precisely so
+                // nobody goes looking in the wrong place.
+                println("INCOMPLETE: handshake and encrypted traffic verified, but the server")
+                println("  granted no playback activity. An unpaired client needs BOTH")
+                println("  unpaired_access advertised (it is - see client/hello above) AND")
+                println("  the operator to trust this client_id. Start the dev server with")
+                println("  --trust-all-unpaired and run this again; trust is remembered per")
+                println("  client_id, which is why this tool now persists its identity.")
+                kotlin.system.exitProcess(2)
             }
-            !finished -> {
-                println("FAIL: timed out before server/activate")
-                kotlin.system.exitProcess(1)
-            }
-            !sawServerHello -> {
-                println("FAIL: handshake completed but no encrypted server/hello arrived")
-                kotlin.system.exitProcess(1)
-            }
-            else -> println("PASS: encrypted handshake and application traffic verified")
+            else -> println("PASS: playback granted (activities=${grantedActivities.map { it.wireName }})")
         }
     }
 
-    private fun ByteArray.toHex(): String =
-        joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+    private fun exitFail(reason: String): Nothing {
+        println("FAIL: $reason")
+        kotlin.system.exitProcess(1)
+    }
+
+    private fun loadOrCreateIdentity(file: File): ClientIdentity {
+        if (file.exists()) {
+            val restored = ClientIdentity.fromStoredKey(file.readText().trim())
+            if (restored != null) return restored
+            println("WARNING: ${file.path} is unreadable; generating a new identity. " +
+                "The server will not recognise it as the same client.")
+        }
+        val fresh = ClientIdentity.generate()
+        file.parentFile?.mkdirs()
+        file.writeText(ClientIdentity.encodeForStorage(fresh))
+        println("generated a new identity at ${file.path}")
+        return fresh
+    }
 }

--- a/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
+++ b/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
@@ -1,0 +1,158 @@
+package com.sendspindroid.conformance
+
+import com.sendspindroid.sendspin.crypto.ClientIdentity
+import com.sendspindroid.sendspin.crypto.PskCandidateSet
+import com.sendspindroid.sendspin.protocol.NoiseWireCodec
+import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end check of the encrypted wire layer against a real server.
+ *
+ * Drives the same [SendSpinHandshakeDriver] and [NoiseWireCodec] the Android app
+ * uses, over a real WebSocket, against an aiosendspin server running with
+ * `allow_unencrypted=False`. Host tests prove the layer against recorded
+ * transcripts; this proves it against a server that will refuse anything it does
+ * not like.
+ *
+ * Usage: `NoiseHandshakeCheck <ws://host:port/sendspin>`
+ */
+object NoiseHandshakeCheck {
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val url = args.firstOrNull() ?: "ws://127.0.0.1:8927/sendspin"
+        val identity = ClientIdentity.generate()
+        println("client_id: ${identity.clientId}")
+        println("connecting: $url")
+
+        val done = CountDownLatch(1)
+        var failure: String? = null
+        var codec: NoiseWireCodec? = null
+        var sawServerHello = false
+
+        val client = OkHttpClient.Builder()
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+
+        lateinit var socket: WebSocket
+        lateinit var driver: SendSpinHandshakeDriver
+
+        fun fail(reason: String) {
+            if (failure == null) failure = reason
+            done.countDown()
+        }
+
+        driver = SendSpinHandshakeDriver(
+            identity = identity,
+            candidates = PskCandidateSet.sentinelOnly(),
+            onEvent = { event ->
+                when (event) {
+                    is SendSpinHandshakeDriver.Event.SendCleartext -> {
+                        println("-> text  ${event.text.take(120)}")
+                        socket.send(event.text)
+                    }
+                    is SendSpinHandshakeDriver.Event.TransportReady -> {
+                        println("HANDSHAKE OK")
+                        println("   server_id : ${event.serverInit.serverId}")
+                        println("   matched   : ${event.matchedPsk.category} ${event.matchedPsk.pskId}")
+                        println("   h         : ${event.transport.handshakeHash.toHex().take(32)}...")
+                        val c = NoiseWireCodec(event.transport)
+                        codec = c
+                        // First encrypted message: client/hello.
+                        val hello = """{"type":"client/hello","payload":{"name":"NoiseHandshakeCheck",""" +
+                            """"trust_level":"none","supported_roles":["player@v1"],""" +
+                            """"player@v1_support":{"supported_formats":[{"codec":"pcm",""" +
+                            """"sample_rate":48000,"channels":2,"bit_depth":16}],""" +
+                            """"buffer_capacity":1680000,"supported_commands":["volume","mute"]},""" +
+                            """"supported_pair_methods":[],"unpaired_access":{"enabled":true}}}"""
+                        runBlocking {
+                            c.encodeJson(hello).forEach { socket.send(ByteString.of(*it)) }
+                        }
+                        println("-> enc   client/hello (${hello.length} bytes plaintext)")
+                    }
+                    is SendSpinHandshakeDriver.Event.Fail ->
+                        fail("${event.reason}: ${event.detail}")
+                }
+            },
+        )
+
+        socket = client.newWebSocket(Request.Builder().url(url).build(), object : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                println("socket open")
+                driver.start()
+            }
+
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                // Cleartext handshake frames. okhttp hands us a String; the raw
+                // bytes are its UTF-8 encoding, which for a frame okhttp itself
+                // decoded is byte-identical.
+                driver.onCleartextFrame(text.toByteArray(Charsets.UTF_8))
+            }
+
+            override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+                val c = codec
+                if (c == null) {
+                    fail("binary frame before transport mode")
+                    return
+                }
+                when (val decoded = c.decode(bytes.toByteArray())) {
+                    is NoiseWireCodec.Decoded.Json -> {
+                        println("<- enc   ${decoded.text.take(160)}")
+                        if (decoded.text.contains("server/hello")) sawServerHello = true
+                        // server/activate means the server accepted us.
+                        if (decoded.text.contains("server/activate")) done.countDown()
+                    }
+                    is NoiseWireCodec.Decoded.Typed ->
+                        println("<- enc   binary type=${decoded.type} ${decoded.body.size} bytes")
+                    is NoiseWireCodec.Decoded.Fragment ->
+                        println("<- enc   fragment type=${decoded.type}")
+                    is NoiseWireCodec.Decoded.ProtocolError ->
+                        fail("decode failed: ${decoded.reason}")
+                }
+            }
+
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                fail("socket failure: ${t.message}")
+            }
+
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                println("socket closed: $code $reason")
+                done.countDown()
+            }
+        })
+
+        val finished = done.await(30, TimeUnit.SECONDS)
+        socket.close(1000, "done")
+        client.dispatcher.executorService.shutdown()
+
+        println()
+        val err = failure
+        when {
+            err != null -> {
+                println("FAIL: $err")
+                kotlin.system.exitProcess(1)
+            }
+            !finished -> {
+                println("FAIL: timed out before server/activate")
+                kotlin.system.exitProcess(1)
+            }
+            !sawServerHello -> {
+                println("FAIL: handshake completed but no encrypted server/hello arrived")
+                kotlin.system.exitProcess(1)
+            }
+            else -> println("PASS: encrypted handshake and application traffic verified")
+        }
+    }
+
+    private fun ByteArray.toHex(): String =
+        joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilderTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilderTest.kt
@@ -48,35 +48,35 @@ class MessageBuilderTest {
 
     @Test
     fun buildPlayerState_hasCorrectType() {
-        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(50, false)).jsonObject
+        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(50, false, available = true)).jsonObject
         assertEquals(SendSpinProtocol.MessageType.CLIENT_STATE, msg["type"]?.jsonPrimitive?.content)
     }
 
     @Test
     fun buildPlayerState_hasPlayerObjectWithFields() {
-        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(75, true, "error")).jsonObject
+        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(75, true, available = false)).jsonObject
         val payload = msg["payload"]!!.jsonObject
         val player = payload["player"]!!.jsonObject
         assertEquals(75, player["volume"]?.jsonPrimitive?.int)
         assertTrue(player["muted"]?.jsonPrimitive?.boolean ?: false)
         // Per spec, `state` is a top-level payload field, not part of the
         // player object.
-        assertEquals("error", payload["state"]?.jsonPrimitive?.content)
+        assertEquals("false", payload["available"]?.jsonPrimitive?.content)
         assertNull("state must not be nested in player", player["state"])
     }
 
     @Test
     fun buildPlayerState_defaultSyncState() {
-        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(50, false)).jsonObject
+        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(50, false, available = true)).jsonObject
         val payload = msg["payload"]!!.jsonObject
-        assertEquals("synchronized", payload["state"]?.jsonPrimitive?.content)
+        assertEquals("true", payload["available"]?.jsonPrimitive?.content)
     }
 
     @Test
     fun buildPlayerState_staticDelayMsRoundedToInt() {
         // Spec: static_delay_ms is an integer.
         val msg = Json.parseToJsonElement(
-            MessageBuilder.buildPlayerState(50, false, "synchronized", 12.5)
+            MessageBuilder.buildPlayerState(50, false, true, 12.5)
         ).jsonObject
         val player = msg["payload"]!!.jsonObject["player"]!!.jsonObject
         assertEquals(13, player["static_delay_ms"]?.jsonPrimitive?.int)
@@ -85,7 +85,7 @@ class MessageBuilderTest {
     @Test
     fun buildPlayerState_staticDelayMsDefaultsToZero() {
         val msg = Json.parseToJsonElement(
-            MessageBuilder.buildPlayerState(50, false)
+            MessageBuilder.buildPlayerState(50, false, available = true)
         ).jsonObject
         val player = msg["payload"]!!.jsonObject["player"]!!.jsonObject
         assertEquals(0, player["static_delay_ms"]?.jsonPrimitive?.int)
@@ -96,19 +96,19 @@ class MessageBuilderTest {
         // Spec: 0-5000, negative values not supported. A negative user sync
         // offset is applied locally but reported as 0.
         val negative = Json.parseToJsonElement(
-            MessageBuilder.buildPlayerState(50, false, "synchronized", -120.0)
+            MessageBuilder.buildPlayerState(50, false, true, -120.0)
         ).jsonObject["payload"]!!.jsonObject["player"]!!.jsonObject
         assertEquals(0, negative["static_delay_ms"]?.jsonPrimitive?.int)
 
         val huge = Json.parseToJsonElement(
-            MessageBuilder.buildPlayerState(50, false, "synchronized", 9999.0)
+            MessageBuilder.buildPlayerState(50, false, true, 9999.0)
         ).jsonObject["payload"]!!.jsonObject["player"]!!.jsonObject
         assertEquals(5000, huge["static_delay_ms"]?.jsonPrimitive?.int)
     }
 
     @Test
     fun buildPlayerState_declaresSetStaticDelaySupport() {
-        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(50, false)).jsonObject
+        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(50, false, available = true)).jsonObject
         val player = msg["payload"]!!.jsonObject["player"]!!.jsonObject
         val commands = player["supported_commands"]!!.jsonArray.map { it.jsonPrimitive.content }
         assertEquals(listOf("set_static_delay"), commands)
@@ -118,7 +118,7 @@ class MessageBuilderTest {
     fun buildPlayerState_includesRequiredTimingFields() {
         // Spec: required_lead_time_ms and min_buffer_ms are always required
         // for players.
-        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(50, false)).jsonObject
+        val msg = Json.parseToJsonElement(MessageBuilder.buildPlayerState(50, false, available = true)).jsonObject
         val player = msg["payload"]!!.jsonObject["player"]!!.jsonObject
         assertEquals(
             SendSpinProtocol.PlayerTiming.REQUIRED_LEAD_TIME_MS,

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/ClientIdentity.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/ClientIdentity.kt
@@ -1,0 +1,63 @@
+package com.sendspindroid.sendspin.crypto
+
+/**
+ * The client's Sendspin identity: a long-lived Curve25519 keypair whose public
+ * half IS the `client_id`.
+ *
+ * `README.md#definitions`: "A Curve25519 keypair used to identify a client or
+ * server in the Noise handshake. The base64url-encoded public key (43
+ * characters, no padding) serves as the `client_id` or `server_id`. Persistent
+ * across reboots."
+ *
+ * That persistence is not cosmetic. The key is a pre-message input to every
+ * KKpsk2 handshake, and it is half of the pairing token. Regenerating it makes
+ * the client a different device to every server it has ever paired with, and
+ * the resulting failure is a silent socket close.
+ *
+ * The private key never leaves this object; [toString] renders only the public
+ * identifier so a stray log line cannot leak it.
+ */
+class ClientIdentity(privateKey: ByteArray) {
+
+    init {
+        require(privateKey.size == KEY_SIZE) {
+            "a Curve25519 private key is $KEY_SIZE bytes, got ${privateKey.size}"
+        }
+    }
+
+    private val secret = privateKey.copyOf()
+
+    /** The raw 32-byte public key, as the Noise handshake needs it. */
+    val publicKey: ByteArray = x25519PublicKey(secret)
+
+    /** The 43-character base64url `client_id` that goes on the wire. */
+    val clientId: String = Base64Url.encode(publicKey)
+
+    /** A copy. The caller must not retain it longer than the handshake. */
+    internal fun privateKeyBytes(): ByteArray = secret.copyOf()
+
+    override fun toString(): String = "ClientIdentity($clientId)"
+
+    companion object {
+        const val KEY_SIZE = 32
+
+        /** Mint a new identity from the platform CSPRNG. */
+        fun generate(): ClientIdentity = ClientIdentity(secureRandomBytes(KEY_SIZE))
+
+        /**
+         * Rebuild from a stored private key.
+         *
+         * @return null if [base64Url] is not a 32-byte base64url value. The
+         *   caller must treat that as "no identity stored" rather than silently
+         *   minting a new one over the top - see the storage layer.
+         */
+        fun fromStoredKey(base64Url: String): ClientIdentity? {
+            val bytes = Base64Url.decodeOrNull(base64Url) ?: return null
+            return if (bytes.size == KEY_SIZE) ClientIdentity(bytes) else null
+        }
+
+        /** Encode a private key for storage. */
+        fun encodeForStorage(identity: ClientIdentity): String =
+            Base64Url.encode(identity.secret)
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriver.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriver.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid.sendspin.protocol
 
 import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.crypto.ClientIdentity
 import com.sendspindroid.sendspin.crypto.NoiseCipherSuite
 import com.sendspindroid.sendspin.crypto.NoiseHandshake
 import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
@@ -40,8 +41,7 @@ import kotlinx.serialization.json.jsonPrimitive
  * (`connection.md#failure-handling`).
  */
 class SendSpinHandshakeDriver(
-    private val clientId: String,
-    private val clientStaticPrivateKey: ByteArray,
+    private val identity: ClientIdentity,
     private val candidates: PskCandidateSet,
     private val suite: NoiseCipherSuite = DEFAULT_SUITE,
     private val onEvent: (Event) -> Unit = {},
@@ -89,7 +89,7 @@ class SendSpinHandshakeDriver(
         if (phase != Phase.New) return fail(
             NoiseHandshakeException.Cause.WrongPhase, "start() called in $phase"
         )
-        val text = InitMessages.buildClientInit(clientId, suite.wireName)
+        val text = InitMessages.buildClientInit(identity.clientId, suite.wireName)
         clientInitSent = text
         phase = Phase.AwaitingServerInit
         onEvent(Event.SendCleartext(text))
@@ -157,7 +157,7 @@ class SendSpinHandshakeDriver(
         val override = ephemeralOverrideForTest
         handshake = if (override == null) {
             NoiseHandshake.responder(
-                staticPrivateKey = clientStaticPrivateKey,
+                staticPrivateKey = identity.privateKeyBytes(),
                 remoteStaticPublicKey = parsed.serverStaticKey,
                 suite = suite,
                 prologue = prologue,
@@ -165,7 +165,7 @@ class SendSpinHandshakeDriver(
         } else {
             NoiseHandshake(
                 suite = suite,
-                staticPrivateKey = clientStaticPrivateKey,
+                staticPrivateKey = identity.privateKeyBytes(),
                 remoteStaticPublicKey = parsed.serverStaticKey,
                 prologue = prologue,
                 generateEphemeral = override,

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
@@ -127,6 +127,8 @@ object SendSpinProtocol {
 
         const val CLIENT_HELLO = "client/hello"
         const val SERVER_HELLO = "server/hello"
+        const val SERVER_ACTIVATE = "server/activate"
+        const val PAIR_ABORT = "pair/abort"
         const val CLIENT_TIME = "client/time"
         const val SERVER_TIME = "server/time"
         const val CLIENT_STATE = "client/state"

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/ServerActivate.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/ServerActivate.kt
@@ -1,0 +1,220 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.crypto.PskCategory
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** The purposes a server may declare on a connection. */
+enum class Activity(val wireName: String) {
+    PLAYBACK("playback"),
+    PAIRING("pairing"),
+    MANAGEMENT("management");
+
+    companion object {
+        fun fromWire(value: String): Activity? = entries.firstOrNull { it.wireName == value }
+    }
+}
+
+/**
+ * A parsed `server/activate`.
+ *
+ * @param activeRoles null means the field was ABSENT, which is different from
+ *   present-and-empty: an absent value persists whatever the previous
+ *   activation set, while an empty list clears the roles.
+ */
+data class ServerActivate(
+    val activities: Set<Activity>,
+    val activeRoles: List<String>?,
+    val pairingMethod: String?,
+    val pinLength: Int?,
+    /** Activities the client did not recognise; ignored, but worth logging. */
+    val unknownActivities: List<String>,
+)
+
+/** What the client must do about an activation. */
+sealed interface ActivationOutcome {
+    /** Accept, with the roles that are now live. */
+    data class Accept(val activeRoles: List<String>) : ActivationOutcome
+
+    /** Close the connection with this `client/goodbye` reason, sending nothing else. */
+    data class Close(val goodbyeReason: String) : ActivationOutcome
+
+    /** Reply `pair/abort` with this reason; the connection stays open. */
+    data class AbortPairing(val reason: String) : ActivationOutcome
+}
+
+/**
+ * Parsing and admissibility for `server/activate`.
+ *
+ * The admissibility table (`messaging.md#server--client-serveractivate`) binds
+ * what a server may declare to which PSK admitted the connection:
+ *
+ * | PSK matched  | Allowed activity sets                                    |
+ * |--------------|----------------------------------------------------------|
+ * | Sendspin PSK | `['pairing']` or any subset of `{playback, management}`   |
+ * | Pairing PSK  | `['pairing']`                                            |
+ * | Sentinel PSK | `[]`, `['pairing']`, `['playback']`*                      |
+ *
+ * \* `['playback']` on the Sentinel only when the client has unpaired access
+ * enabled - which is why advertising `unpaired_access` in `client/hello` is what
+ * makes unpaired playback possible at all.
+ */
+object ServerActivateRules {
+
+    const val GOODBYE_UNAUTHORIZED = "unauthorized"
+    const val GOODBYE_PAIRING_REQUIRED = "pairing_required"
+    const val ABORT_METHOD_NOT_SUPPORTED = "method_not_supported"
+
+    /** A source captures sensitive audio, so it may never run untrusted. */
+    const val ROLE_SOURCE_V1 = "source@v1"
+
+    fun parse(payload: JsonObject?): ServerActivate? {
+        if (payload == null) return null
+        val rawActivities = payload["activities"]?.jsonArray
+            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+            ?: return null   // activities is required
+        val known = mutableSetOf<Activity>()
+        val unknown = mutableListOf<String>()
+        for (raw in rawActivities) {
+            val activity = Activity.fromWire(raw)
+            if (activity != null) known += activity else unknown += raw
+        }
+        // Absent stays null; present-but-empty becomes an empty list.
+        val roles = payload["active_roles"]?.jsonArray
+            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+        val pairing = payload["pairing"] as? JsonObject
+        return ServerActivate(
+            activities = known,
+            activeRoles = roles,
+            // The client ignores `pairing` unless 'pairing' is in activities.
+            pairingMethod = pairing?.get("method")?.jsonPrimitive?.contentOrNull,
+            pinLength = pairing?.get("pin_length")?.jsonPrimitive?.intOrNull,
+            unknownActivities = unknown,
+        )
+    }
+
+    /** Is [activities] a set this PSK category may declare? */
+    fun activitiesAllowed(
+        category: PskCategory,
+        activities: Set<Activity>,
+        unpairedAccessEnabled: Boolean,
+    ): Boolean = when (category) {
+        // 'pairing' alone, or any subset of {playback, management} - so a set
+        // mixing pairing with either of the others is never allowed.
+        PskCategory.LONG_TERM ->
+            activities == setOf(Activity.PAIRING) ||
+                activities.none { it == Activity.PAIRING }
+
+        PskCategory.PAIRING -> activities == setOf(Activity.PAIRING)
+
+        PskCategory.SENTINEL -> when {
+            activities.isEmpty() -> true
+            activities == setOf(Activity.PAIRING) -> true
+            activities == setOf(Activity.PLAYBACK) -> unpairedAccessEnabled
+            else -> false
+        }
+    }
+
+    /**
+     * "A connection is playback-capable when its activities extended with
+     * 'playback' are an allowed set for the matched PSK."
+     *
+     * Only a playback-capable connection may carry non-empty `active_roles`,
+     * and it may do so even when 'playback' is not currently declared.
+     */
+    fun playbackCapable(
+        category: PskCategory,
+        activities: Set<Activity>,
+        unpairedAccessEnabled: Boolean,
+    ): Boolean = activitiesAllowed(
+        category, activities + Activity.PLAYBACK, unpairedAccessEnabled
+    )
+
+    /**
+     * Decide what to do with an activation.
+     *
+     * @param previousRoles roles persisted from an earlier activation, used when
+     *   [activate] omits the field.
+     * @param offeredPairMethods the LIVE pairing configuration, which may have
+     *   drifted from what `client/hello` advertised.
+     */
+    fun evaluate(
+        activate: ServerActivate,
+        category: PskCategory,
+        unpairedAccessEnabled: Boolean,
+        previousRoles: List<String>,
+        isFirstActivation: Boolean,
+        offeredPairMethods: Set<String>,
+    ): ActivationOutcome {
+        // "A client treats a first server/activate that omits it as carrying an
+        // empty active_roles"; later omissions persist the previous value.
+        val requestedRoles = activate.activeRoles
+            ?: if (isFirstActivation) emptyList() else previousRoles
+
+        val allowed = activitiesAllowed(category, activate.activities, unpairedAccessEnabled)
+        val capable = playbackCapable(category, activate.activities, unpairedAccessEnabled)
+
+        // Rule 1: would enabling unpaired access have made this admissible? If
+        // so the server is asking for something we could grant but have turned
+        // off, and the honest answer is "pair with me first" rather than a flat
+        // unauthorized. Only reachable on the Sentinel.
+        if (category == PskCategory.SENTINEL && !unpairedAccessEnabled) {
+            val allowedIfEnabled =
+                activitiesAllowed(category, activate.activities, unpairedAccessEnabled = true)
+            val capableIfEnabled =
+                playbackCapable(category, activate.activities, unpairedAccessEnabled = true)
+            val admissibleIfEnabled = allowedIfEnabled &&
+                (requestedRoles.isEmpty() || capableIfEnabled) &&
+                !forbidsRoleAtTrustLevel(category, requestedRoles)
+            if (!allowed || (requestedRoles.isNotEmpty() && !capable)) {
+                if (admissibleIfEnabled) {
+                    return ActivationOutcome.Close(GOODBYE_PAIRING_REQUIRED)
+                }
+            }
+        }
+
+        // Rule 2: structurally not permitted for this PSK, whatever we enable.
+        if (!allowed) return ActivationOutcome.Close(GOODBYE_UNAUTHORIZED)
+        if (requestedRoles.isNotEmpty() && !capable) {
+            // The spec is specific here: a LATER activation that drops
+            // playback-capability without explicitly sending active_roles
+            // treats the persisted roles as empty rather than rejecting.
+            if (activate.activeRoles == null && !isFirstActivation) {
+                return ActivationOutcome.Accept(emptyList())
+            }
+            return ActivationOutcome.Close(GOODBYE_UNAUTHORIZED)
+        }
+        if (forbidsRoleAtTrustLevel(category, requestedRoles)) {
+            return ActivationOutcome.Close(GOODBYE_UNAUTHORIZED)
+        }
+
+        // Rule 3: a pairing method we cannot or must not run. Connection stays
+        // open - the server may re-activate with a different method.
+        if (Activity.PAIRING in activate.activities) {
+            val method = activate.pairingMethod
+            val methodAllowedForPsk = when (category) {
+                // "pairing.method MUST be 'pairing_psk' if and only if the
+                // matched PSK is the Sendspin Pairing PSK."
+                PskCategory.PAIRING -> method == "pairing_psk"
+                else -> method != null && method != "pairing_psk"
+            }
+            if (method == null || !methodAllowedForPsk || method !in offeredPairMethods) {
+                return ActivationOutcome.AbortPairing(ABORT_METHOD_NOT_SUPPORTED)
+            }
+        }
+
+        return ActivationOutcome.Accept(requestedRoles)
+    }
+
+    /**
+     * `source@v1` MUST NOT be activated at trust level 'none' - it captures
+     * microphone or line-in audio, so an unauthenticated server must never get
+     * it. Trust is `user` only for a long-term record.
+     */
+    private fun forbidsRoleAtTrustLevel(category: PskCategory, roles: List<String>): Boolean =
+        category != PskCategory.LONG_TERM && roles.contains(ROLE_SOURCE_V1)
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/BinaryMessageParser.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/BinaryMessageParser.kt
@@ -92,7 +92,39 @@ object BinaryMessageParser {
     }
 
     /**
-     * Parse binary message from a ByteArray.
+     * Parse a binary message whose type byte has already been stripped.
+     *
+     * This is the encrypted path: [com.sendspindroid.sendspin.protocol.NoiseWireCodec]
+     * removes the type byte when it decrypts, so re-deriving it here would mean
+     * stripping it twice. [body] is the remainder, still
+     * `[8-byte big-endian timestamp][payload]`.
+     */
+    fun parse(type: Int, body: ByteArray): BinaryMessage? {
+        if (body.size < TIMESTAMP_SIZE) {
+            Log.w(TAG, "Binary message body too short: ${body.size} bytes")
+            return null
+        }
+        val timestampMicros = readTimestamp(body, 0)
+        return createMessage(type, timestampMicros, body.copyOfRange(TIMESTAMP_SIZE, body.size))
+    }
+
+    private const val TIMESTAMP_SIZE = 8
+
+    private fun readTimestamp(bytes: ByteArray, offset: Int): Long =
+        ((bytes[offset].toLong() and 0xFF) shl 56) or
+            ((bytes[offset + 1].toLong() and 0xFF) shl 48) or
+            ((bytes[offset + 2].toLong() and 0xFF) shl 40) or
+            ((bytes[offset + 3].toLong() and 0xFF) shl 32) or
+            ((bytes[offset + 4].toLong() and 0xFF) shl 24) or
+            ((bytes[offset + 5].toLong() and 0xFF) shl 16) or
+            ((bytes[offset + 6].toLong() and 0xFF) shl 8) or
+            (bytes[offset + 7].toLong() and 0xFF)
+
+    /**
+     * Parse a whole binary frame, type byte included.
+     *
+     * The legacy (unencrypted) path and the conformance client still receive
+     * frames this way.
      */
     fun parse(bytes: ByteArray): BinaryMessage? {
         if (bytes.size < HEADER_SIZE) {
@@ -101,18 +133,7 @@ object BinaryMessageParser {
         }
 
         val msgType = bytes[0].toInt() and 0xFF
-
-        // Extract timestamp (big-endian int64) from bytes 1-8
-        val timestampMicros = ((bytes[1].toLong() and 0xFF) shl 56) or
-                ((bytes[2].toLong() and 0xFF) shl 48) or
-                ((bytes[3].toLong() and 0xFF) shl 40) or
-                ((bytes[4].toLong() and 0xFF) shl 32) or
-                ((bytes[5].toLong() and 0xFF) shl 24) or
-                ((bytes[6].toLong() and 0xFF) shl 16) or
-                ((bytes[7].toLong() and 0xFF) shl 8) or
-                (bytes[8].toLong() and 0xFF)
-
-        // Get payload (everything after header)
+        val timestampMicros = readTimestamp(bytes, 1)
         val payload = bytes.copyOfRange(HEADER_SIZE, bytes.size)
 
         return createMessage(msgType, timestampMicros, payload)

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -194,13 +194,20 @@ object MessageBuilder {
         available: Boolean,
         staticDelayMs: Double = 0.0,
         requiredLeadTimeMs: Int = SendSpinProtocol.PlayerTiming.REQUIRED_LEAD_TIME_MS,
-        minBufferMs: Int = SendSpinProtocol.PlayerTiming.MIN_BUFFER_MS
+        minBufferMs: Int = SendSpinProtocol.PlayerTiming.MIN_BUFFER_MS,
+        playerRoleActive: Boolean = true
     ): String {
         val message = buildJsonObject {
             put("type", SendSpinProtocol.MessageType.CLIENT_STATE)
             put("payload", buildJsonObject {
                 put("available", available)
-                put("player", buildJsonObject {
+                // "player?: object - only if client has player role". Sending it
+                // for an inactive role is a compliance failure: aiosendspin
+                // rejects the connection outright with "client/state carried a
+                // player object for an inactive role". A client whose roles are
+                // all state-less still sends this message - `available` alone is
+                // what unlocks the server's streams.
+                if (playerRoleActive) put("player", buildJsonObject {
                     put("volume", volume)
                     put("muted", muted)
                     // Spec: integer, range 0-5000, negative values not

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -151,6 +151,18 @@ object MessageBuilder {
         return message.toString()
     }
 
+    /**
+     * `pair/abort`.
+     *
+     * Only `concurrent_attempt` closes the connection after sending; every
+     * other reason leaves it open so the server can re-activate. Item 2.9
+     * (#226) owns the full enum and the attempt state machine.
+     */
+    fun buildPairAbort(reason: String): String = buildJsonObject {
+        put("type", SendSpinProtocol.MessageType.PAIR_ABORT)
+        put("payload", buildJsonObject { put("reason", reason) })
+    }.toString()
+
     fun buildGoodbye(reason: String): String {
         val message = buildJsonObject {
             put("type", SendSpinProtocol.MessageType.CLIENT_GOODBYE)

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -9,6 +9,31 @@ import kotlin.math.roundToInt
 
 object MessageBuilder {
 
+    /** `trust_level` values (README.md#definitions). Ordered none < user. */
+    const val TRUST_NONE = "none"
+    const val TRUST_USER = "user"
+
+    /**
+     * A `supported_pair_methods` entry.
+     *
+     * "Every client implements at least the Pairing PSK method." The PIN methods
+     * are optional for clients and are deferred to item 4.4 (#220).
+     */
+    data class PairMethodDescriptor(
+        val wireName: String,
+        val locations: List<String>,
+    ) {
+        companion object {
+            /**
+             * `locations: ["device"]` because this client generates its own
+             * Pairing PSK from a CSPRNG and shows the resulting token on screen,
+             * which is what "printed on the device" describes. Item 0.3 (#191)
+             * confirmed Music Assistant renders that hint accurately.
+             */
+            val PAIRING_PSK = PairMethodDescriptor("pairing_psk", listOf("device"))
+        }
+    }
+
     data class FormatEntry(
         val codec: String,
         val sampleRate: Int,
@@ -16,21 +41,43 @@ object MessageBuilder {
         val bitDepth: Int
     )
 
+    /**
+     * Build `client/hello`.
+     *
+     * @param clientId legacy dialect only. `client_id` and `version` moved to
+     *   `client/init` when encryption landed, and `messaging.md#communication`
+     *   forbids sending fields the spec does not define for a message - so on
+     *   an encrypted session this must be null and both fields are omitted.
+     * @param trustLevel `'user'` when a pairing record exists for this server,
+     *   `'none'` otherwise. Required.
+     * @param unpairedAccessEnabled whether this client admits a server with no
+     *   pairing record. This is what decides whether an unpaired connection can
+     *   ever carry playback: the spec permits `['playback']` on a Sentinel-keyed
+     *   session "only when the client has unpaired access enabled", so omitting
+     *   it leaves the server no choice but empty activities.
+     */
     fun buildClientHello(
-        clientId: String,
+        clientId: String?,
         deviceName: String,
         bufferCapacity: Int,
         manufacturer: String,
         supportedFormats: List<FormatEntry>,
         lowMemoryMode: Boolean = false,
-        softwareVersion: String = "unknown"
+        softwareVersion: String = "unknown",
+        trustLevel: String = TRUST_NONE,
+        unpairedAccessEnabled: Boolean = true,
+        supportedPairMethods: List<PairMethodDescriptor> = listOf(PairMethodDescriptor.PAIRING_PSK),
     ): String {
         val message = buildJsonObject {
             put("type", SendSpinProtocol.MessageType.CLIENT_HELLO)
             put("payload", buildJsonObject {
-                put("client_id", clientId)
+                // Legacy-only. On an encrypted session these live in client/init.
+                if (clientId != null) {
+                    put("client_id", clientId)
+                    put("version", SendSpinProtocol.VERSION)
+                }
                 put("name", deviceName)
-                put("version", SendSpinProtocol.VERSION)
+                put("trust_level", trustLevel)
                 put("supported_roles", buildJsonArray {
                     add(kotlinx.serialization.json.JsonPrimitive(SendSpinProtocol.Roles.PLAYER))
                     add(kotlinx.serialization.json.JsonPrimitive(SendSpinProtocol.Roles.CONTROLLER))
@@ -73,6 +120,22 @@ object MessageBuilder {
                         })
                     })
                 }
+                // Both required by messaging.md#client--server-clienthello.
+                put("supported_pair_methods", buildJsonArray {
+                    for (method in supportedPairMethods) {
+                        add(buildJsonObject {
+                            put("method", method.wireName)
+                            put("locations", buildJsonArray {
+                                for (location in method.locations) {
+                                    add(kotlinx.serialization.json.JsonPrimitive(location))
+                                }
+                            })
+                        })
+                    }
+                })
+                put("unpaired_access", buildJsonObject {
+                    put("enabled", unpairedAccessEnabled)
+                })
             })
         }
         return message.toString()
@@ -98,10 +161,25 @@ object MessageBuilder {
         return message.toString()
     }
 
+    /**
+     * Build `client/state`.
+     *
+     * @param available whether this client can participate in playback. The
+     *   spec renamed the old `state` string to a boolean (#115), so
+     *   `"synchronized"` / `"error"` / `"external_source"` no longer exist on
+     *   the wire. A player reports `true` only once its clock is synchronised:
+     *   "A player MUST NOT report `available: true` until its time filter has
+     *   converged enough to begin scheduling playback."
+     *
+     *   `false` now means only one thing - the client's output is in use by an
+     *   external system (messaging.md#external-source-handling). It is NOT the
+     *   way to report a sync problem, which is why the convergence gate lives
+     *   at the call site rather than here.
+     */
     fun buildPlayerState(
         volume: Int,
         muted: Boolean,
-        syncState: String = "synchronized",
+        available: Boolean,
         staticDelayMs: Double = 0.0,
         requiredLeadTimeMs: Int = SendSpinProtocol.PlayerTiming.REQUIRED_LEAD_TIME_MS,
         minBufferMs: Int = SendSpinProtocol.PlayerTiming.MIN_BUFFER_MS
@@ -109,9 +187,7 @@ object MessageBuilder {
         val message = buildJsonObject {
             put("type", SendSpinProtocol.MessageType.CLIENT_STATE)
             put("payload", buildJsonObject {
-                // Per spec, `state` is a top-level payload field (sibling of
-                // `player`), not part of the player object.
-                put("state", syncState)
+                put("available", available)
                 put("player", buildJsonObject {
                     put("volume", volume)
                     put("muted", muted)

--- a/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriverTest.kt
+++ b/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriverTest.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid.sendspin.protocol
 
 import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.crypto.ClientIdentity
 import com.sendspindroid.sendspin.crypto.NoiseHandshake
 import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
 import com.sendspindroid.sendspin.crypto.Psk
@@ -58,8 +59,7 @@ class SendSpinHandshakeDriverTest {
      */
     private fun driverWith(recorder: Recorder): SendSpinHandshakeDriver =
         SendSpinHandshakeDriver(
-            clientId = WireTestVectors.clientId,
-            clientStaticPrivateKey = hex(WireTestVectors.clientStaticPrivate),
+            identity = ClientIdentity(hex(WireTestVectors.clientStaticPrivate)),
             candidates = candidates,
             onEvent = recorder::handle,
             ephemeralOverrideForTest = { hex(WireTestVectors.clientEphemeralPrivate) },
@@ -158,8 +158,7 @@ class SendSpinHandshakeDriverTest {
     fun anUnknownPskIdFailsAsALookupMiss() {
         val r = Recorder()
         val driver = SendSpinHandshakeDriver(
-            clientId = WireTestVectors.clientId,
-            clientStaticPrivateKey = hex(WireTestVectors.clientStaticPrivate),
+            identity = ClientIdentity(hex(WireTestVectors.clientStaticPrivate)),
             // Sentinel only: the transcript's PSK is not a candidate.
             candidates = PskCandidateSet.sentinelOnly(),
             onEvent = r::handle,
@@ -177,8 +176,7 @@ class SendSpinHandshakeDriverTest {
         val wrongBinding = Psk(hex(WireTestVectors.psk), PskCategory.LONG_TERM, "some-other-server")
         val r = Recorder()
         val driver = SendSpinHandshakeDriver(
-            clientId = WireTestVectors.clientId,
-            clientStaticPrivateKey = hex(WireTestVectors.clientStaticPrivate),
+            identity = ClientIdentity(hex(WireTestVectors.clientStaticPrivate)),
             candidates = PskCandidateSet.of(listOf(wrongBinding)).getOrThrow(),
             onEvent = r::handle,
             ephemeralOverrideForTest = { hex(WireTestVectors.clientEphemeralPrivate) },

--- a/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/ServerActivateRulesTest.kt
+++ b/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/ServerActivateRulesTest.kt
@@ -1,0 +1,264 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.crypto.PskCategory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * The `server/activate` admissibility table.
+ *
+ * These rules decide whether an unauthenticated server gets to drive this
+ * device's audio, so the negative cases matter more than the positive ones.
+ */
+class ServerActivateRulesTest {
+
+    private fun parse(json: String): ServerActivate? =
+        ServerActivateRules.parse(
+            Json.parseToJsonElement(json).jsonObject["payload"]?.jsonObject
+        )
+
+    private fun activate(
+        vararg activities: Activity,
+        roles: List<String>? = null,
+        method: String? = null,
+    ) = ServerActivate(activities.toSet(), roles, method, null, emptyList())
+
+    private fun evaluate(
+        activate: ServerActivate,
+        category: PskCategory = PskCategory.SENTINEL,
+        unpairedAccess: Boolean = true,
+        previousRoles: List<String> = emptyList(),
+        first: Boolean = true,
+        methods: Set<String> = setOf("pairing_psk"),
+    ) = ServerActivateRules.evaluate(
+        activate, category, unpairedAccess, previousRoles, first, methods
+    )
+
+    // ---- the spec's own worked example ----
+
+    @Test
+    fun sentinelPlaybackWithUnpairedAccessDisabledAsksForPairing() {
+        // "Under a hypothetical unpaired_access: enabled, ['playback'] would be
+        // an allowed set ... so the activation would be admissible: the client
+        // closes with 'pairing_required'."
+        val outcome = evaluate(
+            activate(Activity.PLAYBACK, roles = listOf("player@v1")),
+            unpairedAccess = false,
+        )
+        assertEquals(
+            ActivationOutcome.Close(ServerActivateRules.GOODBYE_PAIRING_REQUIRED),
+            outcome,
+        )
+    }
+
+    @Test
+    fun sentinelPlaybackPlusManagementIsUnauthorizedNotPairingRequired() {
+        // "no unpaired-access setting makes that set allowed on the Sentinel
+        // PSK, so the reason is 'unauthorized'." The distinction matters: one
+        // tells the operator to pair, the other says never.
+        val outcome = evaluate(
+            activate(Activity.PLAYBACK, Activity.MANAGEMENT, roles = listOf("player@v1")),
+            unpairedAccess = false,
+        )
+        assertEquals(
+            ActivationOutcome.Close(ServerActivateRules.GOODBYE_UNAUTHORIZED),
+            outcome,
+        )
+    }
+
+    // ---- allowed sets per PSK category ----
+
+    @Test
+    fun sentinelAllowsEmptyPairingAndPlaybackOnly() {
+        assertTrue(evaluate(activate()) is ActivationOutcome.Accept)
+        assertTrue(evaluate(activate(Activity.PLAYBACK)) is ActivationOutcome.Accept)
+        // management is never allowed on an unauthenticated session.
+        assertEquals(
+            ActivationOutcome.Close(ServerActivateRules.GOODBYE_UNAUTHORIZED),
+            evaluate(activate(Activity.MANAGEMENT)),
+        )
+    }
+
+    @Test
+    fun pairingPskAllowsOnlyPairing() {
+        val cat = PskCategory.PAIRING
+        assertTrue(
+            evaluate(activate(Activity.PAIRING, method = "pairing_psk"), category = cat)
+                is ActivationOutcome.Accept
+        )
+        for (bad in listOf(setOf(Activity.PLAYBACK), emptySet(), setOf(Activity.MANAGEMENT))) {
+            assertEquals(
+                ActivationOutcome.Close(ServerActivateRules.GOODBYE_UNAUTHORIZED),
+                evaluate(ServerActivate(bad, null, null, null, emptyList()), category = cat),
+                "activities=$bad",
+            )
+        }
+    }
+
+    @Test
+    fun longTermAllowsPairingAloneOrSubsetsOfPlaybackAndManagement() {
+        val cat = PskCategory.LONG_TERM
+        assertTrue(evaluate(activate(Activity.PAIRING, method = "dynamic_pin"),
+            category = cat, methods = setOf("dynamic_pin")) is ActivationOutcome.Accept)
+        assertTrue(evaluate(activate(Activity.PLAYBACK, Activity.MANAGEMENT),
+            category = cat) is ActivationOutcome.Accept)
+        assertTrue(evaluate(activate(), category = cat) is ActivationOutcome.Accept)
+        // Mixing pairing with the others is not a permitted set.
+        assertEquals(
+            ActivationOutcome.Close(ServerActivateRules.GOODBYE_UNAUTHORIZED),
+            evaluate(activate(Activity.PAIRING, Activity.PLAYBACK), category = cat),
+        )
+    }
+
+    // ---- active_roles ----
+
+    @Test
+    fun rolesRequirePlaybackCapability() {
+        // Pairing-only connections are not playback-capable, so they may not
+        // carry roles.
+        assertEquals(
+            ActivationOutcome.Close(ServerActivateRules.GOODBYE_UNAUTHORIZED),
+            evaluate(
+                activate(Activity.PAIRING, roles = listOf("player@v1"), method = "pairing_psk"),
+                category = PskCategory.PAIRING,
+            ),
+        )
+    }
+
+    @Test
+    fun rolesMayBeCarriedWithoutPlaybackBeingDeclared() {
+        // "it may do so even when 'playback' is not currently in activities."
+        val outcome = evaluate(
+            activate(roles = listOf("player@v1")),
+            category = PskCategory.LONG_TERM,
+        )
+        assertEquals(ActivationOutcome.Accept(listOf("player@v1")), outcome)
+    }
+
+    @Test
+    fun absentRolesOnTheFirstActivationMeanEmpty() {
+        assertEquals(
+            ActivationOutcome.Accept(emptyList()),
+            evaluate(activate(Activity.PLAYBACK), first = true),
+        )
+    }
+
+    @Test
+    fun absentRolesLaterPersistThePreviousValue() {
+        assertEquals(
+            ActivationOutcome.Accept(listOf("player@v1")),
+            evaluate(
+                activate(Activity.PLAYBACK),
+                previousRoles = listOf("player@v1"),
+                first = false,
+            ),
+        )
+    }
+
+    @Test
+    fun losingPlaybackCapabilityLaterClearsRolesRatherThanRejecting() {
+        // "the persisted roles are treated as empty rather than the message
+        // rejected" - a subtle rule that would otherwise drop the connection.
+        val outcome = evaluate(
+            activate(Activity.PAIRING, method = "pairing_psk"),
+            category = PskCategory.PAIRING,
+            previousRoles = listOf("player@v1"),
+            first = false,
+        )
+        assertEquals(ActivationOutcome.Accept(emptyList()), outcome)
+    }
+
+    @Test
+    fun sourceRoleIsRefusedWhenUntrusted() {
+        // A source captures microphone or line-in audio; an unauthenticated
+        // server must never be handed it.
+        for (category in listOf(PskCategory.SENTINEL, PskCategory.PAIRING)) {
+            val outcome = evaluate(
+                activate(Activity.PLAYBACK, roles = listOf("source@v1")),
+                category = category,
+            )
+            assertEquals(
+                ActivationOutcome.Close(ServerActivateRules.GOODBYE_UNAUTHORIZED),
+                outcome,
+                category.name,
+            )
+        }
+        // Permitted once paired.
+        assertTrue(
+            evaluate(
+                activate(Activity.PLAYBACK, roles = listOf("source@v1")),
+                category = PskCategory.LONG_TERM,
+            ) is ActivationOutcome.Accept
+        )
+    }
+
+    // ---- pairing method ----
+
+    @Test
+    fun aMethodWeDoNotOfferAbortsButKeepsTheConnection() {
+        val outcome = evaluate(
+            activate(Activity.PAIRING, method = "static_pin"),
+            methods = setOf("pairing_psk"),
+        )
+        assertEquals(
+            ActivationOutcome.AbortPairing(ServerActivateRules.ABORT_METHOD_NOT_SUPPORTED),
+            outcome,
+        )
+    }
+
+    @Test
+    fun pairingPskIsOnlyValidOnAPairingPskSession() {
+        // "MUST be 'pairing_psk' if and only if the matched PSK is the Pairing PSK."
+        assertEquals(
+            ActivationOutcome.AbortPairing(ServerActivateRules.ABORT_METHOD_NOT_SUPPORTED),
+            evaluate(activate(Activity.PAIRING, method = "pairing_psk"),
+                category = PskCategory.SENTINEL),
+        )
+        assertEquals(
+            ActivationOutcome.AbortPairing(ServerActivateRules.ABORT_METHOD_NOT_SUPPORTED),
+            evaluate(activate(Activity.PAIRING, method = "dynamic_pin"),
+                category = PskCategory.PAIRING, methods = setOf("dynamic_pin")),
+        )
+    }
+
+    // ---- parsing ----
+
+    @Test
+    fun parsesActivitiesRolesAndPairing() {
+        val a = parse(
+            """{"type":"server/activate","payload":{"activities":["playback"],
+               "active_roles":["player@v1"],"pairing":{"method":"dynamic_pin","pin_length":6}}}"""
+        )!!
+        assertEquals(setOf(Activity.PLAYBACK), a.activities)
+        assertEquals(listOf("player@v1"), a.activeRoles)
+        assertEquals("dynamic_pin", a.pairingMethod)
+        assertEquals(6, a.pinLength)
+    }
+
+    @Test
+    fun distinguishesAbsentRolesFromEmptyRoles() {
+        assertNull(parse("""{"payload":{"activities":[]}}""")!!.activeRoles)
+        assertEquals(
+            emptyList(),
+            parse("""{"payload":{"activities":[],"active_roles":[]}}""")!!.activeRoles,
+        )
+    }
+
+    @Test
+    fun ignoresUnknownActivitiesRatherThanFailing() {
+        // Forward compatibility: "MUST ignore unrecognized payload fields".
+        val a = parse("""{"payload":{"activities":["playback","teleport"]}}""")!!
+        assertEquals(setOf(Activity.PLAYBACK), a.activities)
+        assertEquals(listOf("teleport"), a.unknownActivities)
+    }
+
+    @Test
+    fun missingActivitiesIsUnparseable() {
+        assertNull(parse("""{"payload":{"active_roles":[]}}"""))
+        assertNull(ServerActivateRules.parse(null))
+    }
+}

--- a/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/message/ClientHelloFieldsTest.kt
+++ b/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/message/ClientHelloFieldsTest.kt
@@ -1,0 +1,93 @@
+package com.sendspindroid.sendspin.protocol.message
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * The `client/hello` fields added for the encrypted dialect (item 1.8).
+ *
+ * `unpaired_access` is the load-bearing one. The spec permits `['playback']` on
+ * a Sentinel-keyed session "only when the client has unpaired access enabled",
+ * and aiosendspin's `_playback_capable` requires
+ * `unpaired_access.enabled and trusted_unpaired`. A client that never advertises
+ * the field leaves an unpaired server no choice but to send empty activities,
+ * so it can never play audio before pairing - which is exactly the empty
+ * `server/activate` observed while this field was missing.
+ */
+class ClientHelloFieldsTest {
+
+    private val formats = listOf(MessageBuilder.FormatEntry("pcm", 48000, 2, 16))
+
+    private fun hello(
+        clientId: String? = null,
+        trustLevel: String = MessageBuilder.TRUST_NONE,
+        unpairedAccess: Boolean = true,
+    ) = Json.parseToJsonElement(
+        MessageBuilder.buildClientHello(
+            clientId = clientId,
+            deviceName = "Tablet",
+            bufferCapacity = 1_680_000,
+            manufacturer = "test",
+            supportedFormats = formats,
+            trustLevel = trustLevel,
+            unpairedAccessEnabled = unpairedAccess,
+        )
+    ).jsonObject["payload"]!!.jsonObject
+
+    @Test
+    fun advertisesUnpairedAccessSoAnUnpairedServerCanGrantPlayback() {
+        assertEquals(
+            true,
+            hello(unpairedAccess = true)["unpaired_access"]!!
+                .jsonObject["enabled"]!!.jsonPrimitive.booleanOrNull,
+        )
+        assertEquals(
+            false,
+            hello(unpairedAccess = false)["unpaired_access"]!!
+                .jsonObject["enabled"]!!.jsonPrimitive.booleanOrNull,
+        )
+    }
+
+    @Test
+    fun carriesTrustLevel() {
+        assertEquals("none", hello()["trust_level"]!!.jsonPrimitive.content)
+        assertEquals(
+            "user",
+            hello(trustLevel = MessageBuilder.TRUST_USER)["trust_level"]!!.jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun offersThePairingPskMethodWhichEveryClientMustImplement() {
+        val methods = hello()["supported_pair_methods"]!!.jsonArray
+        assertEquals(1, methods.size)
+        val only = methods[0].jsonObject
+        assertEquals("pairing_psk", only["method"]!!.jsonPrimitive.content)
+        // Informational hint. This client generates its own Pairing PSK and
+        // shows the resulting token on screen, which is what "device" describes.
+        assertEquals("device", only["locations"]!!.jsonArray[0].jsonPrimitive.content)
+    }
+
+    @Test
+    fun omitsClientIdAndVersionOnAnEncryptedSession() {
+        // Both moved to client/init, and messaging.md forbids sending fields the
+        // spec does not define for a message.
+        val encrypted = hello(clientId = null)
+        assertFalse(encrypted.containsKey("client_id"))
+        assertFalse(encrypted.containsKey("version"))
+    }
+
+    @Test
+    fun keepsClientIdAndVersionOnTheLegacyDialect() {
+        val legacy = hello(clientId = "legacy-uuid")
+        assertTrue(legacy.containsKey("client_id"))
+        assertEquals(1, legacy["version"]!!.jsonPrimitive.content.toInt())
+    }
+}

--- a/ci/conformance/dev_server.py
+++ b/ci/conformance/dev_server.py
@@ -215,6 +215,16 @@ class DevServer:
     # -- console -----------------------------------------------------------
 
     async def console(self) -> None:
+        if self._args.no_console or not sys.stdin.isatty():
+            # Started from a script, nohup, or CI. Without this the first
+            # readline() returns EOF immediately and the server shuts down a
+            # moment after reporting that it started successfully - which looks
+            # exactly like a crash on connect. isatty() is not reliable on
+            # Windows shells, hence the explicit flag.
+            LOGGER.info("stdin is not a terminal; console disabled, serving until killed")
+            while True:
+                await asyncio.sleep(3600)
+
         loop = asyncio.get_running_loop()
         self._print_help()
         while True:
@@ -316,6 +326,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--trust-all-unpaired",
         action="store_true",
         help="auto-trust every unpaired client so it becomes playback-capable",
+    )
+    parser.add_argument(
+        "--no-console",
+        action="store_true",
+        help="do not read commands from stdin; serve until killed",
     )
     parser.add_argument(
         "--debug",


### PR DESCRIPTION
Stacked on #233 and #234 — review those first; this branch contains their commits.

Closes #197. Closes #198.

## #197: the table is enforced, not logged

`server/activate` decides whether a server gets to drive this device's audio.
`ServerActivateRules` is a pure function with **17 tests**, including both
worked examples the spec supplies — the pair that distinguishes *"pair with me
first"* from *"never"*:

| activation on a Sentinel session | outcome |
|---|---|
| `['playback']`, unpaired access **off** | `pairing_required` |
| `['playback','management']` | `unauthorized` |

The first says an operator could grant this by enabling something; the second
says no setting makes it legal. Collapsing them would send someone hunting for a
switch that cannot help.

Also enforced: only a playback-capable connection may carry `active_roles`, and
**`source@v1` is refused at trust level `none`** — a source captures microphone
or line-in audio and must never run for an unauthenticated server.

Two subtleties that are easy to get backwards, both tested:

- An absent `active_roles` means **empty on the first activation** but
  **persists the previous value** on later ones.
- A later activation that drops playback-capability without sending
  `active_roles` **clears** the persisted roles rather than rejecting. The spec
  is explicit, and rejecting would drop a connection the server considers
  healthy.

## #198: the client stops talking out of turn

*"Only after receiving the initial `server/activate` should the client send any
other messages (including `client/time` and the initial `client/state`)."* Both
now start from the first accepted activation instead of from `server/hello`.

`server/hello` carries only `name` now. `active_roles` moved to
`server/activate`, and `connection_reason` was an aiosendspin legacy-mode
invention — neither is acted on any more, though both stay parsed for the legacy
dialect that still sends them.

## Verification

```
shared : 533 tests, 0 failed
app    : 722 tests, 0 failed
```

Live against aiosendspin with `allow_unencrypted=False`: handshake completes,
`server/hello` and `server/activate` arrive encrypted, activation accepted.

## Still not demonstrated: audio actually flowing

The activation still arrives as `activities: []`, so nothing plays. As
established on #234, that's the **trust** side, not the fields — `noiseCheck`
mints a fresh `ClientIdentity` per run so `trusted_unpaired` is never true for
the same `client_id` twice, and the tool sends a hand-written `client/hello`
rather than `buildClientHello`.

Everything needed for playback is now in place on the client. Proving it needs a
pinned identity in the check tool plus a trust step — worth doing as its own
small piece of work, because it's the actual Phase 1 exit criterion and it will
exercise `available:true`, the activation accept path, and the audio path
together for the first time.
