### PR TITLE
fix(connection): stop a connect attempt announcing itself as a disconnect

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -966,7 +966,15 @@ class PlaybackService : MediaLibraryService() {
                         // From-Idle: initial connect attempt, no UI overlay needed.
                         // From-Failed: reconnect attempt after a transient failure.
                         // From-Ready: reselection (network handover) -- DRAINING applies.
-                        if (prevSendSpinState is TransportState.Ready) {
+                        if (prevSendSpinState !is TransportState.Ready) {
+                            // Announce the attempt from here, where the transition
+                            // has already happened. The connect* methods used to do
+                            // it on their first line, before anything had left Idle,
+                            // and the publisher reports observed state rather than
+                            // the argument it is handed - so that call announced
+                            // DISCONNECTED at the very moment a connection began.
+                            broadcastConnectionState(STATE_CONNECTING)
+                        } else {
                             // PORTED FROM onReconnecting (the Ready->Connecting path during
                             // network handover or stall watchdog):
                             val serverName = sendSpinClient?.getServerName() ?: ""
@@ -1868,18 +1876,31 @@ class PlaybackService : MediaLibraryService() {
         val sessionState = coordinator.sessionState.value
         val reconnectStatus = coordinator.reconnectStatus.value
 
+        // coordinator.sessionState is a combine() of several upstream flows, so it
+        // settles a beat after sendSpinClient.connectionState - the flow every
+        // collector here reacts to. Deriving the published state from the lagging
+        // copy made a broadcast triggered by a client transition announce the
+        // PREVIOUS state. On first connect the previous state is Idle, so the
+        // service announced DISCONNECTED while it was actually connecting;
+        // MainActivity reads a non-user-initiated DISCONNECTED as an unexpected
+        // drop and answers with a second, competing reconnect loop, which then
+        // tore down the connection the first one had just established.
+        val sendSpinState = sendSpinClient?.connectionState?.value ?: sessionState.sendSpin
+
         val connectionStateString = when {
             reconnectStatus is ReconnectStatus.Attempting -> STATE_RECONNECTING
-            sessionState.sendSpin is TransportState.Failed -> STATE_ERROR
-            sessionState.sendSpin is TransportState.Ready -> STATE_CONNECTED
-            sessionState.sendSpin is TransportState.Connecting -> STATE_CONNECTING
+            sendSpinState is TransportState.Failed -> STATE_ERROR
+            sendSpinState is TransportState.Ready -> STATE_CONNECTED
+            sendSpinState is TransportState.Connecting -> STATE_CONNECTING
             else -> STATE_DISCONNECTED
         }
 
         val serverName: String? = sessionState.server?.name
 
-        val errorMessage: String? = when (val s = sessionState.sendSpin) {
-            is TransportState.Failed -> failureReasonToMessage(s.reason)
+        // Same source as connectionStateString above, or STATE_ERROR could be
+        // published with a null message when the two copies disagree.
+        val errorMessage: String? = when (sendSpinState) {
+            is TransportState.Failed -> failureReasonToMessage(sendSpinState.reason)
             else -> null
         }
 
@@ -1979,8 +2000,9 @@ class PlaybackService : MediaLibraryService() {
         Log.d(TAG, "Connecting to server: $address path=$path")
         lastDisconnectUserInitiated = false
 
-        // Broadcast connecting state to controllers (MainActivity)
-        broadcastConnectionState(STATE_CONNECTING)
+        // No broadcast here: the coordinator is still Idle at this point, and
+        // the publisher reports whatever state the coordinator is in. The
+        // Connecting branch of the connectionState collector announces it.
 
         try {
             if (sendSpinClient?.isConnected == true) {
@@ -2016,8 +2038,8 @@ class PlaybackService : MediaLibraryService() {
         Log.d(TAG, "Connecting to remote server via Remote ID: $remoteId")
         lastDisconnectUserInitiated = false
 
-        // Broadcast connecting state to controllers (MainActivity)
-        broadcastConnectionState(STATE_CONNECTING)
+        // See connectToServer: announcing Connecting before the coordinator
+        // leaves Idle publishes DISCONNECTED instead.
 
         try {
             if (sendSpinClient?.isConnected == true) {
@@ -2056,8 +2078,8 @@ class PlaybackService : MediaLibraryService() {
         Log.d(TAG, "Connecting to proxy server: $url")
         lastDisconnectUserInitiated = false
 
-        // Broadcast connecting state to controllers (MainActivity)
-        broadcastConnectionState(STATE_CONNECTING)
+        // See connectToServer: announcing Connecting before the coordinator
+        // leaves Idle publishes DISCONNECTED instead.
 
         try {
             if (sendSpinClient?.isConnected == true) {


### PR DESCRIPTION
Connecting to a server always built the connection twice. The first attempt completed - transport up, `client/hello` exchanged, and on the encrypted path a full Noise handshake - and was then torn down and rebuilt from scratch.

## What happened

`broadcastSessionExtras()` publishes the state it *observes*, not the state its caller names, and it read that state from `coordinator.sessionState`. That is a `combine()` of several upstream flows, so it settles a beat after `sendSpinClient.connectionState` - the flow the collectors in this file actually react to.

Instrumenting the publisher showed the two copies disagreeing by one transition, in both directions:

```
publishing=disconnected  coordinator=Idle        client=Connecting
publishing=reconnecting  coordinator=Connecting  client=Ready
publishing=reconnecting  coordinator=Ready       client=Connecting
```

The first line is the bug. A connect broadcast fired while the lagging copy still said `Idle`, so the service announced `DISCONNECTED` at the instant a connection began. `MainActivity` treats a `DISCONNECTED` carrying `wasUserInitiated=false` as an unexpected drop and starts its own reconnect loop; that loop re-entered `connectToServer()`, found a live client, disconnected it, and started over.

The lag is inherent rather than a coding slip - `combine` re-emits on its own coroutine, so anything derived from it is always at least one dispatch behind its sources. That is fine for rendering and wrong as the truth source for an event-triggered publisher, because the trigger and the read then race by construction.

## Fix

- Derive the published state from `sendSpinClient.connectionState`, the authoritative flow, falling back to the coordinator copy only before the client exists.
- Move `errorMessage` to the same source, so `STATE_ERROR` cannot be published with a null message when the copies disagree.
- The `connect*` methods no longer broadcast before connecting - nothing has left `Idle` at that point, so the announcement described the old state. The `Connecting` branch of the collector announces it instead, after the transition has happened.

## Verification

Measured on a tablet against a live Music Assistant server:

| metric | before | after |
|---|---|---|
| `client/hello` sent | 2 | 1 |
| `Already connected, disconnecting first` | 1 | 0 |
| `Disconnecting (user-initiated)` | 1 | 0 |
| `Failed to send binary frame` | 1 | 0 |
| `Starting UI-level auto-reconnect` | 1 | 0 |
| `Transport connected` | 2 | 1 |

The UI now reports `connecting -> connected` instead of `disconnected -> reconnecting -> connected`.

722 app tests and the shared suite pass.

## Note on test coverage

No unit-level regression test is included. `PlaybackService` is a `MediaLibraryService` that no existing test instantiates, and the bug lives in the interaction between two StateFlows and an IPC broadcast - reproducing it below the device level would mean introducing Robolectric service instantiation that is new for this class. The existing `PlaybackServiceConnectionLifecycleTest` reproduces logic rather than exercising the service, so a test added there would pass with or without this fix. Verification here is the on-device measurement above. Happy to add the Robolectric harness as a follow-up if it is wanted.
