### PR TITLE
fix(conformance): make the noise check able to report audio

### DIFF
--- a/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
+++ b/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
@@ -195,8 +195,15 @@ object NoiseHandshakeCheck {
                         }
                     }
                     is NoiseWireCodec.Decoded.Typed -> {
-                        if (decoded.type == SendSpinProtocol.BinaryType.AUDIO) audioFrames++
-                        else println("<- enc   binary type=${decoded.type} ${decoded.body.size}B")
+                        if (decoded.type == SendSpinProtocol.BinaryType.AUDIO) {
+                            audioFrames++
+                            // --hold never reaches the RESULT block, so without a
+                            // line here a streaming session and a silent one look
+                            // exactly the same: no output at all.
+                            if (audioFrames == 1 || audioFrames % 100 == 0) {
+                                println("<- enc   audio frame #$audioFrames ${decoded.body.size}B")
+                            }
+                        } else println("<- enc   binary type=${decoded.type} ${decoded.body.size}B")
                     }
                     is NoiseWireCodec.Decoded.Fragment ->
                         println("<- enc   fragment type=${decoded.type}")

--- a/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
+++ b/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
@@ -259,15 +259,27 @@ object NoiseHandshakeCheck {
             !finished -> exitFail("timed out")
             !sawServerHello -> exitFail("no encrypted server/hello")
             Activity.PLAYBACK !in grantedActivities -> {
-                // Not a client bug: an unpaired client is only playback-capable
-                // once the operator trusts this client_id. Say so precisely so
-                // nobody goes looking in the wrong place.
-                println("INCOMPLETE: handshake and encrypted traffic verified, but the server")
-                println("  granted no playback activity. An unpaired client needs BOTH")
-                println("  unpaired_access advertised (it is - see client/hello above) AND")
-                println("  the operator to trust this client_id. Start the dev server with")
-                println("  --trust-all-unpaired and run this again; trust is remembered per")
-                println("  client_id, which is why this tool now persists its identity.")
+                // Never a client bug, but two very different situations share
+                // this exit. A server declares 'playback' only while playback is
+                // actually running, so an idle server reporting no playback
+                // activity is entirely normal. Separate that from "the server is
+                // offering this client nothing" so nobody looks in the wrong place.
+                println("INCOMPLETE: handshake and encrypted traffic verified, but the")
+                println("  server declared no playback activity.")
+                println()
+                if (grantedRoles.isEmpty()) {
+                    println("  It granted no roles either, so this client is not eligible to")
+                    println("  play at all. Either the operator has not trusted this client_id,")
+                    println("  or the player has not been set up on the server. For the dev")
+                    println("  server, start it with --trust-all-unpaired. Trust is remembered")
+                    println("  per client_id, which is why this tool persists its identity.")
+                } else {
+                    println("  It did grant roles, so this client IS eligible and playback is")
+                    println("  simply not running right now. A server declares")
+                    println("  activities=['playback'] when playback starts, not at connect")
+                    println("  time. Start playback on this player and re-run with --hold to")
+                    println("  watch the second server/activate and the audio frames arrive.")
+                }
                 kotlin.system.exitProcess(2)
             }
             else -> println("PASS: playback granted (activities=${grantedActivities.map { it.wireName }})")


### PR DESCRIPTION
Two fixes to `NoiseHandshakeCheck`, both found while chasing a report that a live server "connected but never streamed audio". It turned out audio *was* streaming the whole time - the tool simply had no way to say so.

## 1. `--hold` could not show that audio was arriving

The `Typed` branch counted audio frames into a variable and printed nothing, while printing a line for every *other* binary type. Combined with `--hold`'s loop never reaching the `RESULT` block, a session streaming audio and one receiving nothing produced identical output: none at all.

That is the worst possible failure mode for a diagnostic tool - it reported the same thing whether the thing under test worked or not.

Audio frames now log on the first frame and every hundredth:

```
<- enc   audio frame #1 4808B
<- enc   audio frame #100 4808B
```

Verified against a live Music Assistant server: on play it re-activates with `activities: ["playback"]`, sends `stream/start` for `pcm 48000/2/16`, then streams 25 ms chunks (4808B = 8-byte timestamp + 4800B PCM). 2300+ frames, zero AEAD failures, zero fragments.

## 2. The exit-2 message blamed trust for an idle server

The `INCOMPLETE` text told the reader the operator had to trust this `client_id` and to restart the dev server with `--trust-all-unpaired`. That is only one of two states reaching this exit, and against a live server it is the wrong one: a server declares the `playback` activity while playback is actually running, so an idle server that has granted full roles lands here as its normal resting state. The old text sent you looking in exactly the wrong place - which is what its own comment said it existed to prevent.

Split by whether roles were granted:

- **No roles** - not eligible; the trust advice still applies.
- **Roles granted** - eligible, playback simply is not running; start playback and re-run with `--hold`.

Both branches verified against a live server.
