### PR TITLE
feat(protocol): encryption only, and name the one failure a user can fix

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/coordinator/TransportState.kt
+++ b/android/app/src/main/java/com/sendspindroid/coordinator/TransportState.kt
@@ -26,4 +26,15 @@ sealed class FailureReason {
     object AuthRejected : FailureReason()
     object ProtocolError : FailureReason()
     object Exhausted : FailureReason()
+
+    /**
+     * The server answered `client/init` with a legacy `server/hello`, so it
+     * predates mandatory encryption (spec #84, 2026-06-29) and this client has
+     * no unencrypted path to offer it.
+     *
+     * Separate from [HandshakeFailed] because it is the only connection failure
+     * with a remedy the user controls: upgrade the server. Reported as such
+     * rather than as a generic "could not connect".
+     */
+    object ServerLacksEncryption : FailureReason()
 }

--- a/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
+++ b/android/app/src/main/java/com/sendspindroid/playback/PlaybackService.kt
@@ -949,6 +949,9 @@ class PlaybackService : MediaLibraryService() {
                                 is FailureReason.TransientNetwork -> "Network error"
                                 is FailureReason.ProtocolError -> "Protocol error"
                                 is FailureReason.Exhausted -> "Connection lost after multiple attempts"
+                                is FailureReason.ServerLacksEncryption ->
+                                    "This server does not support encrypted connections. " +
+                                        "Music Assistant 2.9 or newer is required."
                             }
                             Log.e(TAG, "SendSpin error: $message")
 
@@ -1967,6 +1970,9 @@ class PlaybackService : MediaLibraryService() {
         is FailureReason.TransientNetwork -> "Network error"
         is FailureReason.ProtocolError -> "Protocol error"
         is FailureReason.Exhausted -> "Connection lost after multiple attempts"
+        is FailureReason.ServerLacksEncryption ->
+            "This server does not support encrypted connections. " +
+                "Music Assistant 2.9 or newer is required."
     }
 
     /**

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -10,6 +10,7 @@ import com.sendspindroid.sendspin.transport.ProxyWebSocketTransport
 import com.sendspindroid.sendspin.protocol.ControllerState
 import com.sendspindroid.sendspin.protocol.GroupInfo
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
 import com.sendspindroid.sendspin.crypto.PskCandidateSet
 import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
 import com.sendspindroid.sendspin.protocol.SendSpinProtocolHandler
@@ -318,19 +319,6 @@ class SendSpin(
 
     // ========== Encrypted handshake (spec) ==========
 
-    /**
-     * Whether to attempt the spec's encrypted handshake.
-     *
-     * Defaults to off. Music Assistant still accepts the legacy dialect behind
-     * its `allow_legacy_clients` toggle, and flipping this default before the
-     * encrypted path has run against a real server would strand every user on a
-     * stable MA build. Automatic negotiation - try encrypted, fall back once on
-     * a handshake-phase close - is item 1.10 (#201); until then this is an
-     * explicit opt-in so the path can be exercised against the dev server.
-     */
-    @Volatile
-    var useEncryption: Boolean = false
-
     private var handshakeDriver: SendSpinHandshakeDriver? = null
 
     private fun startEncryptedHandshake() {
@@ -369,7 +357,17 @@ class SendSpin(
                 // this log line is the only diagnostic that will ever exist.
                 Log.e(TAG, "Noise handshake failed: ${event.reason} - ${event.detail}")
                 handshakeDriver = null
-                _connectionState.value = TransportState.Failed(FailureReason.HandshakeFailed)
+                // A server too old to speak the encrypted handshake is the one
+                // failure the user can fix, so it is reported as itself rather
+                // than as a generic handshake failure.
+                val reason = if (event.reason ==
+                    NoiseHandshakeException.Cause.ServerLacksEncryption
+                ) {
+                    FailureReason.ServerLacksEncryption
+                } else {
+                    FailureReason.HandshakeFailed
+                }
+                _connectionState.value = TransportState.Failed(reason)
                 transport?.close(1002, "handshake failed")
             }
         }
@@ -1420,15 +1418,18 @@ class SendSpin(
                 Log.e(TAG, "Proxy connection has no auth token - server will reject")
                 _connectionState.value = TransportState.Failed(FailureReason.AuthRejected)
                 disconnect()
-            } else if (useEncryption) {
+            } else {
                 // Spec order: client/init is the FIRST frame on the socket.
                 // client/hello moves after the Noise handshake and travels
                 // encrypted like every other application message.
+                //
+                // There is no unencrypted branch here. Encryption has been
+                // mandatory since spec #84 (2026-06-29), and a fallback would be
+                // a second wire format that only ever runs when the first one
+                // breaks - the least tested path reached exactly when things are
+                // already going wrong.
                 Log.d(TAG, "Starting encrypted handshake")
                 startEncryptedHandshake()
-            } else {
-                // Local/Remote mode: proceed directly with hello
-                sendClientHello()
             }
         }
 
@@ -1464,11 +1465,14 @@ class SendSpin(
                 }
             }
 
-            // After receiving first message post-auth, send client/hello
+            // Proxy auth is a wrapper around the socket, not a substitute for
+            // the Sendspin handshake: once the proxy has accepted us the
+            // session starts the same way every other session does, with
+            // client/init. It used to send a legacy client/hello here.
             if (awaitingAuthResponse) {
-                Log.d(TAG, "Received auth-ack, sending client/hello")
+                Log.d(TAG, "Received auth-ack, starting encrypted handshake")
                 awaitingAuthResponse = false
-                sendClientHello()
+                startEncryptedHandshake()
                 // Consume the auth-ack message; do NOT forward it to the protocol handler.
                 // If the auth-ack were forwarded, it could be misinterpreted as a protocol
                 // message (e.g., a server/hello arriving before client/hello is sent).

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -230,10 +230,10 @@ abstract class SendSpinProtocolHandler(
         }
         val bufferCapacity = MessageBuilder.calculateBufferCapacity(formats, bufferDuration)
         val text = MessageBuilder.buildClientHello(
-            // On an encrypted session client_id and version live in
-            // client/init; repeating them here would be sending fields the
-            // spec does not define for this message.
-            clientId = if (isEncrypted) null else getClientId(),
+            // Always null: client_id and version live in client/init, and every
+            // session is encrypted, so repeating them here would be sending
+            // fields the spec does not define for this message.
+            clientId = null,
             deviceName = getDeviceName(),
             bufferCapacity = bufferCapacity,
             manufacturer = getManufacturer(),

--- a/android/app/src/test/java/com/sendspindroid/e2e/DiscoverConnectPlayDisconnectTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/e2e/DiscoverConnectPlayDisconnectTest.kt
@@ -78,20 +78,25 @@ class DiscoverConnectPlayDisconnectTest : E2ETestBase() {
     }
 
     @Test
-    fun `handshake sends client hello with correct fields`() {
+    fun `connect opens with client init and withholds hello until encrypted`() {
         injectTransportAndConnect()
         fakeTransport.simulateConnected()
 
-        // Client should have sent a client/hello message
+        // client/init is the FIRST frame on the socket. Encryption is mandatory
+        // (spec #84), so there is no dialect in which hello comes first.
         assertTrue(
-            "Client should send client/hello on connect",
+            "Client should send client/init on connect",
+            fakeTransport.hasSentMessageContaining("client/init")
+        )
+        val initMsg = fakeTransport.sentTextMessages.first { it.contains("client/init") }
+        assertTrue("client/init should carry client_id", initMsg.contains("client_id"))
+
+        // client/hello rides the encrypted channel, so it cannot appear as a
+        // text frame before the Noise handshake completes.
+        assertFalse(
+            "client/hello must not precede the Noise handshake",
             fakeServer.clientSentHello()
         )
-
-        // Verify the hello message contains required fields
-        val helloMsg = fakeTransport.sentTextMessages.first { it.contains("client/hello") }
-        assertTrue("client/hello should contain client_id", helloMsg.contains("client_id"))
-        assertTrue("client/hello should contain name", helloMsg.contains("name"))
     }
 
     @Test

--- a/android/app/src/test/java/com/sendspindroid/e2e/ProxyConnectAuthTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/e2e/ProxyConnectAuthTest.kt
@@ -59,7 +59,7 @@ class ProxyConnectAuthTest : E2ETestBase() {
     }
 
     @Test
-    fun `auth-ack triggers client hello`() {
+    fun `auth-ack triggers the encrypted handshake`() {
         injectTransportAndConnect(
             mode = SendSpin.ConnectionMode.PROXY,
             serverAddress = "https://ma.example.com/sendspin",
@@ -74,8 +74,12 @@ class ProxyConnectAuthTest : E2ETestBase() {
         // Server sends auth_ok
         fakeServer.sendAuthOk()
 
-        // Now client should send client/hello
-        assertTrue("Should send client/hello after auth_ok",
+        // Proxy auth wraps the socket; it does not replace the Sendspin
+        // handshake. Once the proxy accepts us the session starts the same way
+        // any other session does - with client/init, not a legacy hello.
+        assertTrue("Should send client/init after auth_ok",
+            fakeTransport.hasSentMessageContaining("client/init"))
+        assertFalse("client/hello must not precede the Noise handshake",
             fakeServer.clientSentHello())
     }
 

--- a/android/app/src/test/java/com/sendspindroid/e2e/RemoteConnectWebRTCTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/e2e/RemoteConnectWebRTCTest.kt
@@ -153,7 +153,7 @@ class RemoteConnectWebRTCTest : E2ETestBase() {
     }
 
     @Test
-    fun `remote handshake completes with server hello`() {
+    fun `remote mode opens with the encrypted handshake`() {
         injectTransportAndConnect(
             mode = SendSpin.ConnectionMode.REMOTE,
             remoteId = "VVPN3TLP34YMGIZDINCEKQKSIR",
@@ -164,19 +164,16 @@ class RemoteConnectWebRTCTest : E2ETestBase() {
         // Simulate transport becoming connected
         fakeTransport.simulateConnected()
 
-        // Client should send hello (no auth needed for remote mode)
-        assertTrue("Should send client/hello in remote mode",
+        // Remote carries the same wire protocol as local - the DataChannel only
+        // replaces the socket - so it opens with client/init like everything else.
+        assertTrue("Should send client/init in remote mode",
+            fakeTransport.hasSentMessageContaining("client/init"))
+        assertFalse("client/hello must not precede the Noise handshake",
             fakeServer.clientSentHello())
 
-        // Server responds with hello
-        fakeServer.sendServerHello()
-
-        // Should be connected
-        assertTrue("Should be connected after remote handshake", client.isConnected)
-        assertTrue(
-            "State should be Ready after remote handshake, was: ${client.connectionState.value}",
-            client.connectionState.value is com.sendspindroid.coordinator.TransportState.Ready
-        )
+        // Reaching Ready needs a real Noise exchange, which this fake server
+        // does not perform; SendSpinHandshakeDriverTest covers that against
+        // reference-round-tripped vectors.
     }
 
     @Test

--- a/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientDisconnectTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/SendSpinClientDisconnectTest.kt
@@ -366,9 +366,15 @@ class SendSpinDisconnectTest {
         // handshakeComplete should NOT be set (auth_ok is not a server/hello)
         assertFalse("Handshake should not complete from auth_ok", stateField.get(client) as Boolean)
 
-        // A client/hello should have been sent
+        // The encrypted handshake should have started. Proxy auth wraps the
+        // socket rather than replacing the Sendspin handshake, so client/init
+        // goes out here; client/hello follows later, encrypted.
         assertTrue(
-            "sendClientHello should have been called",
+            "startEncryptedHandshake should have been called",
+            fakeTransport.sentMessages.any { it.contains("client/init") }
+        )
+        assertFalse(
+            "client/hello must not precede the Noise handshake",
             fakeTransport.sentMessages.any { it.contains("client/hello") }
         )
     }

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/NoiseHandshakeException.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/NoiseHandshakeException.kt
@@ -44,5 +44,17 @@ class NoiseHandshakeException(
          * Noise-handshake phases.
          */
         Timeout,
+
+        /**
+         * The peer answered `client/init` with something other than
+         * `server/init` - in practice a legacy `server/hello`, from a server
+         * predating mandatory encryption (spec #84, 2026-06-29).
+         *
+         * Distinct from [MalformedMessage] because nothing is malformed: the
+         * reply is a well-formed message in an older dialect. It is the one
+         * handshake failure a user can act on, so it must be separable from
+         * the crypto failures in order to say so.
+         */
+        ServerLacksEncryption,
     }
 }

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriver.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriver.kt
@@ -135,8 +135,12 @@ class SendSpinHandshakeDriver(
     private fun handleServerInit(raw: ByteArray) {
         val envelope = parseEnvelope(raw) ?: return
         if (envelope.first != SendSpinProtocol.MessageType.SERVER_INIT) {
+            // A server that predates mandatory encryption answers client/init
+            // with a legacy server/hello rather than server/init. That is the
+            // one failure here a user can do something about, so it gets its
+            // own cause instead of being folded into MalformedMessage.
             return fail(
-                NoiseHandshakeException.Cause.MalformedMessage,
+                NoiseHandshakeException.Cause.ServerLacksEncryption,
                 "expected server/init, got ${envelope.first}",
             )
         }

--- a/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriverTest.kt
+++ b/android/shared/src/commonTest/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriverTest.kt
@@ -230,6 +230,29 @@ class SendSpinHandshakeDriverTest {
     }
 
     @Test
+    fun aLegacyServerHelloReplyIsReportedAsLackingEncryption() {
+        // A server predating mandatory encryption (spec #84) answers client/init
+        // with a legacy server/hello. Nothing is malformed - it is a well-formed
+        // message in an older dialect - and it is the only handshake failure the
+        // user can act on, so it must be distinguishable from the crypto
+        // failures for the app to say "upgrade your server" rather than
+        // "could not connect".
+        val r = Recorder()
+        val driver = driverWith(r)
+        driver.start()
+        driver.onCleartextFrame(
+            """{"type":"server/hello","payload":{"name":"Music Assistant"}}""".encodeToByteArray()
+        )
+        assertEquals(
+            NoiseHandshakeException.Cause.ServerLacksEncryption,
+            r.failures.single().first
+        )
+        assertEquals(SendSpinHandshakeDriver.Phase.Failed, driver.phase)
+        // Never reply to it: only our own client/init was ever sent.
+        assertEquals(1, r.sent.size)
+    }
+
+    @Test
     fun timeoutFailsBeforeTransportAndIsIgnoredAfter() {
         val r = Recorder()
         val driver = driverWith(r)

--- a/docs/spec-compliance-audit-2026-08-13.md
+++ b/docs/spec-compliance-audit-2026-08-13.md
@@ -278,7 +278,39 @@ have to write. If it does not expose `h`, hand-roll.
 Android has no storage pressure. Binding each PSK to a `server_id` is the
 stronger option and is what `management/list-records` reports.
 
-**D5. Keep the legacy dialect behind a flag through Phase 2.**
+**D5. REVISED (2026-08-17, issue #201): encryption only. There is no legacy
+fallback and no unencrypted path.**
+
+The original decision assumed a fallback was needed to keep MA stable users
+working. Section 2 of this document contradicts that on its own terms: MA 2.9.13
+stable pins `aiosendspin[server]==9.1.0`, which ships the full `noise/` package.
+`allow_legacy_clients` is merely *on by default* and documented temporary - 2.9.x
+servers can already speak the encrypted dialect, so they never needed the
+fallback. Confirmed empirically on 2026-08-17: the app completed a Noise KKpsk2
+handshake against a live Music Assistant instance, was granted `player@v1`, and
+streamed and played audio over the encrypted channel.
+
+Encryption has been normative since 2026-06-29 (spec #84). A fallback would be a
+second wire format exercised only when the first one fails - the least-tested
+path in the client, reached exactly when something is already wrong - and it
+would keep the legacy dialect alive indefinitely, since nothing would force its
+removal.
+
+Consequences, accepted deliberately:
+
+- **Minimum supported server is Music Assistant 2.9.** Anything older has no
+  encrypted endpoint and cannot be connected to at all.
+- That failure must be legible rather than silent. A server predating mandatory
+  encryption answers `client/init` with a legacy `server/hello`; this is now its
+  own `NoiseHandshakeException.Cause.ServerLacksEncryption` rather than being
+  folded into `MalformedMessage`, and it surfaces as "This server does not
+  support encrypted connections. Music Assistant 2.9 or newer is required."
+  It is the one connection failure with a remedy the user controls, so it must
+  be separable from the crypto failures.
+- The minimum version belongs in the release notes. Discovering it as a failed
+  connection is a bad first experience for anyone on an older MA.
+
+Original reasoning, retained for context:
 Users on MA stable (2.9.x) and older builds must keep working while the encrypted
 path stabilizes. Detect by outcome: attempt the spec handshake, and on a
 handshake-phase close, fall back once to the legacy `client/hello` path and
@@ -326,7 +358,7 @@ survives `allow_legacy_clients=False`.
 | 1.7 | Gate all client output on the first `server/activate`; stop reading `active_roles`/`connection_reason` from `server/hello` | `messaging.md#server--client-serveractivate` | `SendSpinProtocolHandler.kt:566-590`, `MessageParser.kt:29-49` | No `client/time` or `client/state` on the wire before the first `server/activate` |
 | 1.8 | `client/hello`: add `trust_level`, `supported_pair_methods`, `unpaired_access`; remove `client_id` and `version` (they moved to `client/init`) | `messaging.md#client--server-clienthello` | `MessageBuilder.kt:19-79` | Matches the spec field list exactly; aiosendspin accepts it without warnings |
 | 1.9 | `client/state`: replace the `state` string with `available: boolean`. Do not report `available: true` until the time filter has converged | `messaging.md#client--server-clientstate` | `MessageBuilder.kt:101-134`, `SendSpinProtocolHandler.kt:319-399` | First `client/state` carries `available: false` (or is withheld) until `timeFilter.isConverged` |
-| 1.10 | Legacy fallback behind D5: try spec handshake, fall back once to the legacy dialect on handshake-phase failure, surface an "unencrypted" indicator in the UI | - | `SendSpin.kt`, connection UI | Connects to both MA 2.9.x (legacy) and an `allow_unencrypted=False` server |
+| 1.10 | Encryption only (revised D5): remove the `useEncryption` flag and the legacy `client/hello` branch so the encrypted handshake is the only path, including after proxy auth. Report a server that answers `client/init` with a legacy `server/hello` as its own failure, not a generic one | - | `SendSpin.kt`, `SendSpinHandshakeDriver.kt`, `NoiseHandshakeException.kt`, `TransportState.kt` | Connects to an `allow_unencrypted=False` server; a pre-2.9 server produces "does not support encrypted connections", not "could not connect" |
 
 **Phase 1 exit criterion:** the conformance harness passes the encrypted
 unpaired-playback scenario against aiosendspin with `allow_unencrypted=False`,
@@ -456,8 +488,17 @@ plus `phase-0` .. `phase-4`.
 
 ### Findings from planning that amend section 4
 
-Two decisions changed while the plans were being written. The issues carry the
+Three decisions changed while the plans were being written. The issues carry the
 corrected guidance; this records why.
+
+**D5 (legacy fallback) is withdrawn: the client is encryption-only.** The
+premise - that MA stable users need an unencrypted path - is contradicted by
+section 2 of this document: 2.9.13 stable pins `aiosendspin[server]==9.1.0`,
+which has full Noise support, so the legacy shim is a default rather than a
+necessity. Encryption is normative (spec #84, 2026-06-29), and a fallback would
+be a second wire format reached only when the first fails. The cost is a minimum
+supported server of MA 2.9, reported through a dedicated failure rather than a
+generic one. See the revised D5 above; #201 carries the work.
 
 **D3 (Noise library) now expects a negative result.** Reading
 `org.signal.forks:noise-java` 0.1.1 at source shows `Pattern.lookup` has no `PSK`


### PR DESCRIPTION
Removes the legacy dialect from the app. The encrypted handshake is now the only way this client talks to a server.

Closes #201. Amends decision D5 in `docs/spec-compliance-audit-2026-08-13.md`.

## Why D5 is withdrawn

D5 kept a legacy fallback so users on Music Assistant stable would keep working. Section 2 of the audit contradicts its own D5: **MA 2.9.13 stable pins `aiosendspin[server]==9.1.0`, which ships the full `noise/` package.** `allow_legacy_clients` is merely on by default and documented temporary - 2.9.x servers can already speak the encrypted dialect and never needed the fallback.

Encryption has been normative since spec #84 (2026-06-29). A fallback would be a second wire format exercised only when the first one fails - the least-tested path in the client, reached exactly when something is already wrong - and nothing would ever force its removal.

## What changed

- The `useEncryption` flag and the `else { sendClientHello() }` branch are gone; `startEncryptedHandshake()` is the only route.
- **Proxy mode starts the same way.** Auth wraps the socket, it does not replace the Sendspin handshake, so `auth-ack` now sends `client/init` rather than a legacy hello.
- `sendClientHello()` passes `clientId = null` unconditionally - `client_id` and `version` live in `client/init`.

## Naming the one failure a user can fix

A server predating mandatory encryption answers `client/init` with a legacy `server/hello`. That was reported as `MalformedMessage`, which is both wrong - nothing is malformed, it is a well-formed message in an older dialect - and useless, because it put the one failure a user can act on in the same bucket as AEAD tag mismatches and truncated frames.

It now has its own `Cause.ServerLacksEncryption`, surfaced as `FailureReason.ServerLacksEncryption`:

> This server does not support encrypted connections. Music Assistant 2.9 or newer is required.

## Consequences, accepted deliberately

- **Minimum supported server is MA 2.9.** Anything older cannot connect at all. This belongs in the release notes rather than being discovered as a failed connection.
- With no fallback, a field bug in the handshake has no in-app workaround. A developer-only escape hatch was considered and not added; worth revisiting if the handshake proves unstable in the field.

## Tests

722 app tests and the shared suite pass.

Four tests asserted the legacy opening and now assert the encrypted one - `client/init` first, `client/hello` withheld until the handshake completes: `DiscoverConnectPlayDisconnectTest`, `ProxyConnectAuthTest`, `RemoteConnectWebRTCTest`, `SendSpinClientDisconnectTest`.

Added `aLegacyServerHelloReplyIsReportedAsLackingEncryption` pinning the new classification.

**One reduction worth flagging:** `RemoteConnectWebRTCTest` loses its `isConnected`/`Ready` assertions. Reaching Ready now needs a real Noise exchange the fake server cannot perform; `SendSpinHandshakeDriverTest` covers that against reference-round-tripped vectors, but that particular test proves less than it did.

## Verification

On device against a live Music Assistant server: handshake completed, playback granted, audio playing, clock sync converged to 189us error and -7.68ppm drift, zero handshake failures.

## Out of scope

The CI conformance adapter (`conformance-client/Main.kt`) still speaks the legacy dialect, because `client-initiated-pcm` is the harness's scenario contract and `buildClientHello` keeps its `clientId` parameter for it. Migrating that adapter needs the harness scenario to expect encryption, and is tracked separately.
