### PR TITLE
feat(protocol): message fragmentation for binary types 2 and 3

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -970,11 +970,11 @@ abstract class SendSpinProtocolHandler(
             is NoiseWireCodec.Decoded.Typed ->
                 BinaryMessageParser.parse(decoded.type, decoded.body)
                     ?.let { dispatchBinaryMessage(it) }
-            is NoiseWireCodec.Decoded.Fragment ->
-                // Reassembly lands in item 1.5. Until then a fragmented message
-                // is unreadable, and silently ignoring it would strand the
-                // stream; the spec's answer to an unhandleable frame is to close.
-                onProtocolFailure("fragmentation is not implemented yet (item 1.5)")
+            is NoiseWireCodec.Decoded.Buffered -> {
+                // A fragment landed and the message is still incomplete. The
+                // codec holds the partial buffer; nothing to dispatch until the
+                // fragment-end frame arrives.
+            }
             is NoiseWireCodec.Decoded.ProtocolError ->
                 onProtocolFailure(decoded.reason)
         }

--- a/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
+++ b/android/conformance-client/src/main/kotlin/com/sendspindroid/conformance/NoiseHandshakeCheck.kt
@@ -198,8 +198,8 @@ object NoiseHandshakeCheck {
                         if (decoded.type == SendSpinProtocol.BinaryType.AUDIO) audioFrames++
                         else println("<- enc   binary type=${decoded.type} ${decoded.body.size}B")
                     }
-                    is NoiseWireCodec.Decoded.Fragment ->
-                        println("<- enc   fragment type=${decoded.type}")
+                    is NoiseWireCodec.Decoded.Buffered ->
+                        println("<- enc   fragment buffered")
                     is NoiseWireCodec.Decoded.ProtocolError ->
                         fail("decode failed: ${decoded.reason}")
                 }

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/NoiseWireCodecFragmentationTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/NoiseWireCodecFragmentationTest.kt
@@ -1,0 +1,116 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.protocol.message.FragmentWriter
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Fragmentation as seen through [NoiseWireCodec].
+ *
+ * The codec is the only place that sees decrypted plaintexts, so it is where
+ * reassembly has to happen. These tests use identity "crypto" so the framing is
+ * the only thing under test - the real AEAD is covered by the handshake driver's
+ * golden vectors.
+ */
+class NoiseWireCodecFragmentationTest {
+
+    /** A codec whose encrypt/decrypt are the identity, so plaintext == frame. */
+    private fun plaintextCodec() = NoiseWireCodec(
+        decrypt = { it },
+        encrypt = { it },
+    )
+
+    @Test
+    fun aFragmentedJsonMessageIsReassembledIntoJson() {
+        // orig_type 0 must come back out as Json, not as a Typed frame of type 0.
+        val codec = plaintextCodec()
+        val json = """{"type":"server/state","payload":{}}"""
+        val frames = FragmentWriter.frames(
+            SendSpinProtocol.BinaryType.JSON,
+            json.encodeToByteArray(),
+        )
+        // Force fragmentation regardless of size by feeding hand-built frames.
+        val big = FragmentWriter.frames(
+            SendSpinProtocol.BinaryType.JSON,
+            ByteArray(70_000) { 0x20 },  // spaces, so it is still valid UTF-8
+        )
+        assertTrue("precondition: should have fragmented", big.size > 1)
+
+        var last: NoiseWireCodec.Decoded? = null
+        for (frame in frames) last = codec.decode(frame)
+        assertTrue(last is NoiseWireCodec.Decoded.Json)
+        assertEquals(json, (last as NoiseWireCodec.Decoded.Json).text)
+    }
+
+    @Test
+    fun aFragmentedAudioMessageIsReassembledAsTyped() {
+        val codec = plaintextCodec()
+        val payload = ByteArray(200_000) { (it % 251).toByte() }
+        val frames = FragmentWriter.frames(SendSpinProtocol.BinaryType.AUDIO, payload)
+        assertTrue("precondition: should have fragmented", frames.size > 2)
+
+        val results = frames.map { codec.decode(it) }
+        // Every frame but the last buffers silently.
+        for (r in results.dropLast(1)) {
+            assertTrue("expected Buffered, got $r", r is NoiseWireCodec.Decoded.Buffered)
+        }
+        val complete = results.last()
+        assertTrue(complete is NoiseWireCodec.Decoded.Typed)
+        complete as NoiseWireCodec.Decoded.Typed
+        assertEquals(SendSpinProtocol.BinaryType.AUDIO, complete.type)
+        assertArrayEquals(payload, complete.body)
+    }
+
+    @Test
+    fun anUnfragmentedFrameStillDecodesNormally() {
+        val codec = plaintextCodec()
+        val decoded = codec.decode(
+            byteArrayOf(SendSpinProtocol.BinaryType.AUDIO.toByte(), 1, 2, 3)
+        )
+        assertTrue(decoded is NoiseWireCodec.Decoded.Typed)
+        assertArrayEquals(byteArrayOf(1, 2, 3), (decoded as NoiseWireCodec.Decoded.Typed).body)
+    }
+
+    @Test
+    fun aMalformedFragmentSequenceIsAProtocolError() {
+        // fragment-end with nothing in flight. The caller closes the socket on
+        // this, so it must not be swallowed as an ignorable unknown frame.
+        val codec = plaintextCodec()
+        val decoded = codec.decode(
+            byteArrayOf(SendSpinProtocol.BinaryType.FRAGMENT_END.toByte(), 0xA)
+        )
+        assertTrue(decoded is NoiseWireCodec.Decoded.ProtocolError)
+    }
+
+    @Test
+    fun aNonFragmentFrameArrivingMidSequenceIsAProtocolError() {
+        val codec = plaintextCodec()
+        codec.decode(byteArrayOf(SendSpinProtocol.BinaryType.FRAGMENT_MORE.toByte(), 0, 0xA))
+        val decoded = codec.decode(
+            byteArrayOf(SendSpinProtocol.BinaryType.AUDIO.toByte(), 1, 2, 3)
+        )
+        assertTrue(decoded is NoiseWireCodec.Decoded.ProtocolError)
+    }
+
+    @Test
+    fun encodeSplitsAnOversizePayloadAndKeepsEveryFrameUnderTheNoiseLimit() {
+        val codec = plaintextCodec()
+        val frames = kotlinx.coroutines.runBlocking {
+            codec.encode(SendSpinProtocol.BinaryType.AUDIO, ByteArray(200_000))
+        }
+        assertTrue("should have fragmented", frames.size > 2)
+        for (f in frames) {
+            assertTrue("frame too big", f.size <= SendSpinProtocol.NoiseFraming.MAX_TRANSPORT_MESSAGE)
+        }
+    }
+
+    @Test
+    fun encodeNoLongerThrowsOnAnOversizePayload() {
+        // Before fragmentation landed this threw MessageTooLarge. It must now
+        // succeed, or artwork over 64 KB can never be sent.
+        val codec = plaintextCodec()
+        kotlinx.coroutines.runBlocking {
+            codec.encode(SendSpinProtocol.BinaryType.ARTWORK_BASE, ByteArray(300_000))
+        }
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/FragmentReassemblerTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/FragmentReassemblerTest.kt
@@ -1,0 +1,160 @@
+package com.sendspindroid.sendspin.protocol.message
+
+import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Receiver side of `messaging.md#fragmentation`.
+ *
+ * Pure byte manipulation, so no Log mocking is needed here - the reassembler
+ * reports problems by returning [FragmentReassembler.Result.ProtocolError],
+ * never by logging and continuing. A malformed sequence MUST close the
+ * connection, so silently swallowing one would be a spec violation.
+ */
+class FragmentReassemblerTest {
+
+    private val more = SendSpinProtocol.BinaryType.FRAGMENT_MORE
+    private val end = SendSpinProtocol.BinaryType.FRAGMENT_END
+
+    private fun bytes(vararg values: Int) = ByteArray(values.size) { values[it].toByte() }
+
+    @Test
+    fun threeFrameSequenceReassemblesJsonBody() {
+        val r = FragmentReassembler()
+        assertEquals(
+            FragmentReassembler.Result.Buffered,
+            r.accept(more, bytes(0, 0x7B, 0x22))  // orig_type 0 (JSON), then {"
+        )
+        assertEquals(
+            FragmentReassembler.Result.Buffered,
+            r.accept(more, bytes(0x61, 0x22))     // a"
+        )
+        val result = r.accept(end, bytes(0x7D))   // }
+        assertTrue(result is FragmentReassembler.Result.Complete)
+        result as FragmentReassembler.Result.Complete
+        assertEquals(0, result.type)
+        assertArrayEquals(bytes(0x7B, 0x22, 0x61, 0x22, 0x7D), result.body)
+    }
+
+    @Test
+    fun minimumSequenceOneMoreThenOneEndCompletes() {
+        // "The minimum is one fragment-more frame followed by one fragment-end
+        // frame."
+        val r = FragmentReassembler()
+        r.accept(more, bytes(4, 0xAA))
+        val result = r.accept(end, bytes(0xBB))
+        assertTrue(result is FragmentReassembler.Result.Complete)
+        result as FragmentReassembler.Result.Complete
+        assertEquals(4, result.type)
+        assertArrayEquals(bytes(0xAA, 0xBB), result.body)
+    }
+
+    @Test
+    fun emptyFinalFragmentCompletes() {
+        // A fragment-end carrying no data is legal: it terminates the message.
+        val r = FragmentReassembler()
+        r.accept(more, bytes(8, 0x01, 0x02))
+        val result = r.accept(end, ByteArray(0))
+        assertTrue(result is FragmentReassembler.Result.Complete)
+        result as FragmentReassembler.Result.Complete
+        assertEquals(8, result.type)
+        assertArrayEquals(bytes(0x01, 0x02), result.body)
+    }
+
+    @Test
+    fun continuationFrameFirstByteIsDataNotOrigType() {
+        // The subtle one. "when a fragmented message is already in flight, a
+        // type 2 frame is a continuation and carries only data" - so a leading
+        // 0x02 here is payload, not a nested orig_type.
+        val r = FragmentReassembler()
+        r.accept(more, bytes(0, 0xAA))
+        r.accept(more, bytes(0x02))
+        val result = r.accept(end, ByteArray(0))
+        assertTrue(result is FragmentReassembler.Result.Complete)
+        result as FragmentReassembler.Result.Complete
+        assertEquals(0, result.type)
+        assertArrayEquals(bytes(0xAA, 0x02), result.body)
+    }
+
+    @Test
+    fun origTypeTwoIsProtocolError() {
+        // "A sender MUST NOT use a fragment type (2 or 3) as orig_type."
+        val r = FragmentReassembler()
+        assertTrue(r.accept(more, bytes(2, 0xAA)) is FragmentReassembler.Result.ProtocolError)
+    }
+
+    @Test
+    fun origTypeThreeIsProtocolError() {
+        val r = FragmentReassembler()
+        assertTrue(r.accept(more, bytes(3, 0xAA)) is FragmentReassembler.Result.ProtocolError)
+    }
+
+    @Test
+    fun fragmentEndWithNothingInFlightIsProtocolError() {
+        val r = FragmentReassembler()
+        assertTrue(r.accept(end, bytes(0xAA)) is FragmentReassembler.Result.ProtocolError)
+    }
+
+    @Test
+    fun nonFragmentFrameWhileInFlightIsProtocolError() {
+        // "a non-fragment frame received while a fragmented message is in
+        // flight in the same direction" - type 4 is audio.
+        val r = FragmentReassembler()
+        r.accept(more, bytes(0, 0xAA))
+        assertTrue(r.accept(4, bytes(0xBB)) is FragmentReassembler.Result.ProtocolError)
+    }
+
+    @Test
+    fun nonFragmentFrameWithNothingInFlightPassesThrough() {
+        // Lets the codec hand every frame to the reassembler rather than
+        // duplicating the "is this fragment-related?" test at the call site.
+        val r = FragmentReassembler()
+        assertEquals(FragmentReassembler.Result.Passthrough, r.accept(4, bytes(0xAA)))
+    }
+
+    @Test
+    fun openingFragmentWithEmptyBodyIsProtocolError() {
+        // No room for orig_type.
+        val r = FragmentReassembler()
+        assertTrue(r.accept(more, ByteArray(0)) is FragmentReassembler.Result.ProtocolError)
+    }
+
+    @Test
+    fun exceedingSizeCapIsProtocolErrorNotOom() {
+        // The spec sets no cap; an unbounded reassembly buffer is a remote
+        // memory-exhaustion vector on a phone. Exceeding it must be an error,
+        // never a silent truncation.
+        val r = FragmentReassembler(maxMessageBytes = 1024)
+        r.accept(more, bytes(0) + ByteArray(600))
+        val result = r.accept(more, ByteArray(600))
+        assertTrue(result is FragmentReassembler.Result.ProtocolError)
+    }
+
+    @Test
+    fun resetClearsInFlightState() {
+        val r = FragmentReassembler()
+        r.accept(more, bytes(0, 0xAA))
+        r.reset()
+        // With nothing in flight this is an opening frame again, so orig_type
+        // is read from byte 0 and the result is Buffered, not ProtocolError.
+        assertEquals(FragmentReassembler.Result.Buffered, r.accept(more, bytes(4, 0xBB)))
+        val result = r.accept(end, ByteArray(0))
+        assertTrue(result is FragmentReassembler.Result.Complete)
+        assertEquals(4, (result as FragmentReassembler.Result.Complete).type)
+    }
+
+    @Test
+    fun completingAMessageClearsStateForTheNext() {
+        val r = FragmentReassembler()
+        r.accept(more, bytes(0, 0xAA))
+        r.accept(end, ByteArray(0))
+        // A second, independent message must reassemble cleanly.
+        r.accept(more, bytes(16, 0xCC))
+        val result = r.accept(end, bytes(0xDD))
+        assertTrue(result is FragmentReassembler.Result.Complete)
+        result as FragmentReassembler.Result.Complete
+        assertEquals(16, result.type)
+        assertArrayEquals(bytes(0xCC, 0xDD), result.body)
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/FragmentWriterTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/FragmentWriterTest.kt
@@ -1,0 +1,109 @@
+package com.sendspindroid.sendspin.protocol.message
+
+import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Sender side of `messaging.md#fragmentation`.
+ *
+ * The writer emits AEAD *plaintexts* - `[type][data]` - which the Noise codec
+ * then encrypts one at a time. Nothing here knows about encryption.
+ */
+class FragmentWriterTest {
+
+    private val more = SendSpinProtocol.BinaryType.FRAGMENT_MORE
+    private val end = SendSpinProtocol.BinaryType.FRAGMENT_END
+
+    @Test
+    fun payloadOf65518BytesProducesExactlyOneUnfragmentedFrame() {
+        // "Senders should not fragment messages that fit in a single
+        // non-fragmented frame." 1 + 65518 == 65519 == MAX_PLAINTEXT.
+        val frames = FragmentWriter.frames(4, ByteArray(Fragmentation.MAX_UNFRAGMENTED_PAYLOAD))
+        assertEquals(1, frames.size)
+        assertEquals(Fragmentation.MAX_PLAINTEXT, frames[0].size)
+        assertEquals(4, frames[0][0].toInt() and 0xFF)
+    }
+
+    @Test
+    fun payloadOf65519BytesProducesTwoFrames() {
+        // One byte over. Opening frame spends a byte on orig_type, so it can
+        // only carry 65517 data; the 2-byte remainder rides the fragment-end.
+        val frames = FragmentWriter.frames(4, ByteArray(Fragmentation.MAX_UNFRAGMENTED_PAYLOAD + 1))
+        assertEquals(2, frames.size)
+        assertEquals(Fragmentation.MAX_PLAINTEXT, frames[0].size)
+        assertEquals(more, frames[0][0].toInt() and 0xFF)
+        assertEquals(4, frames[0][1].toInt() and 0xFF)   // orig_type
+        assertEquals(3, frames[1].size)                   // [3] + 2 data bytes
+        assertEquals(end, frames[1][0].toInt() and 0xFF)
+    }
+
+    @Test
+    fun writerNeverProducesPlaintextOverTheNoiseLimit() {
+        for (size in listOf(0, 1, 1000, 65517, 65518, 65519, 65520, 131072, 300000)) {
+            for (frame in FragmentWriter.frames(0, ByteArray(size))) {
+                assertTrue(
+                    "payload $size produced a ${frame.size}-byte plaintext",
+                    frame.size <= Fragmentation.MAX_PLAINTEXT
+                )
+            }
+        }
+    }
+
+    @Test
+    fun aFragmentedMessageOpensWithMoreContinuesWithMoreAndEndsWithEnd() {
+        // "A fragmented message consists of an opening fragment-more frame
+        // (carrying orig_type), zero or more continuation fragment-more frames,
+        // and a closing fragment-end frame."
+        val frames = FragmentWriter.frames(8, ByteArray(200_000))
+        assertTrue("should have fragmented", frames.size > 2)
+        assertEquals(more, frames.first()[0].toInt() and 0xFF)
+        assertEquals(8, frames.first()[1].toInt() and 0xFF)  // orig_type, opening frame only
+        for (middle in frames.subList(1, frames.size - 1)) {
+            assertEquals(more, middle[0].toInt() and 0xFF)
+        }
+        assertEquals(end, frames.last()[0].toInt() and 0xFF)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun writerRejectsOrigTypeTwo() {
+        FragmentWriter.frames(more, ByteArray(10))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun writerRejectsOrigTypeThree() {
+        FragmentWriter.frames(end, ByteArray(10))
+    }
+
+    @Test
+    fun roundTripWriterThenReassembler() {
+        val sizes = listOf(0, 1, 1000, 65517, 65518, 65519, 131072, 300000)
+        val types = listOf(0, 4, 8, 16)
+        for (type in types) {
+            for (size in sizes) {
+                val payload = ByteArray(size) { (it * 31 + type).toByte() }
+                val frames = FragmentWriter.frames(type, payload)
+                val r = FragmentReassembler()
+                var delivered: Pair<Int, ByteArray>? = null
+                for (frame in frames) {
+                    val frameType = frame[0].toInt() and 0xFF
+                    val body = frame.copyOfRange(1, frame.size)
+                    when (val result = r.accept(frameType, body)) {
+                        is FragmentReassembler.Result.Complete ->
+                            delivered = result.type to result.body
+                        // A message small enough not to need fragmenting comes
+                        // straight back out as itself.
+                        FragmentReassembler.Result.Passthrough ->
+                            delivered = frameType to body
+                        FragmentReassembler.Result.Buffered -> {}
+                        is FragmentReassembler.Result.ProtocolError ->
+                            fail("type $type size $size: ${result.reason}")
+                    }
+                }
+                assertNotNull("type $type size $size never completed", delivered)
+                assertEquals("type $type size $size", type, delivered!!.first)
+                assertArrayEquals("type $type size $size", payload, delivered.second)
+            }
+        }
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/NoiseWireCodec.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/NoiseWireCodec.kt
@@ -2,6 +2,8 @@ package com.sendspindroid.sendspin.protocol
 
 import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
 import com.sendspindroid.sendspin.crypto.NoiseTransport
+import com.sendspindroid.sendspin.protocol.message.FragmentReassembler
+import com.sendspindroid.sendspin.protocol.message.FragmentWriter
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -25,7 +27,16 @@ import kotlinx.coroutines.sync.withLock
  * This is the only place that byte is added or stripped. Fragmentation (item
  * 1.5) plugs in here too, which is why [encodeJson] and [encode] return a list.
  */
-class NoiseWireCodec(private val transport: NoiseTransport) {
+class NoiseWireCodec internal constructor(
+    private val decrypt: (ByteArray) -> ByteArray,
+    private val encrypt: (ByteArray) -> ByteArray,
+    private val reassembler: FragmentReassembler = FragmentReassembler(),
+) {
+
+    constructor(transport: NoiseTransport) : this(
+        decrypt = { transport.decrypt(it) },
+        encrypt = { transport.encrypt(it) },
+    )
 
     /**
      * Serialises sends.
@@ -49,21 +60,14 @@ class NoiseWireCodec(private val transport: NoiseTransport) {
      */
     suspend fun encode(type: Int, payload: ByteArray): List<ByteArray> {
         require(type in 0..255) { "binary message type is a uint8, got $type" }
-        if (payload.size > SendSpinProtocol.NoiseFraming.MAX_PAYLOAD) {
-            // Item 1.5 replaces this with a fragmented send. Failing loudly is
-            // the right interim behaviour: silently truncating or letting the
-            // AEAD reject it would both be far harder to diagnose.
-            throw NoiseHandshakeException(
-                NoiseHandshakeException.Cause.MessageTooLarge,
-                "payload of ${payload.size} bytes exceeds the " +
-                    "${SendSpinProtocol.NoiseFraming.MAX_PAYLOAD}-byte single-frame " +
-                    "limit and fragmentation is not implemented yet (item 1.5)",
-            )
-        }
-        val plaintext = ByteArray(1 + payload.size)
-        plaintext[0] = type.toByte()
-        payload.copyInto(plaintext, 1)
-        return sendMutex.withLock { listOf(transport.encrypt(plaintext)) }
+        // FragmentWriter returns one frame when the payload fits and a
+        // fragment-more/.../fragment-end sequence when it does not. The mutex is
+        // held across the whole list, which is what enforces "a sender must
+        // finish a fragmented message before sending any other frame in that
+        // direction" - a second sender interleaving here would corrupt both
+        // messages and desynchronise the peer's reassembly buffer.
+        val plaintexts = FragmentWriter.frames(type, payload)
+        return sendMutex.withLock { plaintexts.map { encrypt(it) } }
     }
 
     /**
@@ -82,7 +86,7 @@ class NoiseWireCodec(private val transport: NoiseTransport) {
             )
         }
         val plaintext = try {
-            transport.decrypt(frameBytes)
+            decrypt(frameBytes)
         } catch (e: NoiseHandshakeException) {
             // Includes a replayed or reordered frame: the per-direction counter
             // means a repeat fails the tag check rather than decrypting twice.
@@ -93,13 +97,27 @@ class NoiseWireCodec(private val transport: NoiseTransport) {
         }
         val type = plaintext[0].toInt() and 0xFF
         val body = plaintext.copyOfRange(1, plaintext.size)
-        return when (type) {
-            SendSpinProtocol.BinaryType.JSON -> Decoded.Json(body.decodeToString())
-            SendSpinProtocol.BinaryType.FRAGMENT_MORE,
-            SendSpinProtocol.BinaryType.FRAGMENT_END ->
-                Decoded.Fragment(type, body)
-            else -> Decoded.Typed(type, body)
+
+        // Every frame goes through the reassembler: it owns the rule that a
+        // non-fragment frame arriving mid-sequence is a protocol error, which
+        // cannot be decided by looking at the frame alone.
+        return when (val result = reassembler.accept(type, body)) {
+            is FragmentReassembler.Result.Complete -> asMessage(result.type, result.body)
+            FragmentReassembler.Result.Passthrough -> asMessage(type, body)
+            FragmentReassembler.Result.Buffered -> Decoded.Buffered
+            is FragmentReassembler.Result.ProtocolError ->
+                Decoded.ProtocolError(result.reason)
         }
+    }
+
+    /**
+     * A completed message, however it arrived. A reassembled `orig_type` of 0
+     * has to land here too, or a fragmented JSON message would be delivered as
+     * an opaque binary frame.
+     */
+    private fun asMessage(type: Int, body: ByteArray): Decoded = when (type) {
+        SendSpinProtocol.BinaryType.JSON -> Decoded.Json(body.decodeToString())
+        else -> Decoded.Typed(type, body)
     }
 
     sealed interface Decoded {
@@ -115,14 +133,11 @@ class NoiseWireCodec(private val transport: NoiseTransport) {
             override fun hashCode(): Int = 31 * type + body.contentHashCode()
         }
 
-        /** A fragmentation frame. Reassembly arrives in item 1.5. */
-        data class Fragment(val type: Int, val body: ByteArray) : Decoded {
-            override fun equals(other: Any?): Boolean =
-                this === other ||
-                    (other is Fragment && type == other.type && body.contentEquals(other.body))
-
-            override fun hashCode(): Int = 31 * type + body.contentHashCode()
-        }
+        /**
+         * A fragment was consumed and the message is still incomplete. Nothing
+         * to dispatch; wait for the next frame.
+         */
+        object Buffered : Decoded
 
         /** Close the socket, send nothing. */
         data class ProtocolError(val reason: String) : Decoded

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/Fragmentation.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/Fragmentation.kt
@@ -1,0 +1,217 @@
+package com.sendspindroid.sendspin.protocol.message
+
+import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+
+/**
+ * Message fragmentation, `messaging.md#fragmentation`.
+ *
+ * Noise caps a transport message at 65535 bytes, so any Sendspin message whose
+ * payload exceeds [Fragmentation.MAX_UNFRAGMENTED_PAYLOAD] must be split across
+ * fragment frames. Fragment-more (`2`) opens and continues; fragment-end (`3`)
+ * closes.
+ *
+ * Both halves live here because they are exact inverses and are round-tripped
+ * against each other in tests.
+ */
+object Fragmentation {
+
+    /** Noise's own per-transport-message limit. */
+    const val NOISE_MAX_MESSAGE = SendSpinProtocol.NoiseFraming.MAX_TRANSPORT_MESSAGE
+
+    /** Both defined cipher suites use a 16-byte AEAD tag. */
+    const val AEAD_TAG = SendSpinProtocol.NoiseFraming.AEAD_TAG
+
+    /** The most plaintext one frame can carry: 65519. */
+    const val MAX_PLAINTEXT = SendSpinProtocol.NoiseFraming.MAX_PLAINTEXT
+
+    /** `[type][payload]`, so 65518. */
+    const val MAX_UNFRAGMENTED_PAYLOAD = SendSpinProtocol.NoiseFraming.MAX_PAYLOAD
+
+    /** Opening fragment-more is `[2][orig_type][data]`, so 65517. */
+    const val MAX_FIRST_FRAGMENT_DATA = MAX_PLAINTEXT - 2
+
+    /** Continuation `[2][data]` and fragment-end `[3][data]`, so 65518. */
+    const val MAX_FRAGMENT_DATA = MAX_PLAINTEXT - 1
+
+    /**
+     * Default ceiling on a single reassembled message.
+     *
+     * The spec sets no cap. Without one a peer can hold the connection open
+     * sending fragment-more frames forever and exhaust memory on a phone, so
+     * exceeding this is a protocol error rather than a silent truncation.
+     */
+    const val DEFAULT_MAX_MESSAGE_BYTES = 8 * 1024 * 1024
+
+    /** `2` and `3` are the fragment types and may never be an `orig_type`. */
+    fun isFragmentType(type: Int): Boolean =
+        type == SendSpinProtocol.BinaryType.FRAGMENT_MORE ||
+            type == SendSpinProtocol.BinaryType.FRAGMENT_END
+}
+
+/**
+ * Splits an outbound message into frames.
+ *
+ * Returns AEAD *plaintexts*; the Noise codec encrypts each one. The whole list
+ * must go on the wire consecutively, because "a sender must finish a fragmented
+ * message with a fragment-end frame before sending any other frame in that
+ * direction" - which is why this returns a list rather than streaming.
+ */
+object FragmentWriter {
+
+    /**
+     * @param type the message's real type; MUST NOT be `2` or `3`
+     * @return one `[type][payload]` frame when it fits, otherwise
+     *   `[2][type][data]`, zero or more `[2][data]`, and a closing `[3][data]`
+     */
+    fun frames(type: Int, payload: ByteArray): List<ByteArray> {
+        require(!Fragmentation.isFragmentType(type)) {
+            "a fragment type ($type) may never be used as orig_type"
+        }
+        require(type in 0..255) { "binary message type is a uint8, got $type" }
+
+        if (1 + payload.size <= Fragmentation.MAX_PLAINTEXT) {
+            return listOf(byteArrayOf(type.toByte()) + payload)
+        }
+
+        val out = mutableListOf<ByteArray>()
+        // Opening frame spends one byte on orig_type, so it carries less data
+        // than the continuations that follow it.
+        val first = payload.copyOfRange(0, Fragmentation.MAX_FIRST_FRAGMENT_DATA)
+        out += byteArrayOf(SendSpinProtocol.BinaryType.FRAGMENT_MORE.toByte(), type.toByte()) + first
+
+        var offset = Fragmentation.MAX_FIRST_FRAGMENT_DATA
+        // Leave at least one byte for the fragment-end frame so the sequence
+        // always terminates with a type 3, as the spec requires.
+        while (payload.size - offset > Fragmentation.MAX_FRAGMENT_DATA) {
+            val next = payload.copyOfRange(offset, offset + Fragmentation.MAX_FRAGMENT_DATA)
+            out += byteArrayOf(SendSpinProtocol.BinaryType.FRAGMENT_MORE.toByte()) + next
+            offset += Fragmentation.MAX_FRAGMENT_DATA
+        }
+
+        val remainder = payload.copyOfRange(offset, payload.size)
+        out += byteArrayOf(SendSpinProtocol.BinaryType.FRAGMENT_END.toByte()) + remainder
+        return out
+    }
+}
+
+/**
+ * Reassembles one direction of a connection.
+ *
+ * Stateful and single-direction, so one instance per connection per direction.
+ * "Only one fragmented message may be in flight at a time per direction", which
+ * is why a single buffer and a single [origType] suffice.
+ *
+ * Chunks are accumulated and concatenated once on completion rather than
+ * regrown per frame: a 300 KB message arrives as five frames, and repeated
+ * array copying would make reassembly quadratic in message size.
+ */
+class FragmentReassembler(
+    private val maxMessageBytes: Int = Fragmentation.DEFAULT_MAX_MESSAGE_BYTES,
+) {
+
+    sealed class Result {
+        /** Dispatch this as a whole message of [type]. */
+        data class Complete(val type: Int, val body: ByteArray) : Result() {
+            override fun equals(other: Any?): Boolean =
+                this === other ||
+                    (other is Complete && type == other.type && body.contentEquals(other.body))
+
+            override fun hashCode(): Int = 31 * type + body.contentHashCode()
+        }
+
+        /** Fragment consumed; nothing to dispatch yet. */
+        object Buffered : Result()
+
+        /** Not fragment-related and nothing in flight: dispatch normally. */
+        object Passthrough : Result()
+
+        /** MUST close the connection. */
+        data class ProtocolError(val reason: String) : Result()
+    }
+
+    private var origType: Int? = null
+    private val chunks = mutableListOf<ByteArray>()
+    private var buffered = 0
+
+    /** Whether a fragmented message is currently being reassembled. */
+    val inFlight: Boolean get() = origType != null
+
+    /**
+     * Feed one decrypted frame, type byte already stripped.
+     *
+     * @param type the frame's own type byte
+     * @param body everything after it
+     */
+    fun accept(type: Int, body: ByteArray): Result {
+        val open = origType
+
+        if (type == SendSpinProtocol.BinaryType.FRAGMENT_MORE) {
+            return if (open == null) startNew(body) else append(body)
+        }
+
+        if (type == SendSpinProtocol.BinaryType.FRAGMENT_END) {
+            if (open == null) {
+                return Result.ProtocolError(
+                    "fragment-end with no fragmented message in flight"
+                )
+            }
+            val appended = append(body)
+            if (appended is Result.ProtocolError) return appended
+            val complete = Result.Complete(open, concatenate())
+            reset()
+            return complete
+        }
+
+        // A non-fragment frame while a message is in flight breaks the rule that
+        // a sender must finish a fragmented message before sending anything else
+        // in that direction.
+        if (open != null) {
+            return Result.ProtocolError(
+                "non-fragment frame (type $type) while a fragmented message is in flight"
+            )
+        }
+        return Result.Passthrough
+    }
+
+    /** Drop any in-flight message. Call on reconnect and after a re-handshake. */
+    fun reset() {
+        origType = null
+        chunks.clear()
+        buffered = 0
+    }
+
+    private fun startNew(body: ByteArray): Result {
+        if (body.isEmpty()) {
+            return Result.ProtocolError("opening fragment-more carries no orig_type")
+        }
+        val orig = body[0].toInt() and 0xFF
+        if (Fragmentation.isFragmentType(orig)) {
+            return Result.ProtocolError("orig_type of $orig is itself a fragment type")
+        }
+        origType = orig
+        // Byte 0 was orig_type; the rest is data.
+        return append(body.copyOfRange(1, body.size))
+    }
+
+    private fun append(data: ByteArray): Result {
+        if (buffered + data.size > maxMessageBytes) {
+            reset()
+            return Result.ProtocolError(
+                "fragmented message exceeds the ${maxMessageBytes}-byte reassembly cap"
+            )
+        }
+        chunks.add(data)
+        buffered += data.size
+        return Result.Buffered
+    }
+
+    private fun concatenate(): ByteArray {
+        val out = ByteArray(buffered)
+        var offset = 0
+        for (chunk in chunks) {
+            chunk.copyInto(out, offset)
+            offset += chunk.size
+        }
+        return out
+    }
+}


### PR DESCRIPTION
Noise caps a transport message at 65535 bytes, so a Sendspin message whose payload exceeds 65518 must be split across fragment frames. Until now the app treated types `2` and `3` as unhandleable and closed the connection, and could not send anything oversized at all - `encode()` threw `MessageTooLarge`.

Closes #196.

## Not academic

The largest payload observed against a live Music Assistant server is a **46992-byte artwork frame - 72% of the single-frame ceiling**. A busier album cover crosses it, and the failure mode was artwork that simply stops working.

## Receive

`FragmentReassembler` holds one buffer and one `orig_type` per direction, which is all the spec allows in flight. Chunks accumulate and are concatenated once on completion rather than regrown per frame, so a 300 KB message is not quadratic in its own size.

The subtle case is a continuation frame: when a message is already in flight, a type `2` frame carries **only data**, so a leading `0x02` is payload and not a nested `orig_type`. A naive implementation reads it as the start of a new message. There is a test for exactly that (`continuationFrameFirstByteIsDataNotOrigType`).

All three malformed sequences the spec makes protocol errors are implemented and tested: fragment-end with nothing in flight, a non-fragment frame arriving mid-sequence, and an `orig_type` of `2` or `3`.

**The spec sets no ceiling on a reassembled message.** An unbounded buffer is a remote memory-exhaustion vector on a phone, so there is an 8 MB cap whose breach is a protocol error - never a silent truncation.

## Send

`FragmentWriter` emits AEAD plaintexts; the codec encrypts each one. A payload that fits is left unfragmented, as the spec asks. The codec holds its send mutex across the whole frame list, which is what enforces *"a sender must finish a fragmented message before sending any other frame in that direction"* - an interleaving sender would desynchronise the peer's reassembly buffer.

## Codec

Every frame now goes through the reassembler, because the rule that a non-fragment frame mid-sequence is a protocol error cannot be decided from one frame alone.

A reassembled `orig_type` of `0` is dispatched as `Json`, not as an opaque binary frame - that mapping is easy to get wrong and has its own test.

`Decoded.Fragment` is replaced by `Decoded.Buffered`: there is nothing for a caller to do with a partial message except wait.

`NoiseWireCodec` gained an **internal** constructor taking `encrypt`/`decrypt` function references, so the framing can be tested without a completed Noise handshake (the vectors only give one side, so no paired transport is available). The public constructor is unchanged.

## Tests

**27 new tests, written before the implementation** - 13 reassembler, 7 writer including a writer-to-reassembler round trip across 8 payload sizes and 4 message types, and 7 through the codec. 722 app tests and the shared suite pass.

One test was corrected mid-flight rather than the code: I had asserted that a 65518-byte payload fragments, which contradicted my own first test - 65518 is exactly what fits unfragmented.

## Not included

`FragmentReassembler.reset()` exists and is tested, but nothing calls it: `installEncryptedTransport` builds a fresh codec per handshake, so reassembly state is already discarded on reconnect. The in-band re-handshake (#223) is where it will be needed. I removed the `resetReassembly()` passthrough I had added on the codec rather than ship a method with no caller.

Sender-side fragmentation is not on any current critical path - the client sends only JSON today - but it is implemented and tested because the reassembler needs a matching writer to round-trip against, and `source@v1` (#222) depends on it.
