### PR TITLE
feat(crypto): trust store for long-term PSK records

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -10,6 +10,8 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import java.util.UUID
 import com.sendspindroid.sendspin.crypto.ClientIdentity
+import com.sendspindroid.sendspin.crypto.EncryptedPrefsTrustStore
+import com.sendspindroid.sendspin.crypto.TrustStore
 
 /**
  * Centralized access to user settings stored in SharedPreferences.
@@ -49,6 +51,10 @@ object UserSettings {
     const val KEY_LAYOUT_MODE = "layout_mode"
     const val KEY_AUTO_START_ON_BOOT = "auto_start_on_boot"
     const val KEY_SEARCH_LIBRARY_ONLY = "search_library_only"  // Backward compatibility: search local library only
+
+    // Long-term PSK records from pairing (stored in encrypted prefs).
+    // Record semantics live in the trust store; this is only the blob.
+    const val KEY_PSK_RECORDS = "sendspin_psk_records"
 
     // Remote access preference keys (stored in encrypted prefs)
     const val KEY_REMOTE_SERVERS = "remote_servers"
@@ -235,6 +241,50 @@ object UserSettings {
             return fresh
         }
     }
+
+    // ========== Long-term PSK records (trust store backing) ==========
+    //
+    // Only the opaque blob lives here. Record semantics - the psk_id namespace,
+    // `used`, and the add/remove rules - belong to the trust store, so that
+    // there is exactly one place they can be got wrong.
+
+    @Volatile
+    private var cachedTrustStore: TrustStore? = null
+
+    /**
+     * The process-wide trust store.
+     *
+     * One instance, for the same reason the identity is cached: two stores over
+     * the same preferences would each hold their own record list, so a write
+     * through one would be invisible to the other and the `psk_id` namespace
+     * check would run against a stale view.
+     */
+    fun getOrCreateTrustStore(): TrustStore {
+        cachedTrustStore?.let { return it }
+        synchronized(this) {
+            cachedTrustStore?.let { return it }
+            val store = EncryptedPrefsTrustStore()
+            cachedTrustStore = store
+            return store
+        }
+    }
+
+    /** The serialised record store, or "" when nothing has been paired. */
+    fun getPskRecordsBlob(): String =
+        sensitivePrefs?.getString(KEY_PSK_RECORDS, null) ?: ""
+
+    /**
+     * Persist the serialised record store.
+     *
+     * `commit()` rather than `apply()`, for the same reason the identity uses
+     * it: an asynchronous write that loses a race with process death drops a
+     * record the server has already accepted, and the next connect fails as
+     * `unauthorized` with nothing to point at.
+     *
+     * @return false if there is no storage to write to.
+     */
+    fun setPskRecordsBlob(blob: String): Boolean =
+        sensitivePrefs?.edit()?.putString(KEY_PSK_RECORDS, blob)?.commit() ?: false
 
     fun getPlayerId(): String {
         // Fast path: prefs available and ID already stored
@@ -753,6 +803,9 @@ object UserSettings {
             isEncrypted = false
             cachedPlayerId = null
             appContext = null
+            // Or a store built over one test's mock prefs would answer queries
+            // in the next test, against records that test never wrote.
+            cachedTrustStore = null
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/crypto/EncryptedPrefsTrustStore.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/crypto/EncryptedPrefsTrustStore.kt
@@ -1,0 +1,54 @@
+package com.sendspindroid.sendspin.crypto
+
+import android.util.Log
+import com.sendspindroid.UserSettings
+
+/**
+ * The trust store, persisted in `UserSettings`' sensitive preferences.
+ *
+ * Android-only because `androidx.security` is an `app/` dependency. All the
+ * record and namespace logic is inherited from [InMemoryTrustStore]; this adds
+ * exactly two things - load on construction, flush on change.
+ *
+ * Subclassing rather than wrapping is deliberate: a delegating wrapper would
+ * have to redeclare every member of [TrustStore] purely to add a write, and the
+ * one that got missed would drop records with no symptom until the next connect.
+ *
+ * @param pairingPskId the client's own Pairing PSK id once 2.2 (#203) provides
+ *   one. It holds a place in the shared `psk_id` namespace even though it is
+ *   never a record.
+ */
+class EncryptedPrefsTrustStore(
+    pairingPskId: String? = null,
+) : InMemoryTrustStore(
+    initial = PskRecordCodec.decode(UserSettings.getPskRecordsBlob()),
+    pairingPskId = pairingPskId,
+    storageIsEncrypted = UserSettings.isEncrypted,
+) {
+
+    init {
+        if (!UserSettings.isEncrypted) {
+            // Not fatal: refusing to store would brick the app on OEM devices
+            // with a broken Keystore. But the PSKs are on disk in the clear, so
+            // it must be visible - `storageIsEncrypted` carries it to the UI.
+            Log.w(
+                TAG,
+                "Storing Sendspin PSK records in UNENCRYPTED preferences: the " +
+                    "device Keystore is unavailable. Pairing still works and the " +
+                    "records persist, but they are not protected at rest."
+            )
+        }
+    }
+
+    override fun onChanged() {
+        if (!UserSettings.setPskRecordsBlob(PskRecordCodec.encode(listRecords()))) {
+            // Losing this write means the server keeps a credential we have
+            // forgotten, so say so rather than failing silently at next connect.
+            Log.e(TAG, "Failed to persist Sendspin PSK records: no storage available")
+        }
+    }
+
+    private companion object {
+        const val TAG = "TrustStore"
+    }
+}

--- a/android/app/src/test/java/com/sendspindroid/sendspin/crypto/EncryptedPrefsTrustStoreTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/crypto/EncryptedPrefsTrustStoreTest.kt
@@ -1,0 +1,135 @@
+package com.sendspindroid.sendspin.crypto
+
+import android.content.SharedPreferences
+import com.sendspindroid.UserSettings
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Persistence for the trust store.
+ *
+ * The case that matters is survival across a process: a record written during
+ * pairing but lost on restart leaves the server holding a credential the client
+ * has forgotten, and the only symptom is an unexplained `unauthorized` on the
+ * next connect. Rebuilding the store over the same backing map is the closest
+ * a unit test gets to a reboot.
+ */
+class EncryptedPrefsTrustStoreTest {
+
+    private lateinit var mockPrefs: SharedPreferences
+    private lateinit var mockSensitivePrefs: SharedPreferences
+    private val sensitiveStore = ConcurrentHashMap<String, String?>()
+
+    private fun psk(fill: Byte) = ByteArray(Psk.PSK_SIZE) { fill }
+
+    @Before
+    fun setUp() {
+        UserSettings.resetForTesting()
+
+        val sensitiveEditor = mockk<SharedPreferences.Editor>(relaxed = true) {
+            every { putString(any(), any()) } answers {
+                sensitiveStore[firstArg()] = secondArg()
+                this@mockk
+            }
+            // The store must use commit(), not apply(): an async write losing a
+            // race with process death loses the record.
+            every { commit() } returns true
+        }
+        mockSensitivePrefs = mockk<SharedPreferences> {
+            every { getString(any(), any()) } answers {
+                sensitiveStore[firstArg()] ?: secondArg()
+            }
+            every { edit() } returns sensitiveEditor
+        }
+        mockPrefs = mockk<SharedPreferences>(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        UserSettings.resetForTesting()
+        sensitiveStore.clear()
+    }
+
+    @Test
+    fun recordsSurviveRebuildingTheStore() {
+        UserSettings.initializeForTesting(mockPrefs, mockSensitivePrefs, encrypted = true)
+
+        val first = EncryptedPrefsTrustStore()
+        first.addRecord(psk(1), serverId = "server-a")
+        first.addRecord(psk(2), serverId = null)
+
+        // A brand-new store object over the same backing prefs: the reboot proxy.
+        val second = EncryptedPrefsTrustStore()
+        val records = second.listRecords().sortedBy { it.pskId }
+
+        assertEquals(2, records.size)
+        val a = second.findByPskId(PskId.derive(psk(1)))
+        assertNotNull(a)
+        assertEquals("server-a", a!!.serverId)
+        assertArrayEquals(psk(1), a.psk)
+
+        val shared = second.findByPskId(PskId.derive(psk(2)))
+        assertNotNull(shared)
+        assertNull("a shared-PSK record has no server binding", shared!!.serverId)
+    }
+
+    @Test
+    fun markUsedSurvivesRebuildingTheStore() {
+        UserSettings.initializeForTesting(mockPrefs, mockSensitivePrefs, encrypted = true)
+        val id = PskId.derive(psk(1))
+
+        val first = EncryptedPrefsTrustStore()
+        first.addRecord(psk(1), serverId = "server-a")
+        first.markUsed(id)
+
+        assertTrue(EncryptedPrefsTrustStore().findByPskId(id)!!.used)
+    }
+
+    @Test
+    fun removeRecordSurvivesRebuildingTheStore() {
+        UserSettings.initializeForTesting(mockPrefs, mockSensitivePrefs, encrypted = true)
+        val id = PskId.derive(psk(1))
+
+        val first = EncryptedPrefsTrustStore()
+        first.addRecord(psk(1), serverId = "server-a")
+        assertTrue(first.removeRecord(id))
+
+        assertNull(EncryptedPrefsTrustStore().findByPskId(id))
+    }
+
+    @Test
+    fun theNamespaceRuleStillAppliesAfterReload() {
+        // The collision check must consider records restored from storage, not
+        // only those added in this process.
+        UserSettings.initializeForTesting(mockPrefs, mockSensitivePrefs, encrypted = true)
+        EncryptedPrefsTrustStore().addRecord(psk(1), serverId = "server-a")
+
+        val result = EncryptedPrefsTrustStore().addRecord(psk(1), serverId = "server-b")
+        assertTrue(result is TrustStore.AddRecordResult.AlreadyExists)
+    }
+
+    @Test
+    fun thereIsExactlyOneTrustStorePerProcess() {
+        // Two instances over the same prefs would each hold their own record
+        // list, and a write through one would be invisible to the other until
+        // it happened to be rebuilt - a namespace check against a stale view.
+        UserSettings.initializeForTesting(mockPrefs, mockSensitivePrefs, encrypted = true)
+        assertSame(UserSettings.getOrCreateTrustStore(), UserSettings.getOrCreateTrustStore())
+    }
+
+    @Test
+    fun aBrokenKeystoreStillStoresButReportsItselfUnencrypted() {
+        // The app deliberately falls back to plain prefs rather than refusing to
+        // run. That tradeoff has to be visible, not merely logged.
+        UserSettings.initializeForTesting(mockPrefs, mockSensitivePrefs, encrypted = false)
+
+        val store = EncryptedPrefsTrustStore()
+        assertFalse(store.storageIsEncrypted)
+        assertTrue(store.addRecord(psk(1), "server-a") is TrustStore.AddRecordResult.Ok)
+        assertEquals(1, EncryptedPrefsTrustStore().listRecords().size)
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/InMemoryTrustStoreTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/InMemoryTrustStoreTest.kt
@@ -1,0 +1,139 @@
+package com.sendspindroid.sendspin.crypto
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Record semantics for the trust store (`management.md#records`).
+ *
+ * The store is where the single `psk_id` namespace is enforced on the write
+ * path: "The three PSK categories share one `psk_id` namespace, so a `psk_id`
+ * must be unique across them." [PskCandidateSet] enforces it at construction;
+ * this enforces it before a record is ever created, so a colliding record
+ * cannot be persisted and then poison every later handshake.
+ */
+class InMemoryTrustStoreTest {
+
+    private fun psk(fill: Byte) = ByteArray(Psk.PSK_SIZE) { fill }
+
+    @Test
+    fun addRecordStoresItUnderItsDerivedPskId() {
+        val store = InMemoryTrustStore()
+        val bytes = psk(1)
+        val result = store.addRecord(bytes, serverId = "server-a")
+        assertTrue(result is TrustStore.AddRecordResult.Ok)
+
+        val expectedId = PskId.derive(bytes)
+        val found = store.findByPskId(expectedId)
+        assertNotNull(found)
+        assertEquals(expectedId, found!!.pskId)
+        assertEquals("server-a", found.serverId)
+        assertArrayEquals(bytes, found.psk)
+        assertFalse("a new record has never authenticated a session", found.used)
+    }
+
+    @Test
+    fun addingAPskThatIsAlreadyARecordIsRejectedAndChangesNothing() {
+        val store = InMemoryTrustStore()
+        store.addRecord(psk(1), serverId = "server-a")
+        val result = store.addRecord(psk(1), serverId = "server-b")
+
+        assertTrue(result is TrustStore.AddRecordResult.AlreadyExists)
+        assertEquals(1, store.listRecords().size)
+        // The original binding must survive: a rejected add that quietly
+        // rebound the record to another server would be worse than an error.
+        assertEquals("server-a", store.findByPskId(PskId.derive(psk(1)))!!.serverId)
+    }
+
+    @Test
+    fun addingTheSentinelPskIsRejected() {
+        // Cross-category collision: the Sentinel is not a record, but it owns
+        // its psk_id in the shared namespace.
+        val store = InMemoryTrustStore()
+        val result = store.addRecord(SentinelPsk.bytes, serverId = "server-a")
+        assertTrue(result is TrustStore.AddRecordResult.AlreadyExists)
+        assertTrue(store.listRecords().isEmpty())
+    }
+
+    @Test
+    fun addingTheConfiguredPairingPskIsRejected() {
+        val pairing = psk(9)
+        val store = InMemoryTrustStore(pairingPskId = PskId.derive(pairing))
+        val result = store.addRecord(pairing, serverId = "server-a")
+        assertTrue(result is TrustStore.AddRecordResult.AlreadyExists)
+        assertTrue(store.listRecords().isEmpty())
+    }
+
+    @Test
+    fun twoDifferentPsksMayShareAServerId() {
+        // Re-pairing with the same server produces a second record; the
+        // namespace rule is about psk_id, not server_id.
+        val store = InMemoryTrustStore()
+        assertTrue(store.addRecord(psk(1), "server-a") is TrustStore.AddRecordResult.Ok)
+        assertTrue(store.addRecord(psk(2), "server-a") is TrustStore.AddRecordResult.Ok)
+        assertEquals(2, store.listRecords().size)
+    }
+
+    @Test
+    fun addRecordRejectsAPskOfTheWrongLength() {
+        val store = InMemoryTrustStore()
+        val result = store.addRecord(ByteArray(16), serverId = null)
+        assertTrue(result is TrustStore.AddRecordResult.Invalid)
+        assertTrue(store.listRecords().isEmpty())
+    }
+
+    @Test
+    fun markUsedFlipsTheFlagAndIsIdempotent() {
+        val store = InMemoryTrustStore()
+        store.addRecord(psk(1), "server-a")
+        val id = PskId.derive(psk(1))
+
+        assertFalse(store.findByPskId(id)!!.used)
+        store.markUsed(id)
+        assertTrue(store.findByPskId(id)!!.used)
+        store.markUsed(id)
+        assertTrue(store.findByPskId(id)!!.used)
+        assertEquals(1, store.listRecords().size)
+    }
+
+    @Test
+    fun markUsedOnAnUnknownPskIdDoesNothing() {
+        val store = InMemoryTrustStore()
+        store.markUsed("not-a-real-psk-id")
+        assertTrue(store.listRecords().isEmpty())
+    }
+
+    @Test
+    fun removeRecordReportsWhetherItRemovedAnything() {
+        val store = InMemoryTrustStore()
+        store.addRecord(psk(1), "server-a")
+        assertTrue(store.removeRecord(PskId.derive(psk(1))))
+        assertFalse(store.removeRecord(PskId.derive(psk(1))))
+        assertFalse(store.removeRecord("not-a-real-psk-id"))
+    }
+
+    @Test
+    fun candidatesAreTheRecordsPlusTheSentinelWithCorrectCategories() {
+        val store = InMemoryTrustStore()
+        store.addRecord(psk(1), "server-a")
+        val candidates = store.candidates()
+
+        assertEquals(2, candidates.size)
+        val sentinel = candidates.single { it.category == PskCategory.SENTINEL }
+        assertEquals(SentinelPsk.EXPECTED_PSK_ID, sentinel.pskId)
+
+        val record = candidates.single { it.category == PskCategory.LONG_TERM }
+        assertEquals("server-a", record.serverId)
+        assertArrayEquals(psk(1), record.bytes)
+    }
+
+    @Test
+    fun candidatesFormAValidCandidateSet() {
+        // The namespace guarantee the store makes must be strong enough that
+        // PskCandidateSet.of never rejects what the store produces.
+        val store = InMemoryTrustStore()
+        store.addRecord(psk(1), "server-a")
+        store.addRecord(psk(2), "server-b")
+        assertTrue(PskCandidateSet.of(store.candidates()).isSuccess)
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskRecordCodecTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskRecordCodecTest.kt
@@ -1,0 +1,90 @@
+package com.sendspindroid.sendspin.crypto
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Serialisation of the record store.
+ *
+ * The load path is the dangerous one: a decode that throws away everything on
+ * one bad entry silently unpairs the device from every server it knows, and the
+ * only symptom is an `unauthorized` on the next connect. So a broken entry is
+ * skipped, never fatal.
+ */
+class PskRecordCodecTest {
+
+    private fun psk(fill: Byte) = ByteArray(Psk.PSK_SIZE) { fill }
+
+    private fun record(fill: Byte, serverId: String?, used: Boolean = false) =
+        PskRecord(PskId.derive(psk(fill)), psk(fill), serverId, used)
+
+    @Test
+    fun roundTripsRecordsIncludingASharedPskRecordAndTheUsedFlag() {
+        val original = listOf(
+            record(1, "server-a"),
+            record(2, "server-b", used = true),
+            record(3, null),  // shared-PSK record: no server binding
+        )
+        val decoded = PskRecordCodec.decode(PskRecordCodec.encode(original))
+
+        assertEquals(3, decoded.size)
+        for ((a, b) in original.zip(decoded)) {
+            assertEquals(a.pskId, b.pskId)
+            assertEquals(a.serverId, b.serverId)
+            assertEquals(a.used, b.used)
+            // Byte equality specifically: a base64 round trip that dropped or
+            // added padding would still produce a plausible-looking record.
+            assertArrayEquals(a.psk, b.psk)
+        }
+    }
+
+    @Test
+    fun decodePreservesRecordsWhenTheBlobCarriesAnUnknownKey() {
+        // Forward compatibility: a later version adding a field must not
+        // wipe the store when this version reads it back.
+        val id = PskId.derive(psk(1))
+        val b64 = Base64Url.encode(psk(1))
+        val blob = """[{"pskId":"$id","psk":"$b64","serverId":"server-a","used":false,"future":42}]"""
+        val decoded = PskRecordCodec.decode(blob)
+        assertEquals(1, decoded.size)
+        assertEquals("server-a", decoded[0].serverId)
+    }
+
+    @Test
+    fun decodeSkipsAStructurallyBrokenEntryAndKeepsTheRest() {
+        val id = PskId.derive(psk(1))
+        val b64 = Base64Url.encode(psk(1))
+        val blob = """[
+            {"pskId":"$id","psk":"$b64","serverId":"server-a","used":false},
+            {"pskId":"broken","psk":"not-base64!!","serverId":null,"used":false}
+        ]"""
+        val decoded = PskRecordCodec.decode(blob)
+        assertEquals("the good record must survive the bad one", 1, decoded.size)
+        assertEquals(id, decoded[0].pskId)
+    }
+
+    @Test
+    fun decodeSkipsAnEntryWhosePskIsTheWrongLength() {
+        val id = PskId.derive(psk(1))
+        val b64 = Base64Url.encode(psk(1))
+        val short = Base64Url.encode(ByteArray(16))
+        val blob = """[
+            {"pskId":"$id","psk":"$b64","serverId":"server-a","used":false},
+            {"pskId":"short","psk":"$short","serverId":null,"used":false}
+        ]"""
+        val decoded = PskRecordCodec.decode(blob)
+        assertEquals(1, decoded.size)
+    }
+
+    @Test
+    fun decodeOfEmptyOrGarbageIsAnEmptyListNotAnException() {
+        assertTrue(PskRecordCodec.decode("").isEmpty())
+        assertTrue(PskRecordCodec.decode("not json").isEmpty())
+        assertTrue(PskRecordCodec.decode("{}").isEmpty())
+    }
+
+    @Test
+    fun encodeOfNoRecordsRoundTripsToNoRecords() {
+        assertTrue(PskRecordCodec.decode(PskRecordCodec.encode(emptyList())).isEmpty())
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/InMemoryTrustStore.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/InMemoryTrustStore.kt
@@ -1,0 +1,79 @@
+package com.sendspindroid.sendspin.crypto
+
+/**
+ * The record and namespace semantics, with no persistence.
+ *
+ * All the logic lives here so it can be tested without Android; the encrypted
+ * preferences implementation wraps this and adds loading and flushing.
+ *
+ * @param initial records restored from storage
+ * @param pairingPskId the client's own Pairing PSK id once 2.2 provides one. It
+ *   participates in the namespace even though it is not a record, because a
+ *   `psk_id` must be unique across all three categories.
+ * @param storageIsEncrypted reported through [TrustStore]; always true for a
+ *   store that never touches disk.
+ */
+open class InMemoryTrustStore(
+    initial: List<PskRecord> = emptyList(),
+    private val pairingPskId: String? = null,
+    override val storageIsEncrypted: Boolean = true,
+) : TrustStore {
+
+    private val records = initial.toMutableList()
+
+    /**
+     * Called after any mutation so a subclass can flush.
+     *
+     * The persistence layer subclasses rather than wraps: a wrapper would have
+     * to redeclare all seven members just to add a write, and the one that got
+     * forgotten would lose records silently.
+     */
+    protected open fun onChanged() {}
+
+    override fun listRecords(): List<PskRecord> = records.toList()
+
+    override fun findByPskId(pskId: String): PskRecord? =
+        records.firstOrNull { it.pskId == pskId }
+
+    override fun addRecord(psk: ByteArray, serverId: String?): TrustStore.AddRecordResult {
+        if (psk.size != Psk.PSK_SIZE) return TrustStore.AddRecordResult.Invalid
+
+        val pskId = PskId.derive(psk)
+        if (isClaimed(pskId)) return TrustStore.AddRecordResult.AlreadyExists
+
+        val record = PskRecord(pskId, psk, serverId, used = false)
+        records += record
+        onChanged()
+        return TrustStore.AddRecordResult.Ok(record)
+    }
+
+    override fun removeRecord(pskId: String): Boolean {
+        val removed = records.removeAll { it.pskId == pskId }
+        if (removed) onChanged()
+        return removed
+    }
+
+    override fun markUsed(pskId: String) {
+        val index = records.indexOfFirst { it.pskId == pskId }
+        if (index < 0) return
+        if (records[index].used) return  // idempotent; no needless write
+        records[index] = records[index].withUsed(true)
+        onChanged()
+    }
+
+    override fun candidates(): List<Psk> =
+        records.map { it.toPsk() } + SentinelPsk.psk
+
+    /**
+     * The write-path half of the single-namespace rule.
+     *
+     * [PskCandidateSet.of] enforces the same rule when the set is built; this
+     * stops a colliding record being persisted in the first place, so the
+     * failure surfaces as a rejected pairing rather than as a client that can
+     * no longer build a candidate set at all.
+     */
+    private fun isClaimed(pskId: String): Boolean =
+        pskId == SentinelPsk.EXPECTED_PSK_ID ||
+            pskId == pairingPskId ||
+            records.any { it.pskId == pskId }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PskRecordCodec.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PskRecordCodec.kt
@@ -1,0 +1,53 @@
+package com.sendspindroid.sendspin.crypto
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Serialises the record store to a single string for the preferences layer.
+ *
+ * JSON rather than the `::`/`|` concatenation used elsewhere in `UserSettings`:
+ * a `server_id` is peer-controlled and a base64url PSK contains `-` and `_`, so
+ * a separator scheme is one unlucky value away from splitting a record in half.
+ *
+ * The PSK is stored base64url unpadded, the same encoding the wire uses, so a
+ * value seen in storage and a value seen in a log line are directly comparable.
+ */
+object PskRecordCodec {
+
+    @Serializable
+    private data class Wire(
+        val pskId: String,
+        val psk: String,
+        val serverId: String? = null,
+        val used: Boolean = false,
+    )
+
+    // ignoreUnknownKeys so a field added by a later version does not make an
+    // otherwise-valid store unreadable and silently unpair the device.
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun encode(records: List<PskRecord>): String =
+        json.encodeToString(
+            records.map { Wire(it.pskId, Base64Url.encode(it.psk), it.serverId, it.used) }
+        )
+
+    /**
+     * Never throws.
+     *
+     * A single unreadable entry is skipped rather than failing the whole load:
+     * discarding every record because one is corrupt would unpair the device
+     * from every server it knows, and the only symptom would be an
+     * `unauthorized` on the next connect.
+     */
+    fun decode(blob: String): List<PskRecord> {
+        if (blob.isBlank()) return emptyList()
+        val wire = runCatching { json.decodeFromString<List<Wire>>(blob) }.getOrNull()
+            ?: return emptyList()
+        return wire.mapNotNull { entry ->
+            val bytes = Base64Url.decodeOrNull(entry.psk) ?: return@mapNotNull null
+            if (bytes.size != Psk.PSK_SIZE) return@mapNotNull null
+            PskRecord(entry.pskId, bytes, entry.serverId, entry.used)
+        }
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/TrustStore.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/TrustStore.kt
@@ -1,0 +1,122 @@
+package com.sendspindroid.sendspin.crypto
+
+/**
+ * A persisted long-term PSK record.
+ *
+ * `management.md#records`: "Each record holds a [Sendspin PSK]; every record
+ * carries `user` [trust level]", and "Across all record operations, a record is
+ * identified by its `psk_id`."
+ *
+ * This is [Psk] plus the two things that only matter once a record is stored:
+ * it is serialisable, and it remembers whether a server has ever authenticated
+ * with it ([used], reported by `management/list-records`).
+ *
+ * @param serverId the stored-pubkey binding (audit decision D4). Null means a
+ *   shared-PSK record, which this phase never creates but 2.7 and 3.3 must not
+ *   destroy if one appears.
+ */
+class PskRecord(
+    val pskId: String,
+    psk: ByteArray,
+    val serverId: String?,
+    val used: Boolean = false,
+) {
+    init {
+        require(psk.size == Psk.PSK_SIZE) {
+            "a Sendspin PSK is ${Psk.PSK_SIZE} bytes, got ${psk.size}"
+        }
+    }
+
+    private val secret = psk.copyOf()
+
+    /** A copy; the internal array is never handed out. */
+    val psk: ByteArray get() = secret.copyOf()
+
+    fun withUsed(used: Boolean): PskRecord = PskRecord(pskId, secret, serverId, used)
+
+    /** Every record is a long-term PSK, so the category is not stored. */
+    fun toPsk(): Psk = Psk(secret, PskCategory.LONG_TERM, serverId)
+
+    // Hand-written rather than a data class: ByteArray equality on a data class
+    // is reference identity, which would make every record comparison pass or
+    // fail for the wrong reason.
+    override fun equals(other: Any?): Boolean =
+        this === other || (
+            other is PskRecord &&
+                pskId == other.pskId &&
+                serverId == other.serverId &&
+                used == other.used &&
+                secret.contentEquals(other.secret)
+            )
+
+    override fun hashCode(): Int {
+        var result = pskId.hashCode()
+        result = 31 * result + (serverId?.hashCode() ?: 0)
+        result = 31 * result + used.hashCode()
+        result = 31 * result + secret.contentHashCode()
+        return result
+    }
+
+    /** Never the bytes. */
+    override fun toString(): String =
+        "PskRecord(pskId=$pskId, serverId=$serverId, used=$used)"
+}
+
+/**
+ * Storage for long-term PSK records, and the source of the handshake candidate
+ * set.
+ *
+ * An interface so tests and `:conformance-client` can substitute an in-memory
+ * implementation for the Android one.
+ */
+interface TrustStore {
+
+    sealed interface AddRecordResult {
+        data class Ok(val record: PskRecord) : AddRecordResult
+
+        /**
+         * The `psk_id` is already claimed - by a record, by the Sentinel, or by
+         * the client's own Pairing PSK. Named after the spec's
+         * `already_exists`, which 3.3 reports verbatim.
+         */
+        object AlreadyExists : AddRecordResult
+
+        /** Not a 32-byte PSK. */
+        object Invalid : AddRecordResult
+    }
+
+    fun listRecords(): List<PskRecord>
+
+    fun findByPskId(pskId: String): PskRecord?
+
+    /**
+     * Add a record, rejecting any `psk_id` already claimed in the shared
+     * namespace. Never overwrites: a collision is an error, not a merge.
+     */
+    fun addRecord(psk: ByteArray, serverId: String?): AddRecordResult
+
+    /** @return true if a record was removed. */
+    fun removeRecord(pskId: String): Boolean
+
+    /** Record that a server has authenticated a session with this PSK. */
+    fun markUsed(pskId: String)
+
+    /**
+     * Every PSK a handshake may match: the records, the Sentinel, and (once 2.2
+     * lands) the Pairing PSK.
+     *
+     * Feeds [PskCandidateSet.of] directly. Because [addRecord] enforces the
+     * namespace on the write path, that call is not expected to fail.
+     */
+    fun candidates(): List<Psk>
+
+    /**
+     * Whether the backing storage is actually encrypted.
+     *
+     * False on devices with a broken Keystore, where the app deliberately falls
+     * back to plain preferences rather than refusing to run. Surfaced rather
+     * than only logged so 2.8's UI can warn instead of silently implying the
+     * PSKs are protected.
+     */
+    val storageIsEncrypted: Boolean
+}


### PR DESCRIPTION
Every pairing produces a long-term Sendspin PSK that has to survive a reboot, or the device silently drops back to `trust_level: none` on the next connect with nothing to point at.

Refs #202. Storage only - no `management/*` handling, and nothing consumes the candidate set yet (that is #204).

## Storage

`PskRecord` is `Psk` plus the two things that only matter once persisted: it serialises, and it remembers whether a server has ever authenticated with it (`used`, which `management/list-records` reports). `equals`/`hashCode` are hand-written over `contentEquals` - **a data class holding a `ByteArray` compares by reference**, so every record comparison would pass or fail for the wrong reason.

`InMemoryTrustStore` holds the semantics and is where the tests run; `EncryptedPrefsTrustStore` subclasses it and adds load-on-construction and flush-on-change. Subclassing rather than wrapping, because a delegating wrapper would have to redeclare all seven members purely to add a write, and the one that got missed would drop records with no symptom until the next connect.

## The namespace rule, moved to the write path

> The three PSK categories share one `psk_id` namespace, so a `psk_id` must be unique across them.

`PskCandidateSet.of()` already enforces that when a set is **built** - which is too late. A colliding record would already be on disk, and the client would then be unable to construct a candidate set at all. `addRecord` now rejects *before* anything is stored, checking against existing records, the Sentinel, and (once #203 lands) the Pairing PSK, so the failure surfaces as a rejected pairing instead of a bricked handshake.

## Decoding never throws

A single unreadable entry is skipped rather than failing the whole load. Discarding every record because one is corrupt would unpair the device from every server it knows, and the only symptom would be an `unauthorized` on the next connect.

JSON rather than the `::`/`|` string concatenation used elsewhere in `UserSettings`: `server_id` is peer-controlled and base64url PSKs contain `-` and `_`, so a separator scheme is one unlucky value away from splitting a record in half.

Writes use `commit()` not `apply()`, for the same reason the identity does - an async write losing a race with process death drops a record the server has already accepted.

## Degraded storage is visible

On OEM devices with a broken Keystore the app deliberately falls back to plain preferences rather than refusing to run. `storageIsEncrypted` carries that up so #225's UI can warn, instead of it being a log line nobody reads.

## Deviations from the plan in #202

The issue predates 1.2/1.3 landing, so three of its eleven items already exist:

- **`PskCandidate` not added** - `Psk` already carries `pskId`, `bytes`, `category` and `serverId`. A parallel type would be a near-duplicate.
- **`PskNamespace` not added** - `PskCandidateSet.of()` is already the single home for the uniqueness rule. Duplicating it in a second public place was the actual risk, so the write-path check lives in the store and defers to the same notion.
- **`AddRecordResult.StorageExhausted` left out** until #229 has something that produces it.

## Tests

**23, all written before the implementation.** 11 store semantics, 6 codec, 6 persistence. 722 app tests and the shared suite pass.

The persistence tests rebuild the store object over the same backing preferences - the closest a unit test gets to a reboot - and cover `markUsed` and `removeRecord` surviving it, the namespace check still applying to records restored from storage, and the unencrypted-fallback path.

`UserSettings.resetForTesting()` now clears the cached store, or one test's store would answer queries in the next against records it never wrote.
