### PR TITLE
feat(crypto): per-device Pairing PSK, and put it in the candidate set

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -10,6 +10,7 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import java.util.UUID
 import com.sendspindroid.sendspin.crypto.ClientIdentity
+import com.sendspindroid.sendspin.crypto.AndroidPairingConfigStore
 import com.sendspindroid.sendspin.crypto.EncryptedPrefsTrustStore
 import com.sendspindroid.sendspin.crypto.TrustStore
 
@@ -55,6 +56,13 @@ object UserSettings {
     // Long-term PSK records from pairing (stored in encrypted prefs).
     // Record semantics live in the trust store; this is only the blob.
     const val KEY_PSK_RECORDS = "sendspin_psk_records"
+
+    // Pairing configuration. The PSK is sensitive; the two flags are policy.
+    // All of it is read and written only through the pairing config store -
+    // these are plain accessors with no policy of their own.
+    const val KEY_PAIRING_PSK = "sendspin_pairing_psk"
+    const val KEY_PAIRING_PSK_ENABLED = "sendspin_pairing_psk_enabled"
+    const val KEY_UNPAIRED_ACCESS = "sendspin_unpaired_access"
 
     // Remote access preference keys (stored in encrypted prefs)
     const val KEY_REMOTE_SERVERS = "remote_servers"
@@ -285,6 +293,28 @@ object UserSettings {
      */
     fun setPskRecordsBlob(blob: String): Boolean =
         sensitivePrefs?.edit()?.putString(KEY_PSK_RECORDS, blob)?.commit() ?: false
+
+    /** The stored Pairing PSK as base64url, or null when none has been minted. */
+    fun getPairingPskBlob(): String? =
+        sensitivePrefs?.getString(KEY_PAIRING_PSK, null)
+
+    /** `commit()`: a lost write would mint a different PSK on next launch. */
+    fun setPairingPskBlob(blob: String): Boolean =
+        sensitivePrefs?.edit()?.putString(KEY_PAIRING_PSK, blob)?.commit() ?: false
+
+    fun getPairingPskEnabled(): Boolean =
+        sensitivePrefs?.getBoolean(KEY_PAIRING_PSK_ENABLED, true) ?: true
+
+    fun setPairingPskEnabled(enabled: Boolean) {
+        sensitivePrefs?.edit()?.putBoolean(KEY_PAIRING_PSK_ENABLED, enabled)?.commit()
+    }
+
+    fun getUnpairedAccessEnabled(): Boolean =
+        sensitivePrefs?.getBoolean(KEY_UNPAIRED_ACCESS, true) ?: true
+
+    fun setUnpairedAccessEnabled(enabled: Boolean) {
+        sensitivePrefs?.edit()?.putBoolean(KEY_UNPAIRED_ACCESS, enabled)?.commit()
+    }
 
     fun getPlayerId(): String {
         // Fast path: prefs available and ID already stored
@@ -806,6 +836,7 @@ object UserSettings {
             // Or a store built over one test's mock prefs would answer queries
             // in the next test, against records that test never wrote.
             cachedTrustStore = null
+            AndroidPairingConfigStore.resetForTesting()
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -11,6 +11,8 @@ import com.sendspindroid.sendspin.protocol.ControllerState
 import com.sendspindroid.sendspin.protocol.GroupInfo
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
+import com.sendspindroid.sendspin.crypto.AndroidPairingConfigStore
+import com.sendspindroid.sendspin.crypto.PskCandidates
 import com.sendspindroid.sendspin.crypto.PskCandidateSet
 import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
 import com.sendspindroid.sendspin.protocol.SendSpinProtocolHandler
@@ -373,11 +375,44 @@ class SendSpin(
         }
     }
 
+    /** Read once per connection; the PSK is process-wide and never rotates itself. */
+    private val pairingConfigStore = AndroidPairingConfigStore()
+
     /**
-     * Phase 1 candidate set: the Sentinel alone, which is what an unpaired
-     * client presents. Pairing records join it in Phase 2 (#202).
+     * Every PSK this handshake may match: the stored records, the Sentinel, and
+     * the Pairing PSK whenever the method is enabled.
+     *
+     * Built from stored state alone, with no reference to whether a pairing
+     * screen is open, because the server re-handshakes to the Pairing PSK
+     * unprompted and that handshake "succeeds only if the client already
+     * recognizes its `psk_id`".
+     *
+     * A collision cannot arise here - the trust store rejects a colliding
+     * record on the write path and rotation rejects a colliding PSK - so a
+     * failure means the invariant broke somewhere upstream, and falling back to
+     * the Sentinel keeps the client connectable while making the problem loud.
      */
-    private fun pskCandidates(): PskCandidateSet = PskCandidateSet.sentinelOnly()
+    private fun pskCandidates(): PskCandidateSet {
+        val candidates = PskCandidates.build(
+            records = UserSettings.getOrCreateTrustStore().listRecords(),
+            config = pairingConfigStore.load(),
+        )
+        return PskCandidateSet.of(candidates).getOrElse {
+            Log.e(TAG, "PSK candidate set is invalid, falling back to the Sentinel", it)
+            PskCandidateSet.sentinelOnly()
+        }
+    }
+
+    override fun isUnpairedAccessEnabled(): Boolean =
+        pairingConfigStore.load().unpairedAccessEnabled
+
+    override fun getSupportedPairMethods(): List<MessageBuilder.PairMethodDescriptor> =
+        if (pairingConfigStore.load().pairingPskEnabled) {
+            listOf(MessageBuilder.PairMethodDescriptor.PAIRING_PSK)
+        } else {
+            // "An implemented method that is disabled is omitted."
+            emptyList()
+        }
 
     override fun sendTextMessage(text: String) {
         val t = transport ?: return  // Silently drop if transport is gone (e.g. post-disconnect race)

--- a/android/app/src/main/java/com/sendspindroid/sendspin/crypto/AndroidPairingConfigStore.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/crypto/AndroidPairingConfigStore.kt
@@ -1,0 +1,103 @@
+package com.sendspindroid.sendspin.crypto
+
+import android.util.Log
+import com.sendspindroid.UserSettings
+
+/**
+ * The pairing configuration, persisted in `UserSettings`' sensitive prefs.
+ *
+ * The Pairing PSK is minted once, on first read, and then never touched again
+ * except by [rotatePairingPsk]. There is deliberately no code path here that
+ * regenerates or clears it on pairing success, on unpair, or on upgrade:
+ * "a successful pairing does not consume or rotate it ... so it can pair the
+ * client with any number of servers", and a client that quietly re-minted it
+ * would invalidate every pairing token it had ever shown, with no error
+ * anywhere - the operator would simply find that pasting the token stopped
+ * working.
+ */
+class AndroidPairingConfigStore : PairingConfigStore {
+
+    override fun load(): PairingConfig {
+        val psk = cachedPsk ?: synchronized(lock) {
+            // Double-checked: two threads racing first-run generation would
+            // each mint a PSK, one would win the write, and the loser's token
+            // would be unpairable.
+            cachedPsk ?: loadOrMintLocked().also { cachedPsk = it }
+        }
+        return PairingConfig(
+            pairingPsk = psk,
+            pairingPskEnabled = UserSettings.getPairingPskEnabled(),
+            unpairedAccessEnabled = UserSettings.getUnpairedAccessEnabled(),
+        )
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        // Only the flag moves. The secret stays, so re-enabling restores every
+        // token already in circulation rather than silently invalidating them.
+        UserSettings.setPairingPskEnabled(enabled)
+    }
+
+    override fun setUnpairedAccess(enabled: Boolean) {
+        UserSettings.setUnpairedAccessEnabled(enabled)
+    }
+
+    override fun rotatePairingPsk(
+        newPsk: ByteArray,
+        claimedPskIds: Set<String>,
+    ): PairingConfigStore.RotateResult {
+        if (newPsk.size != Psk.PSK_SIZE) return PairingConfigStore.RotateResult.Invalid
+        if (PskId.derive(newPsk) in claimedPskIds) {
+            return PairingConfigStore.RotateResult.AlreadyExists
+        }
+        synchronized(lock) {
+            if (!UserSettings.setPairingPskBlob(Base64Url.encode(newPsk))) {
+                Log.e(TAG, "Failed to persist rotated Pairing PSK: no storage available")
+                return PairingConfigStore.RotateResult.Invalid
+            }
+            cachedPsk = newPsk.copyOf()
+        }
+        return PairingConfigStore.RotateResult.Ok
+    }
+
+    private fun loadOrMintLocked(): ByteArray {
+        val stored = UserSettings.getPairingPskBlob()
+        if (!stored.isNullOrBlank()) {
+            val bytes = Base64Url.decodeOrNull(stored)
+            if (bytes != null && bytes.size == Psk.PSK_SIZE) return bytes
+            // Refuse to silently replace an unreadable secret, for the same
+            // reason the identity does: minting a new one would invalidate
+            // every token in circulation and report nothing.
+            Log.e(
+                TAG,
+                "Stored Pairing PSK is unreadable. Refusing to overwrite it; " +
+                    "pairing is unavailable until it is repaired or deliberately reset."
+            )
+            error("stored Pairing PSK is corrupt")
+        }
+        val fresh = secureRandomBytes(Psk.PSK_SIZE)
+        if (!UserSettings.setPairingPskBlob(Base64Url.encode(fresh))) {
+            Log.e(TAG, "Failed to persist a freshly generated Pairing PSK")
+        }
+        Log.i(TAG, "Generated a Pairing PSK (psk_id=${PskId.derive(fresh)})")
+        return fresh
+    }
+
+    internal companion object {
+        private const val TAG = "PairingConfig"
+
+        // Process-wide: the PSK is per device, so two store objects must not be
+        // able to mint two different ones.
+        private val lock = Any()
+
+        @Volatile
+        private var cachedPsk: ByteArray? = null
+
+        /**
+         * Drop the cached secret. Called by `UserSettings.resetForTesting`, or
+         * one test's PSK would answer the next test's "fresh install".
+         */
+        internal fun resetForTesting() {
+            synchronized(lock) { cachedPsk = null }
+        }
+    }
+}

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -241,6 +241,7 @@ abstract class SendSpinProtocolHandler(
             softwareVersion = getSoftwareVersion(),
             trustLevel = getTrustLevel(),
             unpairedAccessEnabled = isUnpairedAccessEnabled(),
+            supportedPairMethods = getSupportedPairMethods(),
         )
         sendProtocolMessage(text)
         Log.d(tag, "Sent client/hello: ${text.take(500)}")
@@ -305,6 +306,17 @@ abstract class SendSpinProtocolHandler(
      * server toggle it.
      */
     protected open fun isUnpairedAccessEnabled(): Boolean = true
+
+    /**
+     * The pairing methods this client currently offers.
+     *
+     * "An implemented method that is disabled is omitted", so a disabled
+     * `pairing_psk` leaves this list - and its PSK leaves the handshake
+     * candidate set at the same time, or the server could still re-handshake to
+     * a method the client no longer advertises.
+     */
+    protected open fun getSupportedPairMethods(): List<MessageBuilder.PairMethodDescriptor> =
+        listOf(MessageBuilder.PairMethodDescriptor.PAIRING_PSK)
 
     /**
      * Send player state update (volume/muted/availability).

--- a/android/app/src/test/java/com/sendspindroid/sendspin/crypto/AndroidPairingConfigStoreTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/crypto/AndroidPairingConfigStoreTest.kt
@@ -1,0 +1,187 @@
+package com.sendspindroid.sendspin.crypto
+
+import android.content.SharedPreferences
+import com.sendspindroid.UserSettings
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+
+/**
+ * Generation and persistence of the per-device Pairing PSK.
+ *
+ * The two properties that matter are that it is unique per install - "generated
+ * from a CSPRNG per device - never a shared default" - and that nothing
+ * consumes it: "a successful pairing does not consume or rotate it ... so it
+ * can pair the client with any number of servers."
+ */
+class AndroidPairingConfigStoreTest {
+
+    private lateinit var mockPrefs: SharedPreferences
+    private lateinit var mockSensitivePrefs: SharedPreferences
+    private lateinit var sensitiveStore: ConcurrentHashMap<String, String?>
+
+    private fun psk(fill: Byte) = ByteArray(Psk.PSK_SIZE) { fill }
+
+    /** A mock prefs pair over an independent backing map, like a fresh install. */
+    private fun freshBacking(): ConcurrentHashMap<String, String?> {
+        val store = ConcurrentHashMap<String, String?>()
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true) {
+            every { putString(any(), any()) } answers {
+                store[firstArg()] = secondArg(); this@mockk
+            }
+            every { putBoolean(any(), any()) } answers {
+                store[firstArg()] = secondArg<Boolean>().toString(); this@mockk
+            }
+            every { commit() } returns true
+        }
+        val prefs = mockk<SharedPreferences> {
+            every { getString(any(), any()) } answers { store[firstArg()] ?: secondArg() }
+            every { getBoolean(any(), any()) } answers {
+                store[firstArg()]?.toBoolean() ?: secondArg()
+            }
+            every { edit() } returns editor
+        }
+        UserSettings.resetForTesting()
+        UserSettings.initializeForTesting(
+            mockk(relaxed = true), prefs, encrypted = true,
+        )
+        return store
+    }
+
+    @Before
+    fun setUp() {
+        UserSettings.resetForTesting()
+        sensitiveStore = freshBacking()
+        mockPrefs = mockk(relaxed = true)
+        mockSensitivePrefs = mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        UserSettings.resetForTesting()
+    }
+
+    @Test
+    fun firstLoadGeneratesA32BytePskAndPersistsIt() {
+        val first = AndroidPairingConfigStore().load()
+        assertEquals(Psk.PSK_SIZE, first.pairingPsk.size)
+
+        // A new store object over the same backing prefs is the reboot proxy.
+        val second = AndroidPairingConfigStore().load()
+        assertArrayEquals(
+            "the Pairing PSK must persist across restarts",
+            first.pairingPsk, second.pairingPsk,
+        )
+    }
+
+    @Test
+    fun twoIndependentInstallsProduceDifferentPairingPsks() {
+        // "never a shared default" - a fixed value would let anyone pair with
+        // any SendSpinDroid install.
+        val a = AndroidPairingConfigStore().load().pairingPsk
+        freshBacking()
+        val b = AndroidPairingConfigStore().load().pairingPsk
+        assertFalse("two installs produced identical Pairing PSKs", a.contentEquals(b))
+    }
+
+    @Test
+    fun concurrentFirstLoadsAgreeOnOnePsk() {
+        // Two threads racing first-run generation would each mint a PSK and one
+        // would win the write, leaving the other's token unpairable.
+        val threads = 8
+        val barrier = CyclicBarrier(threads)
+        val done = CountDownLatch(threads)
+        val results = java.util.Collections.synchronizedList(mutableListOf<String>())
+        val pool = Executors.newFixedThreadPool(threads)
+        repeat(threads) {
+            pool.submit {
+                barrier.await()
+                results += Base64Url.encode(AndroidPairingConfigStore().load().pairingPsk)
+                done.countDown()
+            }
+        }
+        done.await()
+        pool.shutdown()
+        assertEquals("concurrent first loads minted more than one PSK", 1, results.toSet().size)
+    }
+
+    @Test
+    fun defaultsEnablePairingAndUnpairedAccess() {
+        val config = AndroidPairingConfigStore().load()
+        assertTrue(config.pairingPskEnabled)
+        assertTrue(config.unpairedAccessEnabled)
+    }
+
+    @Test
+    fun enabledAndUnpairedAccessFlagsPersist() {
+        val store = AndroidPairingConfigStore()
+        store.setEnabled(false)
+        store.setUnpairedAccess(false)
+
+        val reloaded = AndroidPairingConfigStore().load()
+        assertFalse(reloaded.pairingPskEnabled)
+        assertFalse(reloaded.unpairedAccessEnabled)
+    }
+
+    @Test
+    fun disablingTheMethodDoesNotDiscardThePsk() {
+        // Re-enabling must restore the same secret, or every previously issued
+        // pairing token silently stops working.
+        val store = AndroidPairingConfigStore()
+        val before = store.load().pairingPsk
+        store.setEnabled(false)
+        store.setEnabled(true)
+        assertArrayEquals(before, AndroidPairingConfigStore().load().pairingPsk)
+    }
+
+    @Test
+    fun rotationIsRejectedWhenTheNewPskCollidesWithAKnownPskId() {
+        val store = AndroidPairingConfigStore()
+        val before = store.load().pairingPsk
+        val claimed = setOf(PskId.derive(psk(1)))
+
+        val result = store.rotatePairingPsk(psk(1), claimed)
+        assertTrue(result is PairingConfigStore.RotateResult.AlreadyExists)
+        assertArrayEquals(
+            "a rejected rotation must leave the stored PSK untouched",
+            before, AndroidPairingConfigStore().load().pairingPsk,
+        )
+    }
+
+    @Test
+    fun rotationRejectsAPskOfTheWrongLength() {
+        val store = AndroidPairingConfigStore()
+        val before = store.load().pairingPsk
+        assertTrue(
+            store.rotatePairingPsk(ByteArray(16), emptySet())
+                is PairingConfigStore.RotateResult.Invalid
+        )
+        assertArrayEquals(before, AndroidPairingConfigStore().load().pairingPsk)
+    }
+
+    @Test
+    fun acceptedRotationPersists() {
+        val store = AndroidPairingConfigStore()
+        assertTrue(
+            store.rotatePairingPsk(psk(5), emptySet())
+                is PairingConfigStore.RotateResult.Ok
+        )
+        assertArrayEquals(psk(5), AndroidPairingConfigStore().load().pairingPsk)
+    }
+
+    @Test
+    fun pairingDoesNotConsumeThePairingPsk() {
+        // "a successful pairing does not consume or rotate it". Simulate a
+        // pairing by writing a long-term record, then assert the secret is
+        // byte-identical.
+        val before = AndroidPairingConfigStore().load().pairingPsk
+        UserSettings.getOrCreateTrustStore().addRecord(psk(3), serverId = "server-a")
+        assertArrayEquals(before, AndroidPairingConfigStore().load().pairingPsk)
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskCandidatesTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskCandidatesTest.kt
@@ -1,0 +1,124 @@
+package com.sendspindroid.sendspin.crypto
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Composition of the handshake candidate set.
+ *
+ * This is the one place that decides which secrets a handshake may match, and
+ * it must be answerable with no reference to UI state: the server re-handshakes
+ * to the Pairing PSK unprompted, so a candidate list assembled only while a
+ * pairing screen is open would fail that handshake as a bare socket close with
+ * nothing to diagnose.
+ */
+class PskCandidatesTest {
+
+    private fun psk(fill: Byte) = ByteArray(Psk.PSK_SIZE) { fill }
+
+    private fun record(fill: Byte, serverId: String?) =
+        PskRecord(PskId.derive(psk(fill)), psk(fill), serverId)
+
+    private fun config(enabled: Boolean = true, pairing: Byte = 7) =
+        PairingConfig(
+            pairingPsk = psk(pairing),
+            pairingPskEnabled = enabled,
+            unpairedAccessEnabled = true,
+        )
+
+    @Test
+    fun theEnabledPairingPskAppearsExactlyOnceWithItsDerivedId() {
+        val built = PskCandidates.build(emptyList(), config(enabled = true))
+        val pairing = built.filter { it.category == PskCategory.PAIRING }
+        assertEquals(1, pairing.size)
+        assertEquals(PskId.derive(psk(7)), pairing.single().pskId)
+    }
+
+    @Test
+    fun aDisabledPairingPskIsExcludedButNothingElseChanges() {
+        // "A PSK for a pairing method disabled in the client's pairing config is
+        // excluded from the candidate set, so a handshake referencing it fails
+        // as a lookup miss."
+        val records = listOf(record(1, "server-a"))
+        val enabled = PskCandidates.build(records, config(enabled = true))
+        val disabled = PskCandidates.build(records, config(enabled = false))
+
+        assertTrue(disabled.none { it.category == PskCategory.PAIRING })
+        assertEquals(
+            enabled.filter { it.category != PskCategory.PAIRING }.map { it.pskId },
+            disabled.map { it.pskId },
+        )
+    }
+
+    @Test
+    fun theSentinelIsAlwaysPresentWhateverTheRecordCount() {
+        for (records in listOf(
+            emptyList(),
+            listOf(record(1, "server-a")),
+            listOf(record(1, "server-a"), record(2, "server-b")),
+        )) {
+            val built = PskCandidates.build(records, config())
+            assertEquals(
+                "sentinel missing for ${records.size} records",
+                1,
+                built.count { it.category == PskCategory.SENTINEL },
+            )
+            assertEquals(
+                SentinelPsk.EXPECTED_PSK_ID,
+                built.single { it.category == PskCategory.SENTINEL }.pskId,
+            )
+        }
+    }
+
+    @Test
+    fun everyRecordBecomesALongTermCandidateCarryingItsServerBinding() {
+        val built = PskCandidates.build(
+            listOf(record(1, "server-a"), record(2, null)),
+            config(),
+        )
+        val longTerm = built.filter { it.category == PskCategory.LONG_TERM }
+        assertEquals(2, longTerm.size)
+        assertEquals("server-a", longTerm.single { it.pskId == PskId.derive(psk(1)) }.serverId)
+        assertNull(longTerm.single { it.pskId == PskId.derive(psk(2)) }.serverId)
+    }
+
+    @Test
+    fun noInputCombinationProducesADuplicatePskId() {
+        // A duplicate would make one wire psk_id map to two trust levels, and
+        // PskCandidateSet.of would refuse the whole set - leaving the client
+        // unable to handshake with anything at all.
+        for (enabled in listOf(true, false)) {
+            for (records in listOf(
+                emptyList(),
+                listOf(record(1, "server-a")),
+                listOf(record(1, "server-a"), record(2, "server-b")),
+            )) {
+                val built = PskCandidates.build(records, config(enabled = enabled))
+                assertEquals(
+                    "duplicate psk_id for enabled=$enabled records=${records.size}",
+                    built.size,
+                    built.map { it.pskId }.toSet().size,
+                )
+                assertTrue(PskCandidateSet.of(built).isSuccess)
+            }
+        }
+    }
+
+    @Test
+    fun pairingPskIsCandidateWithNoPairingActivityRunning() {
+        // The standing obligation. "The client MUST keep its Pairing PSK among
+        // its handshake PSK candidates whenever the method is enabled, not only
+        // while a pairing activity is running: the server's re-handshake to the
+        // Pairing PSK succeeds only if the client already recognizes its
+        // psk_id."
+        //
+        // Nothing in build()'s signature can express "a pairing screen is open",
+        // which is the point: there is no way to make this conditional without
+        // deliberately adding a parameter for it.
+        val built = PskCandidates.build(listOf(record(1, "server-a")), config(enabled = true))
+        assertTrue(
+            "the Pairing PSK must be a candidate with no pairing in progress",
+            built.any { it.category == PskCategory.PAIRING },
+        )
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PairingConfig.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PairingConfig.kt
@@ -1,0 +1,67 @@
+package com.sendspindroid.sendspin.crypto
+
+/**
+ * The client's pairing configuration.
+ *
+ * Shaped after the `data` payload of `management/get-pairing-config` so 3.2
+ * (#228) can read and patch this object rather than inventing a second model.
+ *
+ * @param pairingPsk the per-device Pairing PSK. "Generated from a CSPRNG per
+ *   device - never a shared default", and long-lived: "a successful pairing
+ *   does not consume or rotate it". Nothing may rewrite it except a deliberate
+ *   operator rotation or `management/set-pairing-config`.
+ * @param pairingPskEnabled whether the method is offered. A disabled method's
+ *   PSK leaves the candidate set, so a handshake naming it fails as a lookup
+ *   miss, and the descriptor leaves `client/hello`.
+ * @param unpairedAccessEnabled whether this client admits a server with no
+ *   pairing record. Advertised as `unpaired_access.enabled`.
+ */
+class PairingConfig(
+    pairingPsk: ByteArray,
+    val pairingPskEnabled: Boolean,
+    val unpairedAccessEnabled: Boolean,
+) {
+    init {
+        require(pairingPsk.size == Psk.PSK_SIZE) {
+            "a Sendspin PSK is ${Psk.PSK_SIZE} bytes, got ${pairingPsk.size}"
+        }
+    }
+
+    private val secret = pairingPsk.copyOf()
+
+    /** A copy; the internal array is never handed out. */
+    val pairingPsk: ByteArray get() = secret.copyOf()
+
+    /** `psk_id` of the Pairing PSK, whether or not the method is enabled. */
+    val pairingPskId: String by lazy { PskId.derive(secret) }
+
+    fun withEnabled(enabled: Boolean): PairingConfig =
+        PairingConfig(secret, enabled, unpairedAccessEnabled)
+
+    fun withUnpairedAccess(enabled: Boolean): PairingConfig =
+        PairingConfig(secret, pairingPskEnabled, enabled)
+
+    fun withPairingPsk(psk: ByteArray): PairingConfig =
+        PairingConfig(psk, pairingPskEnabled, unpairedAccessEnabled)
+
+    // Hand-written: a data class holding a ByteArray compares by reference.
+    override fun equals(other: Any?): Boolean =
+        this === other || (
+            other is PairingConfig &&
+                pairingPskEnabled == other.pairingPskEnabled &&
+                unpairedAccessEnabled == other.unpairedAccessEnabled &&
+                secret.contentEquals(other.secret)
+            )
+
+    override fun hashCode(): Int {
+        var result = secret.contentHashCode()
+        result = 31 * result + pairingPskEnabled.hashCode()
+        result = 31 * result + unpairedAccessEnabled.hashCode()
+        return result
+    }
+
+    /** Never the bytes. */
+    override fun toString(): String =
+        "PairingConfig(pairingPskId=$pairingPskId, enabled=$pairingPskEnabled, " +
+            "unpairedAccess=$unpairedAccessEnabled)"
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PairingConfigStore.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PairingConfigStore.kt
@@ -1,0 +1,45 @@
+package com.sendspindroid.sendspin.crypto
+
+/**
+ * Storage for the pairing configuration.
+ *
+ * An interface so tests and `:conformance-client` can substitute an in-memory
+ * implementation for the Android one.
+ */
+interface PairingConfigStore {
+
+    sealed interface RotateResult {
+        object Ok : RotateResult
+
+        /** The new `psk_id` is already claimed elsewhere in the shared namespace. */
+        object AlreadyExists : RotateResult
+
+        /** Not a 32-byte PSK. */
+        object Invalid : RotateResult
+    }
+
+    /**
+     * The current configuration, generating and persisting a Pairing PSK on
+     * first use.
+     */
+    fun load(): PairingConfig
+
+    /** Offer or withdraw the `pairing_psk` method. Never discards the secret. */
+    fun setEnabled(enabled: Boolean)
+
+    fun setUnpairedAccess(enabled: Boolean)
+
+    /**
+     * Replace the Pairing PSK.
+     *
+     * The only supported rotation path besides a deliberate local operator
+     * action: "The client MUST NOT rotate it on its own". There is no timer, no
+     * counter, and no automatic rotation anywhere - pairing success in
+     * particular does not consume it.
+     *
+     * @param claimedPskIds every `psk_id` already spoken for - the trust store's
+     *   records and the Sentinel. Passed in rather than read from a store so
+     *   this stays testable and so the namespace rule has no second owner.
+     */
+    fun rotatePairingPsk(newPsk: ByteArray, claimedPskIds: Set<String>): RotateResult
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PskCandidates.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PskCandidates.kt
@@ -1,0 +1,31 @@
+package com.sendspindroid.sendspin.crypto
+
+/**
+ * Builds the set of PSKs a handshake may match.
+ *
+ * Deliberately a pure function of stored state. The server re-handshakes to the
+ * Pairing PSK unprompted - "not only while a pairing activity is running" - so
+ * this must be answerable without reference to any UI state. There is no
+ * parameter here that could express "a pairing screen is open", which is the
+ * safeguard: making the Pairing PSK conditional on activity would require
+ * adding one on purpose.
+ */
+object PskCandidates {
+
+    /**
+     * @param records long-term PSKs from the trust store
+     * @param config the pairing configuration; its Pairing PSK joins the set
+     *   only while [PairingConfig.pairingPskEnabled] is true
+     * @return records, the Sentinel, and (when enabled) the Pairing PSK.
+     *   Suitable for [PskCandidateSet.of], which will not reject it: the trust
+     *   store rejects a colliding record on the write path, and a Pairing PSK
+     *   colliding with a record cannot be stored either.
+     */
+    fun build(records: List<PskRecord>, config: PairingConfig): List<Psk> = buildList {
+        records.forEach { add(it.toPsk()) }
+        add(SentinelPsk.psk)
+        if (config.pairingPskEnabled) {
+            add(Psk(config.pairingPsk, PskCategory.PAIRING))
+        }
+    }
+}


### PR DESCRIPTION
The Pairing PSK is the secret half of the token an operator pastes into Music Assistant. It is minted per device from the CSPRNG on first use, persisted in encrypted preferences, and never rotated by the client itself.

Refs #203.

## The standing obligation

The server re-handshakes **to** the Pairing PSK before it activates pairing, so the client must already recognise its `psk_id` at handshake time - "not only while a pairing activity is running". A candidate set assembled while a pairing screen was open would fail that handshake as a bare socket close with nothing to diagnose.

`PskCandidates.build` is therefore a pure function of stored state: records, the Sentinel, and the Pairing PSK whenever the method is enabled. **Nothing in its signature can express "a pairing screen is open"**, which is the safeguard - making it conditional on activity would require deliberately adding a parameter for it. `pairingPskIsCandidateWithNoPairingActivityRunning` pins that.

## Never a shared default

Two installs must not share a secret, or anyone could pair with any SendSpinDroid. Generation is guarded by a process-wide lock and cache: two threads racing first use would each mint a PSK, one would win the write, and the loser's token would be unpairable. Tested with eight concurrent first loads asserting a single distinct value, and with two independent backing stores asserting different values.

## Nothing consumes it

There is deliberately no path that regenerates or clears the PSK on pairing success, on unpair, or on upgrade: "a successful pairing does not consume or rotate it ... so it can pair the client with any number of servers".

Disabling the method withdraws the descriptor and the candidate but **keeps the secret**, so re-enabling restores every token already in circulation rather than silently invalidating them. Both behaviours are tested.

An unreadable stored PSK is not replaced, for the same reason the identity is not - minting a new one would invalidate every token in circulation and report nothing.

## Wiring

`pskCandidates()` now composes from the trust store and the pairing config instead of returning the Sentinel alone. `client/hello` sources `unpaired_access` and `supported_pair_methods` from the config, so a disabled method is omitted - "An implemented method that is disabled is omitted" - at the same moment its PSK leaves the candidate set. Doing only one of those would let the server re-handshake to a method the client no longer advertises.

## Deviations from the plan in #203

- **No new `RandomSource`** - `secureRandomBytes` already exists in `NoisePrimitives.kt`.
- **`client/hello` already carried the fields** from 1.8; only the gating on config was missing.
- **The plan's `locations: ["operator"]` is wrong.** #191 confirmed against a live Music Assistant that it renders *"The pairing token is printed on the device"* - the `["device"]` the shipped code already sends.
- **`PskCandidates.build` takes no `sentinelPsk` parameter** - it has exactly one possible value.
- **`rotatePairingPsk` takes the claimed `psk_id`s** rather than reaching into the trust store, so the namespace rule keeps a single owner and the rotation path stays testable.

## Tests

**16, all written before the implementation** - 6 candidate composition, 10 generation and persistence. 722 app tests and the shared suite pass.
