### PR TITLE
feat(crypto): make trust level and activation follow the matched PSK

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -12,6 +12,8 @@ import com.sendspindroid.sendspin.protocol.GroupInfo
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
 import com.sendspindroid.sendspin.crypto.AndroidPairingConfigStore
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PskCategory
 import com.sendspindroid.sendspin.crypto.PskCandidates
 import com.sendspindroid.sendspin.crypto.PskCandidateSet
 import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
@@ -324,6 +326,12 @@ class SendSpin(
     private var handshakeDriver: SendSpinHandshakeDriver? = null
 
     private fun startEncryptedHandshake() {
+        // Cleared here rather than on disconnect: every handshake passes through
+        // this point, so a stale category from the previous session can never
+        // survive into the next one and overstate its trust level. This also
+        // covers the in-band re-handshake (#223), which never disconnects.
+        matchedPsk = null
+
         // The wire client_id for an encrypted session is the base64url public
         // key, NOT the legacy UUID player id - the two are different
         // identifiers and the server rejects a non-43-character value.
@@ -347,6 +355,19 @@ class SendSpin(
             is SendSpinHandshakeDriver.Event.TransportReady -> {
                 Log.i(TAG, "Noise handshake complete with ${event.serverInit.serverId} " +
                     "(psk=${event.matchedPsk.category})")
+                // Retained rather than logged and dropped: the category decides
+                // trust_level, which activities the server may declare, and
+                // whether pairing may run. Recomputing it anywhere else would
+                // let those three disagree.
+                matchedPsk = event.matchedPsk
+
+                // "used" means a server has authenticated a session with this
+                // record. Marked on entry to transport mode rather than on the
+                // psk_id match, because a match that then failed AEAD
+                // authenticated nothing.
+                if (event.matchedPsk.category == PskCategory.LONG_TERM) {
+                    UserSettings.getOrCreateTrustStore().markUsed(event.matchedPsk.pskId)
+                }
                 installEncryptedTransport(event.transport)
                 // client/hello is the first ENCRYPTED message, not the first
                 // frame on the socket. It now rides the codec like everything
@@ -379,6 +400,16 @@ class SendSpin(
     private val pairingConfigStore = AndroidPairingConfigStore()
 
     /**
+     * The PSK that admitted the current session, or null before the handshake.
+     *
+     * Single source of truth for everything that follows from how we were
+     * authenticated: `trust_level`, the `server/activate` admissibility table,
+     * and (in 2.5) whether a pairing activation may proceed.
+     */
+    @Volatile
+    private var matchedPsk: Psk? = null
+
+    /**
      * Every PSK this handshake may match: the stored records, the Sentinel, and
      * the Pairing PSK whenever the method is enabled.
      *
@@ -405,6 +436,32 @@ class SendSpin(
 
     override fun isUnpairedAccessEnabled(): Boolean =
         pairingConfigStore.load().unpairedAccessEnabled
+
+    /**
+     * The category that admitted this connection, defaulting to the Sentinel
+     * before a handshake has matched anything - the least-privileged answer,
+     * so a bug here narrows what the server may declare rather than widening it.
+     */
+    override fun matchedPskCategory(): PskCategory =
+        matchedPsk?.category ?: PskCategory.SENTINEL
+
+    /**
+     * `'user'` if and only if a long-term record admitted this session.
+     *
+     * The Sentinel and the Pairing PSK are both `'none'`: neither proves the
+     * server is one we have ever paired with. This single field is what makes
+     * the server pick the long-term row of the admissibility table.
+     */
+    override fun getTrustLevel(): String =
+        if (matchedPsk?.category == PskCategory.LONG_TERM) {
+            MessageBuilder.TRUST_USER
+        } else {
+            MessageBuilder.TRUST_NONE
+        }
+
+    /** The live configuration, not a constant: a disabled method is not offered. */
+    override fun offeredPairMethods(): Set<String> =
+        if (pairingConfigStore.load().pairingPskEnabled) setOf("pairing_psk") else emptySet()
 
     override fun getSupportedPairMethods(): List<MessageBuilder.PairMethodDescriptor> =
         if (pairingConfigStore.load().pairingPskEnabled) {

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskSelectionTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskSelectionTest.kt
@@ -1,0 +1,108 @@
+package com.sendspindroid.sendspin.crypto
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * PSK selection from the `psk_id` in Noise message 1.
+ *
+ * KKpsk2 mixes the PSK at the end of message 2, so the client must choose
+ * before it can process that message; message 1's payload is decryptable
+ * without the PSK precisely so this choice can be made.
+ *
+ * Selection has three outcomes, not two. "I do not know this psk_id" and "I
+ * know it but it belongs to a different server" both close the socket with no
+ * application-level message, so the only place they can ever be told apart is a
+ * log line - and they mean very different things when one appears in the field.
+ */
+class PskSelectionTest {
+
+    private val serverA = "OraobU4leb48EaZTGPbLhNug8XjEZsKXv8qiczhEGTU"
+    private val serverB = "oGsvjWZwiEn6ivL-57RPbdBxRcGYovNllt9tcjDjtVM"
+
+    private fun psk(fill: Byte) = ByteArray(Psk.PSK_SIZE) { fill }
+
+    private fun setOf(vararg candidates: Psk) = PskCandidateSet.of(candidates.toList()).getOrThrow()
+
+    @Test
+    fun theSentinelIsSelectedByItsPublishedPskId() {
+        val set = setOf(SentinelPsk.psk)
+        val result = set.select(SentinelPsk.EXPECTED_PSK_ID, serverA)
+        assertTrue(result is PskCandidateSet.Selection.Matched)
+        assertEquals(
+            PskCategory.SENTINEL,
+            (result as PskCandidateSet.Selection.Matched).candidate.category,
+        )
+    }
+
+    @Test
+    fun aPairingPskIsSelectedByItsDerivedId() {
+        val pairing = Psk(psk(7), PskCategory.PAIRING)
+        val set = setOf(SentinelPsk.psk, pairing)
+        val result = set.select(pairing.pskId, serverA)
+        assertTrue(result is PskCandidateSet.Selection.Matched)
+        assertEquals(
+            PskCategory.PAIRING,
+            (result as PskCandidateSet.Selection.Matched).candidate.category,
+        )
+    }
+
+    @Test
+    fun aRecordMatchesWhenTheServerIdAgrees() {
+        val record = Psk(psk(1), PskCategory.LONG_TERM, serverA)
+        val result = setOf(SentinelPsk.psk, record).select(record.pskId, serverA)
+        assertTrue(result is PskCandidateSet.Selection.Matched)
+    }
+
+    @Test
+    fun aRecordForADifferentServerIsAMismatchNotAMiss() {
+        // The headline stored-pubkey case. Reporting this as "unknown psk_id"
+        // would send the next person looking for a storage bug, when what
+        // actually happened is that a server presented another server's record.
+        val record = Psk(psk(1), PskCategory.LONG_TERM, serverA)
+        val result = setOf(SentinelPsk.psk, record).select(record.pskId, serverB)
+        assertTrue(
+            "expected ServerIdMismatch, got $result",
+            result is PskCandidateSet.Selection.ServerIdMismatch,
+        )
+        result as PskCandidateSet.Selection.ServerIdMismatch
+        assertEquals(serverA, result.expected)
+        assertEquals(serverB, result.actual)
+    }
+
+    @Test
+    fun anUnknownPskIdIsAMiss() {
+        val result = setOf(SentinelPsk.psk).select(Psk(psk(9), PskCategory.PAIRING).pskId, serverA)
+        assertTrue(result is PskCandidateSet.Selection.NoMatch)
+    }
+
+    @Test
+    fun aMalformedPskIdIsAMissRatherThanAThrow() {
+        val set = setOf(SentinelPsk.psk)
+        assertTrue(set.select("", serverA) is PskCandidateSet.Selection.NoMatch)
+        assertTrue(set.select("not-a-psk-id", serverA) is PskCandidateSet.Selection.NoMatch)
+        // 43 characters, correct shape, still unknown.
+        assertTrue(set.select("A".repeat(43), serverA) is PskCandidateSet.Selection.NoMatch)
+    }
+
+    @Test
+    fun unboundCandidatesSkipTheServerIdCheck() {
+        // The Sentinel and the Pairing PSK are by definition not bound to a
+        // server, so they must match whatever server_id turns up.
+        val pairing = Psk(psk(7), PskCategory.PAIRING)
+        val set = setOf(SentinelPsk.psk, pairing)
+        assertTrue(set.select(SentinelPsk.EXPECTED_PSK_ID, serverB) is PskCandidateSet.Selection.Matched)
+        assertTrue(set.select(pairing.pskId, serverB) is PskCandidateSet.Selection.Matched)
+    }
+
+    @Test
+    fun aDisabledPairingMethodMakesItsPskIdAMiss() {
+        // "A PSK for a pairing method disabled in the client's pairing config is
+        // excluded from the candidate set, so a handshake referencing it fails
+        // as a lookup miss." Exercised end to end through PskCandidates.build.
+        val config = PairingConfig(psk(7), pairingPskEnabled = false, unpairedAccessEnabled = true)
+        val built = PskCandidates.build(emptyList(), config)
+        val set = PskCandidateSet.of(built).getOrThrow()
+        assertTrue(set.select(config.pairingPskId, serverA) is PskCandidateSet.Selection.NoMatch)
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PskCandidateSet.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PskCandidateSet.kt
@@ -43,6 +43,40 @@ class PskCandidateSet private constructor(private val candidates: List<Psk>) {
     fun verifyServerBinding(matched: Psk, serverIdFromServerInit: String): Boolean =
         matched.serverId == null || matched.serverId == serverIdFromServerInit
 
+    /** The outcome of choosing a PSK for a handshake. */
+    sealed interface Selection {
+        data class Matched(val candidate: Psk) : Selection
+
+        /** No candidate claims this `psk_id`. */
+        object NoMatch : Selection
+
+        /**
+         * The `psk_id` matched a record bound to a different server.
+         *
+         * Kept apart from [NoMatch] because both close the socket with no
+         * application-level message, so a log line is the only place they can
+         * ever be distinguished - and they mean very different things. A miss
+         * is "I have never been told about this secret"; a mismatch is "I hold
+         * this secret, but for someone else", which is what a spoofed or
+         * misconfigured server looks like.
+         */
+        data class ServerIdMismatch(val expected: String, val actual: String) : Selection
+    }
+
+    /**
+     * Choose the PSK for a handshake: [resolve] then the stored-pubkey check,
+     * in one call so the two cannot drift apart or be applied in the wrong
+     * order.
+     */
+    fun select(pskId: String, serverIdFromServerInit: String): Selection {
+        val matched = resolve(pskId) ?: return Selection.NoMatch
+        val bound = matched.serverId
+        if (bound != null && bound != serverIdFromServerInit) {
+            return Selection.ServerIdMismatch(expected = bound, actual = serverIdFromServerInit)
+        }
+        return Selection.Matched(matched)
+    }
+
     companion object {
         /**
          * @return a failure if two candidates derive the same `psk_id`. That is a

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriver.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinHandshakeDriver.kt
@@ -206,20 +206,29 @@ class SendSpinHandshakeDriver(
             NoiseHandshakeException.Cause.PayloadNotJson,
             "message 1 payload is not {\"psk_id\": ...}",
         )
-        val matched = candidates.resolve(pskId) ?: return fail(
-            NoiseHandshakeException.Cause.PskLookupMiss,
-            "no candidate PSK matches psk_id $pskId",
-        )
         val init = serverInit ?: return fail(
             NoiseHandshakeException.Cause.WrongPhase, "no server/init retained"
         )
-        if (!candidates.verifyServerBinding(matched, init.serverId)) {
-            // Usually a server that rotated its static keypair rather than an
-            // attack: "A server that rotates its static keypair ... appears to
-            // clients as a different server."
-            return fail(
+        // One call, so the lookup and the stored-pubkey check cannot drift apart
+        // or run in the wrong order. Both failures close the socket in silence,
+        // so this detail string is the only diagnostic that will ever exist -
+        // hence spelling out which of the two happened, and the candidate count.
+        val matched = when (val selection = candidates.select(pskId, init.serverId)) {
+            is PskCandidateSet.Selection.Matched -> selection.candidate
+
+            PskCandidateSet.Selection.NoMatch -> return fail(
                 NoiseHandshakeException.Cause.PskLookupMiss,
-                "matched record is bound to a different server_id",
+                "no candidate PSK matches psk_id $pskId " +
+                    "(${candidates.all.size} candidates offered)",
+            )
+
+            is PskCandidateSet.Selection.ServerIdMismatch -> return fail(
+                // Usually a server that rotated its static keypair rather than
+                // an attack: "A server that rotates its static keypair ...
+                // appears to clients as a different server."
+                NoiseHandshakeException.Cause.PskLookupMiss,
+                "psk_id $pskId is a record for server ${selection.expected}, " +
+                    "but server/init announced ${selection.actual}",
             )
         }
 


### PR DESCRIPTION
The handshake already resolved a `psk_id` and applied the stored-pubkey `server_id` check. What it did with the answer was log it and throw it away.

Closes #204.

## Three constants that decided how much the server may do

```
matchedPskCategory() = SENTINEL       // "#204 makes it follow the real handshake result"
getTrustLevel()      = TRUST_NONE     // "#204 makes it follow the matched PSK"
offeredPairMethods() = {pairing_psk}  // hardcoded, not the live config
```

All three now read the session's matched PSK, captured once on `TransportReady` and never recomputed. `trust_level`, the `server/activate` admissibility table, and (in 2.5) whether pairing may run must not be able to disagree about how we were authenticated.

`trust_level` is `user` **if and only if** a `LONG_TERM` record admitted the session. The Sentinel and the Pairing PSK are both `none` - neither proves the server is one we have ever paired with.

Two details worth review:

- **`matchedPsk` is cleared at the START of every handshake**, not on disconnect. Every handshake passes through that point, so a stale category cannot survive into the next session and overstate its trust - and it covers the in-band re-handshake (#223), which never disconnects.
- **Its default before any match is `SENTINEL`**, the least-privileged answer, so a bug narrows what the server may declare rather than widening it.
- **Records are marked `used` on entry to transport mode**, not on `psk_id` match. `used` means a server authenticated a session with this record, and a match that then failed AEAD authenticated nothing.

## Selection is one call, not two

`PskCandidateSet.select()` returns `Matched`, `NoMatch`, or `ServerIdMismatch`, replacing a `resolve()` followed by a separate `verifyServerBinding()` that could drift apart or run in the wrong order.

Splitting the two failures matters because **neither can ever be reported on the wire** - the spec forbids an application-level error here - so the log detail is the only artifact that will ever exist. Both used to say "no candidate PSK matches", which points at a storage bug. A mismatch means the opposite: *we hold that secret, for a different server*, which is what a rotated server keypair or a spoofed `server_id` looks like. Same silent close, opposite investigation. The miss now also reports the candidate count.

## Deviations from the plan in #204

No new `PskSelector` or `NoiseHandshakePayload`. The driver already parses the message-1 `psk_id`, and `PskCandidateSet` already owned both resolution and the binding check - adding parallel types would have given one rule two homes. What was genuinely missing was the three-state outcome, so `select()` was added to the existing class.

## Verification

**8 tests, written before the implementation.** 722 app tests and the shared suite pass.

On device against a live Music Assistant: handshake matches `SENTINEL`, `trust_level: none`, `server/activate` accepted with all four roles, zero lookup misses, zero candidate-set failures, clock sync converging.

That is deliberately a *negative* result - there are no long-term records yet, so nothing can match `LONG_TERM`. The point is that making these hooks live did not perturb the unpaired path. `trust_level: user` only becomes observable once #206 completes a pairing.
