### PR TITLE
feat(protocol): in-band Noise re-handshake

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -10,6 +10,9 @@ import com.sendspindroid.sendspin.transport.ProxyWebSocketTransport
 import com.sendspindroid.sendspin.protocol.ControllerState
 import com.sendspindroid.sendspin.protocol.GroupInfo
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+
+import com.sendspindroid.sendspin.crypto.NoiseCipherSuite
+import com.sendspindroid.sendspin.crypto.asNoiseCrypto
 import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
 import com.sendspindroid.sendspin.crypto.AndroidPairingConfigStore
 import com.sendspindroid.sendspin.crypto.Psk
@@ -17,6 +20,8 @@ import com.sendspindroid.sendspin.crypto.PskCategory
 import com.sendspindroid.sendspin.crypto.PskCandidates
 import com.sendspindroid.sendspin.crypto.PskCandidateSet
 import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
+import kotlinx.serialization.json.JsonObject
+import com.sendspindroid.sendspin.protocol.RehandshakeDriver
 import com.sendspindroid.sendspin.protocol.SendSpinProtocolHandler
 import com.sendspindroid.sendspin.protocol.StreamConfig
 import com.sendspindroid.sendspin.protocol.TrackMetadata
@@ -361,6 +366,17 @@ class SendSpin(
                 // let those three disagree.
                 matchedPsk = event.matchedPsk
 
+                // Retained for the in-band re-handshake, which re-sends none of
+                // this and has no way to ask for it again.
+                sessionFacts = SessionFacts(
+                    serverId = event.serverInit.serverId,
+                    serverStaticKey = event.serverInit.serverStaticKey,
+                    // Carries over unchanged: the re-handshake re-sends no
+                    // client/init, so there is no opportunity to renegotiate it.
+                    suite = SendSpinHandshakeDriver.DEFAULT_SUITE,
+                    priorHandshakeHash = event.transport.handshakeHash,
+                )
+
                 // "used" means a server has authenticated a session with this
                 // record. Marked on entry to transport mode rather than on the
                 // psk_id match, because a match that then failed AEAD
@@ -408,6 +424,25 @@ class SendSpin(
      */
     @Volatile
     private var matchedPsk: Psk? = null
+
+    /**
+     * Everything a re-handshake needs that is NOT re-sent.
+     *
+     * "`client/init` and `server/init` are not re-sent - `client_id`,
+     * `server_id`, and `suite` carry over. The new handshake's prologue is the
+     * prior handshake's hash `h`." So the connection has to retain them; there
+     * is no second chance to read them off the wire.
+     */
+    private class SessionFacts(
+        val serverId: String,
+        val serverStaticKey: ByteArray,
+        val suite: NoiseCipherSuite,
+        /** Prologue for the NEXT handshake. Advances on every promotion. */
+        var priorHandshakeHash: ByteArray,
+    )
+
+    @Volatile
+    private var sessionFacts: SessionFacts? = null
 
     /**
      * Every PSK this handshake may match: the stored records, the Sentinel, and
@@ -462,6 +497,71 @@ class SendSpin(
     /** The live configuration, not a constant: a disabled method is not offered. */
     override fun offeredPairMethods(): Set<String> =
         if (pairingConfigStore.load().pairingPskEnabled) setOf("pairing_psk") else emptySet()
+
+    /**
+     * Run an in-band re-handshake.
+     *
+     * The server initiates this to promote the channel after a pairing, or to
+     * switch a Sentinel-keyed connection to the Pairing PSK before offering
+     * `pairing_psk`. The socket stays open throughout: "The server may rerun
+     * the Noise handshake in transport mode to swap session keys without
+     * closing the WebSocket."
+     *
+     * Every failure below closes without an application-level message, because
+     * the spec allows none - so each one logs its own reason first. That log
+     * line is the only artifact anyone will have.
+     */
+    override fun onRehandshakeMessage(payload: JsonObject?) {
+        val facts = sessionFacts ?: return failRehandshake(
+            "noise/handshake arrived before any handshake completed"
+        )
+        Log.i(TAG, "Re-handshake starting (prior h=${hashPrefix(facts.priorHandshakeHash)})")
+
+        // Candidates are rebuilt now rather than reused from connect time: a
+        // record persisted moments ago by a pairing must be visible to this
+        // very selection, which is why the server started the exchange.
+        val driver = RehandshakeDriver(
+            identity = UserSettings.getOrCreateClientIdentity(),
+            candidates = pskCandidates(),
+            serverId = facts.serverId,
+            serverStaticKey = facts.serverStaticKey,
+            suite = facts.suite,
+            priorHandshakeHash = facts.priorHandshakeHash,
+        )
+
+        val outcome = driver.handle(payload?.get("data")?.jsonPrimitive?.contentOrNull)
+        if (outcome is RehandshakeDriver.Outcome.Fail) return failRehandshake(outcome.reason)
+        outcome as RehandshakeDriver.Outcome.Reply
+
+        // Encrypted under the OLD keys, then the swap. The callback runs only
+        // once that frame is on the wire.
+        sendAndSwapKeys(outcome.replyJson, outcome.transport.asNoiseCrypto()) {
+            facts.priorHandshakeHash = outcome.transport.handshakeHash
+            matchedPsk = outcome.matched
+            if (outcome.matched.category == PskCategory.LONG_TERM) {
+                UserSettings.getOrCreateTrustStore().markUsed(outcome.matched.pskId)
+            }
+            // The channel is promoted, not replaced: transport, group and time
+            // filter all survive. Only the message sequence restarts.
+            resetForRehandshake()
+            Log.i(
+                TAG,
+                "Re-handshake complete: psk=${outcome.matched.category} " +
+                    "trust=${getTrustLevel()} new h=${hashPrefix(outcome.transport.handshakeHash)}"
+            )
+        }
+    }
+
+    /** First 8 hex chars of a handshake hash. Channel-binding data, not a secret. */
+    private fun hashPrefix(hash: ByteArray): String =
+        hash.take(4).joinToString("") { b ->
+            ((b.toInt() and 0xFF) + 0x100).toString(16).substring(1)
+        }
+
+    private fun failRehandshake(reason: String) {
+        Log.e(TAG, "Re-handshake failed: $reason")
+        onProtocolFailure(reason)
+    }
 
     override fun getSupportedPairMethods(): List<MessageBuilder.PairMethodDescriptor> =
         if (pairingConfigStore.load().pairingPskEnabled) {

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -3,6 +3,7 @@ package com.sendspindroid.sendspin.protocol
 import android.util.Log
 import com.sendspindroid.sendspin.AdaptiveBufferPolicy
 import com.sendspindroid.sendspin.SendspinTimeFilter
+import com.sendspindroid.sendspin.crypto.NoiseCrypto
 import com.sendspindroid.sendspin.crypto.NoiseTransport
 import com.sendspindroid.sendspin.crypto.PskCategory
 import com.sendspindroid.sendspin.protocol.message.BinaryMessageParser
@@ -632,6 +633,35 @@ abstract class SendSpinProtocolHandler(
         Log.i(tag, "Encrypted channel established")
     }
 
+    /**
+     * A `noise/handshake` arrived inside the encrypted channel.
+     *
+     * Overridden by the connection, which owns the identity, the candidate set
+     * and the prior handshake hash. The base implementation closes: a
+     * `noise/handshake` is only ever valid in transport mode, and a handler
+     * that cannot run one must not silently ignore it.
+     */
+    protected open fun onRehandshakeMessage(payload: JsonObject?) {
+        onProtocolFailure("noise/handshake received but re-handshake is not supported here")
+    }
+
+    /**
+     * Reset the application-level handshake state after a re-handshake.
+     *
+     * The channel is promoted, not replaced: the transport, the group and the
+     * time filter all survive, so this deliberately does NOT touch them. What
+     * does reset is the message sequence - the server sends `server/hello`
+     * again, and the next `server/activate` is a *first* activation, so a
+     * server that omits `active_roles` clears them rather than inheriting the
+     * roles from before the promotion.
+     */
+    protected fun resetForRehandshake() {
+        handshakeComplete = false
+        activationSeen = false
+        activeRoles = emptyList()
+        activities = emptySet()
+    }
+
     /** Drop the encrypted channel (disconnect, or falling back to legacy). */
     fun clearEncryptedTransport() {
         wireCodec = null
@@ -662,6 +692,36 @@ abstract class SendSpinProtocolHandler(
     }
 
     /**
+     * Send [text] under the current keys, then promote the channel to [next].
+     *
+     * The completing frame of a re-handshake. Ordering is the codec's problem
+     * (it holds the send mutex across encrypt-then-install); ordering with
+     * respect to the *application* is this method's: [onSwapped] runs only
+     * after the frame is on the wire, so the re-asserted `client/hello` cannot
+     * be built from state the swap has not finished changing.
+     */
+    protected fun sendAndSwapKeys(text: String, next: NoiseCrypto, onSwapped: () -> Unit) {
+        val codec = wireCodec
+        if (codec == null) {
+            onProtocolFailure("re-handshake attempted with no encrypted channel")
+            return
+        }
+        getCoroutineScope().launch {
+            try {
+                codec.encodeAndSwap(
+                    SendSpinProtocol.BinaryType.JSON,
+                    text.encodeToByteArray(),
+                    next,
+                ).forEach { sendBinaryFrame(it) }
+                onSwapped()
+            } catch (e: Exception) {
+                Log.e(tag, "Re-handshake key swap failed", e)
+                onProtocolFailure("re-handshake key swap failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
      * A protocol-level failure that requires closing the socket.
      *
      * The spec allows no application-level error message for these, so the only
@@ -687,6 +747,11 @@ abstract class SendSpinProtocolHandler(
             val payload = json["payload"]?.jsonObject
 
             when (type) {
+                // An in-band re-handshake. It arrives as an ordinary encrypted
+                // JSON message inside the current channel, which is why it is
+                // dispatched here and not by the cleartext handshake driver.
+                SendSpinProtocol.MessageType.NOISE_HANDSHAKE -> onRehandshakeMessage(payload)
+
                 SendSpinProtocol.MessageType.SERVER_HELLO -> handleServerHello(payload)
                 SendSpinProtocol.MessageType.SERVER_ACTIVATE -> handleServerActivate(payload)
                 SendSpinProtocol.MessageType.SERVER_TIME -> handleServerTime(payload)

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/NoiseRehandshakeTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/NoiseRehandshakeTest.kt
@@ -1,0 +1,136 @@
+package com.sendspindroid.sendspin.crypto
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * The in-band re-handshake's prologue rule, against reference vectors.
+ *
+ * `connection.md#re-handshake`: "`client/init` and `server/init` are not
+ * re-sent - `client_id`, `server_id`, and `suite` carry over. The new
+ * handshake's prologue is the prior handshake's hash `h`."
+ *
+ * That sentence is the whole risk in item 2.6. Using the *initial* prologue, or
+ * the base64url text of `h` instead of its raw 32 bytes, fails at message-1
+ * decryption with an AEAD error several steps removed from the cause - and the
+ * spec's answer to any handshake failure is a silent socket close, so there is
+ * nothing to read afterwards.
+ *
+ * Vectors are generated and cross-checked against `noiseprotocol` (the library
+ * aiosendspin 9.1.0 depends on) by
+ * `ci/conformance/noise/make_rehandshake_vectors.py`. Both sides there are the
+ * reference; this class is the only consumer.
+ */
+class NoiseRehandshakeTest {
+
+    private fun hex(s: String) = ByteArray(s.length / 2) {
+        s.substring(it * 2, it * 2 + 2).toInt(16).toByte()
+    }
+
+    private val clientStatic = hex("606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f")
+    private val serverStaticPublic = hex("358072d6365880d1aeea329adf9121383851ed21a28e3b75e965d0d2cd166254")
+
+    /** `h` from the initial handshake. The re-handshake's prologue, verbatim. */
+    private val priorHandshakeHash =
+        hex("aaf129d111ad113e55c9cc23439df0e4e43c8f28d8d5f3d3e3ff3e7775562703")
+
+    /** The initial handshake's own prologue - the wrong answer, kept to prove it is wrong. */
+    private val initialPrologue = "sendspin-rehandshake-initial-prologue-v1".encodeToByteArray()
+
+    private val rehandshakePsk =
+        hex("b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0")
+    private val clientEphemeral =
+        hex("404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f")
+
+    private val message1 = hex(
+        "07a37cbc142093c8b755dc1b10e86cb426374ad16aa853ed0bdfc0b2b86d1c7c" +
+            "dd9e7b6b8fa1b6c5c8cc1ef92e141c8bcdc51902ada99e3bfa3a00ef3f639b6c" +
+            "5d2742d4886eee53d808a801bf02d2d8e43292ea8cd04a81535f12ef"
+    )
+    private val expectedMessage2 = hex(
+        "79a631eede1bf9c98f12032cdeadd0e7a079398fc786b88cc846ec89af85a51a" +
+            "d16b35924d8f5c152f908a0674cabe689914"
+    )
+    private val expectedHandshakeHash =
+        hex("ea0381952fe8a29c171d7ddc01ed80de1d56efa7d8e492d481a9bb41c08e8276")
+
+    private fun responder(prologue: ByteArray) = NoiseHandshake(
+        suite = NoiseCipherSuite.CHACHA_POLY,
+        staticPrivateKey = clientStatic,
+        remoteStaticPublicKey = serverStaticPublic,
+        prologue = prologue,
+        generateEphemeral = { clientEphemeral },
+    )
+
+    @Test
+    fun aRehandshakeWithPriorHAsPrologueReproducesTheReference() {
+        val handshake = responder(priorHandshakeHash)
+
+        val payload = handshake.readMessage1(message1)
+        assertEquals(
+            """{"psk_id": "rehandshake-psk-id-placeholder"}""",
+            payload.decodeToString(),
+        )
+
+        val message2 = handshake.writeMessage2(rehandshakePsk)
+        assertArrayEquals(
+            "message 2 must match the reference byte for byte",
+            expectedMessage2, message2.message,
+        )
+        assertArrayEquals(
+            "the new h must match the reference",
+            expectedHandshakeHash, message2.transport.handshakeHash,
+        )
+    }
+
+    @Test
+    fun theInitialPrologueFailsMessageOneDecryption() {
+        // The single most likely silent bug: carrying the first handshake's
+        // prologue into the second. It fails here, at an AEAD tag check, with
+        // nothing naming the prologue as the cause.
+        val handshake = responder(initialPrologue)
+        val failure = runCatching { handshake.readMessage1(message1) }.exceptionOrNull()
+        assertTrue(
+            "expected an AEAD failure, got $failure",
+            failure is NoiseHandshakeException,
+        )
+        assertEquals(
+            NoiseHandshakeException.Cause.AeadFailure,
+            (failure as NoiseHandshakeException).reason,
+        )
+    }
+
+    @Test
+    fun thePrologueIsTheRawBytesNotItsBase64UrlText() {
+        // A plausible mistake, because `h` is rendered as base64url everywhere
+        // it is logged or carried in a field.
+        val asText = Base64Url.encode(priorHandshakeHash).encodeToByteArray()
+        val handshake = responder(asText)
+        assertTrue(
+            runCatching { handshake.readMessage1(message1) }.exceptionOrNull()
+                is NoiseHandshakeException
+        )
+    }
+
+    @Test
+    fun theNewHandshakeHashDiffersFromThePriorOne() {
+        // It has to, or a chained re-handshake would reuse a prologue and the
+        // second exchange would be replayable against the first.
+        val handshake = responder(priorHandshakeHash)
+        handshake.readMessage1(message1)
+        val transport = handshake.writeMessage2(rehandshakePsk).transport
+        assertFalse(transport.handshakeHash.contentEquals(priorHandshakeHash))
+    }
+
+    @Test
+    fun messageTwoPayloadIsTheLiteralTwoBytes() {
+        // "the empty object as the literal two bytes `{}` (not a zero-length
+        // Noise payload)". The reference read it back as exactly that when the
+        // vectors were generated; this pins our side of it.
+        val handshake = responder(priorHandshakeHash)
+        handshake.readMessage1(message1)
+        val message2 = handshake.writeMessage2(rehandshakePsk)
+        // 32-byte ephemeral public + AEAD(2-byte payload) + 16-byte tag.
+        assertEquals(32 + 2 + 16, message2.message.size)
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/NoiseRehandshakeTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/NoiseRehandshakeTest.kt
@@ -32,7 +32,7 @@ class NoiseRehandshakeTest {
 
     /** `h` from the initial handshake. The re-handshake's prologue, verbatim. */
     private val priorHandshakeHash =
-        hex("aaf129d111ad113e55c9cc23439df0e4e43c8f28d8d5f3d3e3ff3e7775562703")
+        hex("c67193e08139054878140bfcb63e2006de919f0d77951210f76789073f781385")
 
     /** The initial handshake's own prologue - the wrong answer, kept to prove it is wrong. */
     private val initialPrologue = "sendspin-rehandshake-initial-prologue-v1".encodeToByteArray()
@@ -44,15 +44,16 @@ class NoiseRehandshakeTest {
 
     private val message1 = hex(
         "07a37cbc142093c8b755dc1b10e86cb426374ad16aa853ed0bdfc0b2b86d1c7c" +
-            "dd9e7b6b8fa1b6c5c8cc1ef92e141c8bcdc51902ada99e3bfa3a00ef3f639b6c" +
-            "5d2742d4886eee53d808a801bf02d2d8e43292ea8cd04a81535f12ef"
+            "dd9e7b6b8fa1b6c5c8cc1ef96a3059b5cff80039bba7a44cee3f0aba6535fe54" +
+            "5d1152fbbf44c65ed703e61a0705a2d583167bbb654a0593a7006bbcd9da3991" +
+            "3dc53c0cf5c6f0e52a"
     )
     private val expectedMessage2 = hex(
         "79a631eede1bf9c98f12032cdeadd0e7a079398fc786b88cc846ec89af85a51a" +
-            "d16b35924d8f5c152f908a0674cabe689914"
+            "d16bef1e916c9d494334fe0e6769045dda6f"
     )
     private val expectedHandshakeHash =
-        hex("ea0381952fe8a29c171d7ddc01ed80de1d56efa7d8e492d481a9bb41c08e8276")
+        hex("f7965fde8e621d2710bb578620d4a159829d4ad06de77c612fdd04b93a977228")
 
     private fun responder(prologue: ByteArray) = NoiseHandshake(
         suite = NoiseCipherSuite.CHACHA_POLY,
@@ -68,7 +69,7 @@ class NoiseRehandshakeTest {
 
         val payload = handshake.readMessage1(message1)
         assertEquals(
-            """{"psk_id": "rehandshake-psk-id-placeholder"}""",
+            """{"psk_id": "6A-_lYjSwe_Zdvax32HHlWsJ_EDijylfWfnhN1VOsaY"}""",
             payload.decodeToString(),
         )
 

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/ChannelKeySwapTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/ChannelKeySwapTest.kt
@@ -1,0 +1,129 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.crypto.NoiseCrypto
+import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Ordering of the in-band re-handshake key swap.
+ *
+ * `messaging.md#client--server-noisehandshake`: "Noise message 2 is still
+ * encrypted under the pre-re-handshake transport keys; the first frame each
+ * side sends after the handshake completes uses the new keys."
+ *
+ * So there is exactly one frame boundary where the keys change, and it falls
+ * *after* our message 2. Swapping a frame too early makes the server unable to
+ * read the message that completes the handshake; a frame too late makes
+ * everything after it unreadable. Both present as a silent close.
+ *
+ * Real AEAD is covered by NoiseRehandshakeTest against reference vectors. Here
+ * the "crypto" only tags which key was used, because ordering is the thing
+ * under test.
+ */
+class ChannelKeySwapTest {
+
+    /** Tags each frame with the key that encrypted it, and refuses the others. */
+    private class TaggedCrypto(private val tag: Byte) : NoiseCrypto {
+        override fun encrypt(plaintext: ByteArray): ByteArray = byteArrayOf(tag) + plaintext
+
+        override fun decrypt(frame: ByteArray): ByteArray {
+            if (frame.isEmpty() || frame[0] != tag) {
+                throw NoiseHandshakeException(
+                    NoiseHandshakeException.Cause.AeadFailure,
+                    "frame was not encrypted under key $tag",
+                )
+            }
+            return frame.copyOfRange(1, frame.size)
+        }
+    }
+
+    private val oldKey: Byte = 0x11
+    private val newKey: Byte = 0x22
+
+    private fun codec() = NoiseWireCodec(TaggedCrypto(oldKey))
+
+    @Test
+    fun messageTwoGoesOutUnderTheOldKeyAndEverythingAfterUnderTheNew() = runBlocking {
+        val codec = codec()
+
+        // The frame that completes the re-handshake.
+        val message2 = codec.encodeAndSwap(
+            SendSpinProtocol.BinaryType.JSON,
+            """{"type":"noise/handshake"}""".encodeToByteArray(),
+            next = TaggedCrypto(newKey),
+        )
+        assertEquals(1, message2.size)
+        assertEquals("message 2 must use the PRE-swap key", oldKey, message2[0][0])
+
+        // The re-asserted client/hello, the first frame of the new session.
+        val hello = codec.encodeJson("""{"type":"client/hello"}""")
+        assertEquals("the frame after the swap must use the NEW key", newKey, hello[0][0])
+    }
+
+    @Test
+    fun theSwapAlsoChangesTheReceiveDirection() {
+        // "the first frame each side sends after the handshake completes uses
+        // the new keys" - the server's next frame is already under them, so
+        // installing only the send side would break the very next message in.
+        val codec = codec()
+        runBlocking {
+            codec.encodeAndSwap(
+                SendSpinProtocol.BinaryType.JSON, "{}".encodeToByteArray(),
+                next = TaggedCrypto(newKey),
+            )
+        }
+        val underNew = byteArrayOf(newKey, SendSpinProtocol.BinaryType.JSON.toByte()) +
+            """{"type":"server/hello"}""".encodeToByteArray()
+        val decoded = codec.decode(underNew)
+        assertTrue("a peer frame under the new key must decode, got $decoded",
+            decoded is NoiseWireCodec.Decoded.Json)
+    }
+
+    @Test
+    fun aFrameStillUnderTheOldKeyIsRejectedAfterTheSwap() {
+        val codec = codec()
+        runBlocking {
+            codec.encodeAndSwap(
+                SendSpinProtocol.BinaryType.JSON, "{}".encodeToByteArray(),
+                next = TaggedCrypto(newKey),
+            )
+        }
+        val stale = byteArrayOf(oldKey, SendSpinProtocol.BinaryType.JSON.toByte()) + "{}".encodeToByteArray()
+        assertTrue(codec.decode(stale) is NoiseWireCodec.Decoded.ProtocolError)
+    }
+
+    @Test
+    fun noOtherFrameCanInterleaveBetweenMessageTwoAndTheSwap() = runBlocking {
+        // "No other messages flow during the exchange." The swap is only safe if
+        // encrypt-then-install is one critical section: a client/time racing it
+        // could otherwise be encrypted under the old key and arrive after the
+        // server has already moved to the new one.
+        val codec = codec()
+        val emitted = mutableListOf<Byte>()
+
+        val racer = async {
+            repeat(20) { emitted += codec.encodeJson("""{"type":"client/time"}""")[0][0] }
+        }
+        val message2 = codec.encodeAndSwap(
+            SendSpinProtocol.BinaryType.JSON, "{}".encodeToByteArray(),
+            next = TaggedCrypto(newKey),
+        )
+        racer.await()
+
+        assertEquals(oldKey, message2[0][0])
+        // Every racing frame used one key or the other, never a torn state -
+        // and none of them can be the message-2 frame itself.
+        assertTrue(emitted.all { it == oldKey || it == newKey })
+        // Once the new key appears, it must never revert.
+        val firstNew = emitted.indexOfFirst { it == newKey }
+        if (firstNew >= 0) {
+            assertTrue(
+                "keys went backwards after the swap: $emitted",
+                emitted.drop(firstNew).all { it == newKey },
+            )
+        }
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/NoiseWireCodecFragmentationTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/NoiseWireCodecFragmentationTest.kt
@@ -16,8 +16,10 @@ class NoiseWireCodecFragmentationTest {
 
     /** A codec whose encrypt/decrypt are the identity, so plaintext == frame. */
     private fun plaintextCodec() = NoiseWireCodec(
-        decrypt = { it },
-        encrypt = { it },
+        object : com.sendspindroid.sendspin.crypto.NoiseCrypto {
+            override fun encrypt(plaintext: ByteArray) = plaintext
+            override fun decrypt(frame: ByteArray) = frame
+        }
     )
 
     @Test

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/RehandshakeDriverTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/RehandshakeDriverTest.kt
@@ -1,0 +1,149 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.crypto.ClientIdentity
+import com.sendspindroid.sendspin.crypto.NoiseCipherSuite
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PskCandidateSet
+import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.crypto.PskId
+import com.sendspindroid.sendspin.crypto.SentinelPsk
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * The re-handshake as the connection drives it: decode, select, reply.
+ *
+ * Every failure here closes the socket with no application-level message
+ * (`connection.md#failure-handling`), so each one has to be distinguishable in
+ * a log or it is undiagnosable in the field.
+ *
+ * Vectors from `ci/conformance/noise/make_rehandshake_vectors.py`, cross-checked
+ * against `noiseprotocol`.
+ */
+class RehandshakeDriverTest {
+
+    private fun hex(s: String) = ByteArray(s.length / 2) {
+        s.substring(it * 2, it * 2 + 2).toInt(16).toByte()
+    }
+
+    private val clientStatic = hex("606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f")
+    private val serverStaticPublic = hex("358072d6365880d1aeea329adf9121383851ed21a28e3b75e965d0d2cd166254")
+    private val priorH = hex("c67193e08139054878140bfcb63e2006de919f0d77951210f76789073f781385")
+
+    /** The PSK the server is promoting the channel to. */
+    private val newPsk = hex("b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0")
+
+    private val message1B64 = Base64Url.encode(
+        hex(
+            "07a37cbc142093c8b755dc1b10e86cb426374ad16aa853ed0bdfc0b2b86d1c7c" +
+                "dd9e7b6b8fa1b6c5c8cc1ef96a3059b5cff80039bba7a44cee3f0aba6535fe54" +
+                "5d1152fbbf44c65ed703e61a0705a2d583167bbb654a0593a7006bbcd9da3991" +
+                "3dc53c0cf5c6f0e52a"
+        )
+    )
+
+    private val serverId = "NYBy1jZYgNGu6jKa35EhODhR7SGijjt16WXQ0s0WYlQ"
+
+    private fun identity() = ClientIdentity.fromStoredKey(Base64Url.encode(clientStatic))!!
+
+    private fun driver(
+        candidates: List<Psk>,
+        prologue: ByteArray = priorH,
+        withServerId: String = serverId,
+    ) = RehandshakeDriver(
+        identity = identity(),
+        candidates = PskCandidateSet.of(candidates).getOrThrow(),
+        serverId = withServerId,
+        serverStaticKey = serverStaticPublic,
+        suite = NoiseCipherSuite.CHACHA_POLY,
+        priorHandshakeHash = prologue,
+    )
+
+    /** The PSK being promoted to, as an unbound (Pairing-category) candidate. */
+    private fun pairingCandidate() = Psk(newPsk, PskCategory.PAIRING)
+
+    /** The same PSK as a long-term record bound to [boundTo]. */
+    private fun recordCandidate(boundTo: String) =
+        Psk(newPsk, PskCategory.LONG_TERM, boundTo)
+
+    @Test
+    fun aValidRehandshakeProducesASignedReplyAndTheNewTransport() {
+        val outcome = driver(listOf(SentinelPsk.psk, pairingCandidate())).handle(message1B64)
+        assertTrue("expected a Reply, got $outcome", outcome is RehandshakeDriver.Outcome.Reply)
+        outcome as RehandshakeDriver.Outcome.Reply
+
+        assertEquals(PskCategory.PAIRING, outcome.matched.category)
+        assertEquals(PskId.derive(newPsk), outcome.matched.pskId)
+
+        val json = Json.parseToJsonElement(outcome.replyJson).jsonObject
+        assertEquals("noise/handshake", json["type"]?.jsonPrimitive?.contentOrNull)
+        val data = json["payload"]?.jsonObject?.get("data")?.jsonPrimitive?.contentOrNull
+        assertNotNull("reply must carry base64url data", data)
+        // 32-byte ephemeral public + AEAD({}) + 16-byte tag.
+        assertEquals(32 + 2 + 16, Base64Url.decodeOrNull(data!!)!!.size)
+
+        // The promotion target, not the old session.
+        assertFalse(outcome.transport.handshakeHash.contentEquals(priorH))
+    }
+
+    @Test
+    fun promotingToALongTermRecordIsWhatRaisesTrustLevel() {
+        // The pairing case: the record was persisted moments ago and must be
+        // visible to this selection.
+        val outcome = driver(listOf(SentinelPsk.psk, recordCandidate(serverId))).handle(message1B64)
+        assertTrue(outcome is RehandshakeDriver.Outcome.Reply)
+        assertEquals(
+            PskCategory.LONG_TERM,
+            (outcome as RehandshakeDriver.Outcome.Reply).matched.category,
+        )
+    }
+
+    @Test
+    fun aRecordBoundToADifferentServerFails() {
+        val outcome = driver(
+            listOf(SentinelPsk.psk, recordCandidate("some-other-server-id")),
+        ).handle(message1B64)
+        assertTrue(outcome is RehandshakeDriver.Outcome.Fail)
+        assertTrue(
+            "the reason must name the binding, got: ${(outcome as RehandshakeDriver.Outcome.Fail).reason}",
+            outcome.reason.contains("record for"),
+        )
+    }
+
+    @Test
+    fun aPskIdMatchingNothingFails() {
+        val outcome = driver(listOf(SentinelPsk.psk)).handle(message1B64)
+        assertTrue(outcome is RehandshakeDriver.Outcome.Fail)
+        assertTrue((outcome as RehandshakeDriver.Outcome.Fail).reason.contains("matches none"))
+    }
+
+    @Test
+    fun theWrongPrologueFailsBeforeSelectionEverRuns() {
+        // The failure this whole item is exposed to. It surfaces as an AEAD
+        // rejection of message 1, naming nothing about prologues.
+        val outcome = driver(
+            listOf(SentinelPsk.psk, pairingCandidate()),
+            prologue = ByteArray(32),
+        ).handle(message1B64)
+        assertTrue(outcome is RehandshakeDriver.Outcome.Fail)
+        assertTrue(
+            (outcome as RehandshakeDriver.Outcome.Fail).reason.contains("message 1 rejected"),
+        )
+    }
+
+    @Test
+    fun malformedInputFailsRatherThanThrowing() {
+        val candidates = listOf(SentinelPsk.psk, pairingCandidate())
+        assertTrue(driver(candidates).handle(null) is RehandshakeDriver.Outcome.Fail)
+        assertTrue(driver(candidates).handle("not base64!!") is RehandshakeDriver.Outcome.Fail)
+        assertTrue(
+            driver(candidates).handle(Base64Url.encode(ByteArray(4)))
+                is RehandshakeDriver.Outcome.Fail
+        )
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/NoiseCrypto.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/NoiseCrypto.kt
@@ -1,0 +1,27 @@
+package com.sendspindroid.sendspin.crypto
+
+/**
+ * The encrypt/decrypt pair for one Noise session.
+ *
+ * Exists so the wire codec can hold a *replaceable* reference to its crypto.
+ * An in-band re-handshake swaps both directions at a single frame boundary
+ * (`connection.md#re-handshake`), so the codec cannot bind to one
+ * [NoiseTransport] for its lifetime.
+ *
+ * Deliberately narrow: nothing here exposes keys, nonces, or the handshake
+ * hash. The codec's job is framing, and the less of the session it can reach,
+ * the less it can get wrong.
+ */
+interface NoiseCrypto {
+    /** @throws NoiseHandshakeException never - encryption of our own data cannot fail the tag check. */
+    fun encrypt(plaintext: ByteArray): ByteArray
+
+    /** @throws NoiseHandshakeException on an AEAD tag failure, replay, or reorder. */
+    fun decrypt(frame: ByteArray): ByteArray
+}
+
+/** Adapts a completed handshake's transport to the codec's narrow view. */
+fun NoiseTransport.asNoiseCrypto(): NoiseCrypto = object : NoiseCrypto {
+    override fun encrypt(plaintext: ByteArray): ByteArray = this@asNoiseCrypto.encrypt(plaintext)
+    override fun decrypt(frame: ByteArray): ByteArray = this@asNoiseCrypto.decrypt(frame)
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/NoiseWireCodec.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/NoiseWireCodec.kt
@@ -1,6 +1,8 @@
 package com.sendspindroid.sendspin.protocol
 
+import com.sendspindroid.sendspin.crypto.NoiseCrypto
 import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
+import com.sendspindroid.sendspin.crypto.asNoiseCrypto
 import com.sendspindroid.sendspin.crypto.NoiseTransport
 import com.sendspindroid.sendspin.protocol.message.FragmentReassembler
 import com.sendspindroid.sendspin.protocol.message.FragmentWriter
@@ -27,16 +29,21 @@ import kotlinx.coroutines.sync.withLock
  * This is the only place that byte is added or stripped. Fragmentation (item
  * 1.5) plugs in here too, which is why [encodeJson] and [encode] return a list.
  */
-class NoiseWireCodec internal constructor(
-    private val decrypt: (ByteArray) -> ByteArray,
-    private val encrypt: (ByteArray) -> ByteArray,
+class NoiseWireCodec(
+    crypto: NoiseCrypto,
     private val reassembler: FragmentReassembler = FragmentReassembler(),
 ) {
 
-    constructor(transport: NoiseTransport) : this(
-        decrypt = { transport.decrypt(it) },
-        encrypt = { transport.encrypt(it) },
-    )
+    constructor(transport: NoiseTransport) : this(transport.asNoiseCrypto())
+
+    /**
+     * Replaced wholesale by an in-band re-handshake, never mutated in place.
+     *
+     * Volatile because the receive path reads it from the socket thread while
+     * [encodeAndSwap] installs a new one from a coroutine.
+     */
+    @Volatile
+    private var crypto: NoiseCrypto = crypto
 
     /**
      * Serialises sends.
@@ -67,7 +74,42 @@ class NoiseWireCodec internal constructor(
         // direction" - a second sender interleaving here would corrupt both
         // messages and desynchronise the peer's reassembly buffer.
         val plaintexts = FragmentWriter.frames(type, payload)
-        return sendMutex.withLock { plaintexts.map { encrypt(it) } }
+        return sendMutex.withLock { plaintexts.map { crypto.encrypt(it) } }
+    }
+
+    /**
+     * Encrypt one message under the CURRENT keys, then install [next].
+     *
+     * This is the frame boundary of an in-band re-handshake. "Noise message 2
+     * is still encrypted under the pre-re-handshake transport keys; the first
+     * frame each side sends after the handshake completes uses the new keys."
+     *
+     * Encrypting and swapping are one critical section on purpose. Doing them
+     * as two calls would let another producer - the `client/time` burst loop is
+     * the realistic one - slip a frame in between, encrypted under the old keys
+     * but arriving after the peer has moved to the new ones. That frame fails
+     * the peer's tag check, and the spec's answer to an AEAD failure in
+     * transport mode is to close the socket without saying why.
+     *
+     * The receive direction swaps here too: the peer's next frame is already
+     * under the new keys.
+     */
+    suspend fun encodeAndSwap(
+        type: Int,
+        payload: ByteArray,
+        next: NoiseCrypto,
+    ): List<ByteArray> {
+        require(type in 0..255) { "binary message type is a uint8, got $type" }
+        val plaintexts = FragmentWriter.frames(type, payload)
+        return sendMutex.withLock {
+            val frames = plaintexts.map { crypto.encrypt(it) }
+            crypto = next
+            // A half-reassembled inbound message cannot survive a key change:
+            // its remaining fragments would arrive under keys that no longer
+            // decrypt into the same stream.
+            reassembler.reset()
+            frames
+        }
     }
 
     /**
@@ -86,7 +128,7 @@ class NoiseWireCodec internal constructor(
             )
         }
         val plaintext = try {
-            decrypt(frameBytes)
+            crypto.decrypt(frameBytes)
         } catch (e: NoiseHandshakeException) {
             // Includes a replayed or reordered frame: the per-direction counter
             // means a repeat fails the tag check rather than decrypting twice.

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/RehandshakeDriver.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/RehandshakeDriver.kt
@@ -1,0 +1,130 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.crypto.ClientIdentity
+import com.sendspindroid.sendspin.crypto.NoiseCipherSuite
+import com.sendspindroid.sendspin.crypto.NoiseHandshake
+import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
+import com.sendspindroid.sendspin.crypto.NoiseTransport
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PskCandidateSet
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * Drives one in-band re-handshake.
+ *
+ * `connection.md#re-handshake`: "The server may rerun the Noise handshake in
+ * transport mode to swap session keys without closing the WebSocket - typically
+ * to promote the trust level after a successful pairing, to switch from
+ * Sentinel to a Pairing PSK, or to rotate session keys on long-running
+ * connections."
+ *
+ * Lives in `shared` rather than the app for a specific reason: the private half
+ * of [ClientIdentity] is `internal` to this module, so a responder can only be
+ * constructed here. The app hands over the session facts and gets back either a
+ * ready-to-send reply or a reason to close.
+ *
+ * Stateless and single-use. A chained re-handshake constructs a new one with
+ * the previous outcome's `h`.
+ *
+ * @param priorHandshakeHash the prologue: the RAW 32 bytes of the previous
+ *   handshake's `h`. Not its base64url text, and not the initial handshake's
+ *   concatenated init bytes. A wrong value here fails [handle] at an AEAD tag
+ *   check that names nothing - see `NoiseRehandshakeTest`.
+ */
+class RehandshakeDriver(
+    private val identity: ClientIdentity,
+    private val candidates: PskCandidateSet,
+    private val serverId: String,
+    private val serverStaticKey: ByteArray,
+    private val suite: NoiseCipherSuite,
+    private val priorHandshakeHash: ByteArray,
+) {
+
+    sealed interface Outcome {
+        /**
+         * Send [replyJson] under the CURRENT keys, then promote the channel to
+         * [transport]. The order is not negotiable: "Noise message 2 is still
+         * encrypted under the pre-re-handshake transport keys."
+         */
+        data class Reply(
+            val replyJson: String,
+            val transport: NoiseTransport,
+            val matched: Psk,
+        ) : Outcome
+
+        /** Close the socket. The spec allows no application-level error message. */
+        data class Fail(val reason: String) : Outcome
+    }
+
+    /**
+     * @param data the base64url `data` field of the inbound `noise/handshake`
+     */
+    fun handle(data: String?): Outcome {
+        if (data == null) return Outcome.Fail("noise/handshake payload has no data field")
+        val message1 = Base64Url.decodeOrNull(data)
+            ?: return Outcome.Fail("noise/handshake data is not base64url")
+
+        val handshake = NoiseHandshake.responder(
+            staticPrivateKey = identity.privateKeyBytes(),
+            remoteStaticPublicKey = serverStaticKey,
+            suite = suite,
+            prologue = priorHandshakeHash,
+        )
+
+        val innerPayload = try {
+            handshake.readMessage1(message1)
+        } catch (e: NoiseHandshakeException) {
+            // Overwhelmingly the prologue if it is not a genuine attack: the
+            // ephemeral public key at the front decrypts fine either way, so
+            // the first thing that notices is this tag check.
+            return Outcome.Fail("re-handshake message 1 rejected: ${e.reason}")
+        }
+
+        val pskId = parsePskId(innerPayload)
+            ?: return Outcome.Fail("re-handshake message 1 payload is not {\"psk_id\": ...}")
+
+        // Selected against the candidate set as it is NOW. A record persisted
+        // moments ago by a pairing has to be visible to this very selection -
+        // promoting to it is the reason the server started this exchange.
+        val matched = when (val selection = candidates.select(pskId, serverId)) {
+            is PskCandidateSet.Selection.Matched -> selection.candidate
+
+            PskCandidateSet.Selection.NoMatch -> return Outcome.Fail(
+                "re-handshake psk_id $pskId matches none of the " +
+                    "${candidates.all.size} candidates"
+            )
+
+            is PskCandidateSet.Selection.ServerIdMismatch -> return Outcome.Fail(
+                "re-handshake psk_id $pskId is a record for ${selection.expected}, " +
+                    "but this session is with ${selection.actual}"
+            )
+        }
+
+        val message2 = try {
+            handshake.writeMessage2(matched.bytes)
+        } catch (e: NoiseHandshakeException) {
+            return Outcome.Fail("re-handshake message 2 failed: ${e.reason}")
+        }
+
+        val reply = buildJsonObject {
+            put("type", JsonPrimitive(SendSpinProtocol.MessageType.NOISE_HANDSHAKE))
+            put("payload", buildJsonObject {
+                put("data", JsonPrimitive(Base64Url.encode(message2.message)))
+            })
+        }.toString()
+
+        return Outcome.Reply(reply, message2.transport, matched)
+    }
+
+    private fun parsePskId(payload: ByteArray): String? = runCatching {
+        Json.parseToJsonElement(payload.decodeToString())
+            .jsonObject["psk_id"]?.jsonPrimitive?.contentOrNull
+    }.getOrNull()
+}

--- a/ci/conformance/noise/make_rehandshake_vectors.py
+++ b/ci/conformance/noise/make_rehandshake_vectors.py
@@ -1,0 +1,191 @@
+"""Generate golden vectors for the in-band re-handshake (item 2.6, #223).
+
+`connection.md#re-handshake`: "`client/init` and `server/init` are not re-sent -
+`client_id`, `server_id`, and `suite` carry over. The new handshake's prologue
+is the prior handshake's hash `h`."
+
+That one sentence is the whole risk. A re-handshake that used the *initial*
+prologue, or the base64url text of `h` rather than its raw 32 bytes, fails at
+message-1 decryption with an AEAD error several steps removed from the cause -
+and the spec's response to any handshake failure is a silent socket close. So
+the vector this produces exists to be asserted against, and the negative cases
+matter as much as the positive one.
+
+Both sides are the reference implementation (`noiseprotocol`, which aiosendspin
+9.1.0 depends on). The Kotlin responder is the consumer of these vectors, not a
+participant in generating them.
+
+Writes ci/conformance/noise/rehandshake-vectors.json only if every check passes.
+"""
+
+import json
+from pathlib import Path
+
+from noise.connection import Keypair, NoiseConnection
+
+HERE = Path(__file__).parent
+PROTO = b"Noise_KKpsk2_25519_ChaChaPoly_SHA256"
+
+# The initial handshake's prologue. Its only role here is to produce a realistic
+# prior `h`; the re-handshake must NOT reuse it.
+INITIAL_PROLOGUE = b"sendspin-rehandshake-initial-prologue-v1"
+
+SERVER_STATIC = bytes(range(0x20, 0x40))
+CLIENT_STATIC = bytes(range(0x60, 0x80))
+
+# Handshake 1 ephemerals.
+SERVER_EPHEMERAL_1 = bytes(range(0x80, 0xA0))
+CLIENT_EPHEMERAL_1 = bytes(range(0xC0, 0xE0))
+
+# Handshake 2 (the re-handshake) ephemerals - distinct, so a vector that
+# accidentally replays handshake 1 is obvious.
+SERVER_EPHEMERAL_2 = bytes(range(0x01, 0x21))
+CLIENT_EPHEMERAL_2 = bytes(range(0x40, 0x60))
+
+# The Sentinel-ish PSK for handshake 1, and the "newly delivered long_term_psk"
+# the re-handshake promotes to. Different values, because promoting the trust
+# level is the whole point of the exchange.
+PSK_1 = bytes(range(0xA0, 0xC0))
+PSK_2 = bytes([(b + 0x11) & 0xFF for b in range(0xA0, 0xC0)])
+
+MSG1_PAYLOAD_1 = json.dumps({"psk_id": "initial-psk-id-placeholder"}).encode()
+MSG1_PAYLOAD_2 = json.dumps({"psk_id": "rehandshake-psk-id-placeholder"}).encode()
+MSG2_PAYLOAD = b"{}"
+
+
+def x25519_pub(private: bytes) -> bytes:
+    from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    return X25519PrivateKey.from_private_bytes(private).public_key().public_bytes(
+        Encoding.Raw, PublicFormat.Raw)
+
+
+def build(role: str, prologue: bytes, psk: bytes, ephemeral: bytes) -> NoiseConnection:
+    """The server is the initiator in both the initial handshake and the re-handshake."""
+    n = NoiseConnection.from_name(PROTO)
+    if role == "server":
+        n.set_as_initiator()
+        n.set_keypair_from_private_bytes(Keypair.STATIC, SERVER_STATIC)
+        n.set_keypair_from_public_bytes(Keypair.REMOTE_STATIC, x25519_pub(CLIENT_STATIC))
+    else:
+        n.set_as_responder()
+        n.set_keypair_from_private_bytes(Keypair.STATIC, CLIENT_STATIC)
+        n.set_keypair_from_public_bytes(Keypair.REMOTE_STATIC, x25519_pub(SERVER_STATIC))
+    n.set_prologue(prologue)
+    n.set_keypair_from_private_bytes(Keypair.EPHEMERAL, ephemeral)
+    n.set_psks(psk)
+    n.start_handshake()
+    return n
+
+
+def run(prologue: bytes, psk: bytes, se: bytes, ce: bytes, msg1_payload: bytes) -> dict:
+    """One complete KKpsk2 exchange. Returns the wire bytes and resulting state."""
+    server = build("server", prologue, psk, se)
+    client = build("client", prologue, psk, ce)
+
+    msg1 = server.write_message(msg1_payload)
+    got_payload1 = client.read_message(msg1)
+    assert got_payload1 == msg1_payload, "message 1 payload round trip"
+
+    msg2 = client.write_message(MSG2_PAYLOAD)
+    got_payload2 = server.read_message(msg2)
+    assert got_payload2 == MSG2_PAYLOAD, "message 2 payload must be the literal {}"
+
+    assert client.handshake_finished and server.handshake_finished
+    assert client.get_handshake_hash() == server.get_handshake_hash(), "h must agree"
+
+    return {
+        "prologue": prologue.hex(),
+        "psk": psk.hex(),
+        "server_ephemeral_private": se.hex(),
+        "client_ephemeral_private": ce.hex(),
+        "message_1": msg1.hex(),
+        "message_1_payload": msg1_payload.decode(),
+        "message_2": msg2.hex(),
+        "handshake_hash": client.get_handshake_hash().hex(),
+    }
+
+
+def main() -> int:
+    # Handshake 1: an ordinary session. Its `h` becomes the next prologue.
+    first = run(INITIAL_PROLOGUE, PSK_1, SERVER_EPHEMERAL_1, CLIENT_EPHEMERAL_1, MSG1_PAYLOAD_1)
+    prior_h = bytes.fromhex(first["handshake_hash"])
+    assert len(prior_h) == 32, "h is a 32-byte SHA-256 output"
+
+    # Handshake 2: prologue is the RAW 32 bytes of the prior h.
+    second = run(prior_h, PSK_2, SERVER_EPHEMERAL_2, CLIENT_EPHEMERAL_2, MSG1_PAYLOAD_2)
+
+    # The chained case: a third handshake's prologue is the second's h, proving
+    # the rule composes rather than being special-cased to "the first one".
+    third = run(
+        bytes.fromhex(second["handshake_hash"]), PSK_2,
+        SERVER_EPHEMERAL_1, CLIENT_EPHEMERAL_1, MSG1_PAYLOAD_2,
+    )
+
+    checks = [
+        ("re-handshake h differs from the prior h",
+         second["handshake_hash"] != first["handshake_hash"], True),
+        ("chained h differs again",
+         third["handshake_hash"] != second["handshake_hash"], True),
+        ("re-handshake message 1 differs from the initial one",
+         second["message_1"] != first["message_1"], True),
+    ]
+
+    # The negative case, and the reason this file exists: the same inputs with
+    # the INITIAL prologue must fail. If this ever passes, the prologue is not
+    # actually binding the two handshakes together.
+    try:
+        run(INITIAL_PROLOGUE, PSK_2, SERVER_EPHEMERAL_2, CLIENT_EPHEMERAL_2, MSG1_PAYLOAD_2)
+        wrong_prologue_h = None
+    except Exception:
+        wrong_prologue_h = "failed-as-expected"
+    # Both sides used the same wrong prologue, so they still agree with each
+    # other - the point is that the resulting h is NOT the re-handshake's h,
+    # so a client using the wrong prologue cannot produce the recorded message 2.
+    mismatched = run(
+        INITIAL_PROLOGUE, PSK_2, SERVER_EPHEMERAL_2, CLIENT_EPHEMERAL_2, MSG1_PAYLOAD_2,
+    )
+    checks.append((
+        "the initial prologue yields a different message 2 than prior-h does",
+        mismatched["message_2"] != second["message_2"], True,
+    ))
+    checks.append((
+        "the initial prologue yields a different h than prior-h does",
+        mismatched["handshake_hash"] != second["handshake_hash"], True,
+    ))
+
+    failed = [(name, got, want) for name, got, want in checks if got != want]
+    for name, got, want in checks:
+        print(f"{'ok  ' if (name, got, want) not in failed else 'FAIL'}  {name}")
+    if failed:
+        return 1
+
+    out = {
+        "_generated_by": "make_rehandshake_vectors.py",
+        "_note": (
+            "The re-handshake's prologue is the RAW 32 bytes of the prior "
+            "handshake's h - not its base64url text, and not the initial "
+            "handshake's prologue. wrong_prologue_* record what the wrong "
+            "choice produces, so a test can assert we do not produce it."
+        ),
+        "protocol": PROTO.decode(),
+        "server_static_private": SERVER_STATIC.hex(),
+        "server_static_public": x25519_pub(SERVER_STATIC).hex(),
+        "client_static_private": CLIENT_STATIC.hex(),
+        "client_static_public": x25519_pub(CLIENT_STATIC).hex(),
+        "initial": first,
+        "rehandshake": second,
+        "chained": third,
+        "wrong_prologue_message_2": mismatched["message_2"],
+        "wrong_prologue_handshake_hash": mismatched["handshake_hash"],
+    }
+    path = HERE / "rehandshake-vectors.json"
+    path.write_text(json.dumps(out, indent=2) + "\n")
+    print(f"\nwrote {path}")
+    print(f"  prior h      : {first['handshake_hash'][:16]}...")
+    print(f"  re-handshake h: {second['handshake_hash'][:16]}...")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/conformance/noise/make_rehandshake_vectors.py
+++ b/ci/conformance/noise/make_rehandshake_vectors.py
@@ -48,8 +48,21 @@ CLIENT_EPHEMERAL_2 = bytes(range(0x40, 0x60))
 PSK_1 = bytes(range(0xA0, 0xC0))
 PSK_2 = bytes([(b + 0x11) & 0xFF for b in range(0xA0, 0xC0)])
 
-MSG1_PAYLOAD_1 = json.dumps({"psk_id": "initial-psk-id-placeholder"}).encode()
-MSG1_PAYLOAD_2 = json.dumps({"psk_id": "rehandshake-psk-id-placeholder"}).encode()
+
+
+def psk_id(psk: bytes) -> str:
+    """base64url(SHA-256("sendspin-psk-id-v1" || PSK)), unpadded - connection.md."""
+    import base64
+    import hashlib
+    digest = hashlib.sha256(b"sendspin-psk-id-v1" + psk).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+# Real derived ids, not placeholders: the client selects its PSK by matching
+# this value, so a placeholder would make the vector unusable for any test that
+# exercises selection.
+MSG1_PAYLOAD_1 = json.dumps({"psk_id": psk_id(PSK_1)}).encode()
+MSG1_PAYLOAD_2 = json.dumps({"psk_id": psk_id(PSK_2)}).encode()
 MSG2_PAYLOAD = b"{}"
 
 

--- a/ci/conformance/noise/rehandshake-vectors.json
+++ b/ci/conformance/noise/rehandshake-vectors.json
@@ -1,0 +1,41 @@
+{
+  "_generated_by": "make_rehandshake_vectors.py",
+  "_note": "The re-handshake's prologue is the RAW 32 bytes of the prior handshake's h - not its base64url text, and not the initial handshake's prologue. wrong_prologue_* record what the wrong choice produces, so a test can assert we do not produce it.",
+  "protocol": "Noise_KKpsk2_25519_ChaChaPoly_SHA256",
+  "server_static_private": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+  "server_static_public": "358072d6365880d1aeea329adf9121383851ed21a28e3b75e965d0d2cd166254",
+  "client_static_private": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+  "client_static_public": "675dd574ed7789310b3d2e7681f3790b466c773b1521fecf36577958371ea52f",
+  "initial": {
+    "prologue": "73656e647370696e2d726568616e647368616b652d696e697469616c2d70726f6c6f6775652d7631",
+    "psk": "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf",
+    "server_ephemeral_private": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+    "client_ephemeral_private": "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
+    "message_1": "493e82fc74464a59268817623d2053c5eb8e2cc4a988b4fee179ec6b010d531dcdf8933800968c0ab0d21481ec022eba379a9f2f0cc31b1fe8d04c6a271e93c1a0c49f2aaa345fe39110be3091c224996d6aafa634cf737e",
+    "message_1_payload": "{\"psk_id\": \"initial-psk-id-placeholder\"}",
+    "message_2": "dc2cca31e8e43bbd91dff7e475cca3347eb478107d5bd765aba4ae4a30c35d44a0aee93892e77347c0a654fd0ad11e2a0e39",
+    "handshake_hash": "aaf129d111ad113e55c9cc23439df0e4e43c8f28d8d5f3d3e3ff3e7775562703"
+  },
+  "rehandshake": {
+    "prologue": "aaf129d111ad113e55c9cc23439df0e4e43c8f28d8d5f3d3e3ff3e7775562703",
+    "psk": "b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0",
+    "server_ephemeral_private": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+    "client_ephemeral_private": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+    "message_1": "07a37cbc142093c8b755dc1b10e86cb426374ad16aa853ed0bdfc0b2b86d1c7cdd9e7b6b8fa1b6c5c8cc1ef92e141c8bcdc51902ada99e3bfa3a00ef3f639b6c5d2742d4886eee53d808a801bf02d2d8e43292ea8cd04a81535f12ef",
+    "message_1_payload": "{\"psk_id\": \"rehandshake-psk-id-placeholder\"}",
+    "message_2": "79a631eede1bf9c98f12032cdeadd0e7a079398fc786b88cc846ec89af85a51ad16b35924d8f5c152f908a0674cabe689914",
+    "handshake_hash": "ea0381952fe8a29c171d7ddc01ed80de1d56efa7d8e492d481a9bb41c08e8276"
+  },
+  "chained": {
+    "prologue": "ea0381952fe8a29c171d7ddc01ed80de1d56efa7d8e492d481a9bb41c08e8276",
+    "psk": "b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0",
+    "server_ephemeral_private": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+    "client_ephemeral_private": "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
+    "message_1": "493e82fc74464a59268817623d2053c5eb8e2cc4a988b4fee179ec6b010d531dcdf8933800968c0ab0d21481f7092faf309f806a1ddb151ff1c70a37221bddd4a4ca902ba72911fa16ad27581ce81d595b6016bf8e1eb980b4b49ab0",
+    "message_1_payload": "{\"psk_id\": \"rehandshake-psk-id-placeholder\"}",
+    "message_2": "dc2cca31e8e43bbd91dff7e475cca3347eb478107d5bd765aba4ae4a30c35d442db1bbb1315ab29142953f5d749f1d41305c",
+    "handshake_hash": "5a0d1d4c3ffbee49e7bcb0cc8e8a2d86ebb76ac173ecdb23df5de7559c03bbfc"
+  },
+  "wrong_prologue_message_2": "79a631eede1bf9c98f12032cdeadd0e7a079398fc786b88cc846ec89af85a51ad16bb3425a8211e48aab85415043b891e3ef",
+  "wrong_prologue_handshake_hash": "5cd44ea0b5ec9850b4b3b518f0c9e9547f040085e273eaa4dc2cb72bb889b540"
+}

--- a/ci/conformance/noise/rehandshake-vectors.json
+++ b/ci/conformance/noise/rehandshake-vectors.json
@@ -11,31 +11,31 @@
     "psk": "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf",
     "server_ephemeral_private": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
     "client_ephemeral_private": "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
-    "message_1": "493e82fc74464a59268817623d2053c5eb8e2cc4a988b4fee179ec6b010d531dcdf8933800968c0ab0d21481ec022eba379a9f2f0cc31b1fe8d04c6a271e93c1a0c49f2aaa345fe39110be3091c224996d6aafa634cf737e",
-    "message_1_payload": "{\"psk_id\": \"initial-psk-id-placeholder\"}",
-    "message_2": "dc2cca31e8e43bbd91dff7e475cca3347eb478107d5bd765aba4ae4a30c35d44a0aee93892e77347c0a654fd0ad11e2a0e39",
-    "handshake_hash": "aaf129d111ad113e55c9cc23439df0e4e43c8f28d8d5f3d3e3ff3e7775562703"
+    "message_1": "493e82fc74464a59268817623d2053c5eb8e2cc4a988b4fee179ec6b010d531dcdf8933800968c0ab0d21481d00d1f970a9c9c5d33853e73b282525c0f20a7ee8fdcb2019d201fdf1fbb344d8694c3323af1433ca494daf07d94472ef646bd76d3407a7b55b842915f",
+    "message_1_payload": "{\"psk_id\": \"UaXYTgo_O5NA363FD_WJGwAORfbAld1hDE9vHMOWFSg\"}",
+    "message_2": "dc2cca31e8e43bbd91dff7e475cca3347eb478107d5bd765aba4ae4a30c35d44a0aed8677b63bc1b1340cfb56c31eebaebfc",
+    "handshake_hash": "c67193e08139054878140bfcb63e2006de919f0d77951210f76789073f781385"
   },
   "rehandshake": {
-    "prologue": "aaf129d111ad113e55c9cc23439df0e4e43c8f28d8d5f3d3e3ff3e7775562703",
+    "prologue": "c67193e08139054878140bfcb63e2006de919f0d77951210f76789073f781385",
     "psk": "b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0",
     "server_ephemeral_private": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
     "client_ephemeral_private": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
-    "message_1": "07a37cbc142093c8b755dc1b10e86cb426374ad16aa853ed0bdfc0b2b86d1c7cdd9e7b6b8fa1b6c5c8cc1ef92e141c8bcdc51902ada99e3bfa3a00ef3f639b6c5d2742d4886eee53d808a801bf02d2d8e43292ea8cd04a81535f12ef",
-    "message_1_payload": "{\"psk_id\": \"rehandshake-psk-id-placeholder\"}",
-    "message_2": "79a631eede1bf9c98f12032cdeadd0e7a079398fc786b88cc846ec89af85a51ad16b35924d8f5c152f908a0674cabe689914",
-    "handshake_hash": "ea0381952fe8a29c171d7ddc01ed80de1d56efa7d8e492d481a9bb41c08e8276"
+    "message_1": "07a37cbc142093c8b755dc1b10e86cb426374ad16aa853ed0bdfc0b2b86d1c7cdd9e7b6b8fa1b6c5c8cc1ef96a3059b5cff80039bba7a44cee3f0aba6535fe545d1152fbbf44c65ed703e61a0705a2d583167bbb654a0593a7006bbcd9da39913dc53c0cf5c6f0e52a",
+    "message_1_payload": "{\"psk_id\": \"6A-_lYjSwe_Zdvax32HHlWsJ_EDijylfWfnhN1VOsaY\"}",
+    "message_2": "79a631eede1bf9c98f12032cdeadd0e7a079398fc786b88cc846ec89af85a51ad16bef1e916c9d494334fe0e6769045dda6f",
+    "handshake_hash": "f7965fde8e621d2710bb578620d4a159829d4ad06de77c612fdd04b93a977228"
   },
   "chained": {
-    "prologue": "ea0381952fe8a29c171d7ddc01ed80de1d56efa7d8e492d481a9bb41c08e8276",
+    "prologue": "f7965fde8e621d2710bb578620d4a159829d4ad06de77c612fdd04b93a977228",
     "psk": "b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0",
     "server_ephemeral_private": "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
     "client_ephemeral_private": "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf",
-    "message_1": "493e82fc74464a59268817623d2053c5eb8e2cc4a988b4fee179ec6b010d531dcdf8933800968c0ab0d21481f7092faf309f806a1ddb151ff1c70a37221bddd4a4ca902ba72911fa16ad27581ce81d595b6016bf8e1eb980b4b49ab0",
-    "message_1_payload": "{\"psk_id\": \"rehandshake-psk-id-placeholder\"}",
-    "message_2": "dc2cca31e8e43bbd91dff7e475cca3347eb478107d5bd765aba4ae4a30c35d442db1bbb1315ab29142953f5d749f1d41305c",
-    "handshake_hash": "5a0d1d4c3ffbee49e7bcb0cc8e8a2d86ebb76ac173ecdb23df5de7559c03bbfc"
+    "message_1": "493e82fc74464a59268817623d2053c5eb8e2cc4a988b4fee179ec6b010d531dcdf8933800968c0ab0d21481b32d6a9132a299510bd52f68e5c20062784db8eca4fc8004900339f719a6694395b7942c3c8d5a2491a6e4f07d2353958d36092934bee7ade6fe8778dc",
+    "message_1_payload": "{\"psk_id\": \"6A-_lYjSwe_Zdvax32HHlWsJ_EDijylfWfnhN1VOsaY\"}",
+    "message_2": "dc2cca31e8e43bbd91dff7e475cca3347eb478107d5bd765aba4ae4a30c35d442db1d8b8206516b3ae61055a20e865e45510",
+    "handshake_hash": "5d28d229f2da99513fe10f605f69c2a36faea68305f940466a8489c05be7884c"
   },
-  "wrong_prologue_message_2": "79a631eede1bf9c98f12032cdeadd0e7a079398fc786b88cc846ec89af85a51ad16bb3425a8211e48aab85415043b891e3ef",
-  "wrong_prologue_handshake_hash": "5cd44ea0b5ec9850b4b3b518f0c9e9547f040085e273eaa4dc2cb72bb889b540"
+  "wrong_prologue_message_2": "79a631eede1bf9c98f12032cdeadd0e7a079398fc786b88cc846ec89af85a51ad16be829ab7c90db555bacabeb2ebb86060d",
+  "wrong_prologue_handshake_hash": "8b2a98a75f313ab2a39cb10ad6375fe612f72c68e01f31167c960289a460302f"
 }


### PR DESCRIPTION
The server reruns the Noise handshake in transport mode to promote a channel after pairing, or to switch a Sentinel-keyed connection to the Pairing PSK before offering `pairing_psk`. Without it the socket stalls after pairing and the client never reaches `trust_level: user`.

Refs #223. Three commits, 19 tests.

## Risk first: the prologue rule (`a5b0951`)

The item rests on one sentence: *"The new handshake's prologue is the prior handshake's hash `h`."* I proved that against the reference before building anything on it.

`make_rehandshake_vectors.py` runs two full KKpsk2 exchanges through `noiseprotocol` (what aiosendspin 9.1.0 depends on), plus a third chained off the second, and refuses to write unless every cross-check passes - including that the wrong prologue produces a different message 2 and a different `h`.

**The finding that justifies the vector:** the wrong-prologue message 2 shares its first 32 bytes with the correct one, because those are the ephemeral public key. Divergence begins only inside the AEAD ciphertext. Same length, same structure, nothing to notice in a hex dump - and the spec's answer to the resulting failure is a silent close. This is not eyeballable.

Our Kotlin reproduces the reference message 2 byte for byte and the new `h`. Three negatives: the initial prologue fails with `AeadFailure`, the base64url *text* of `h` fails, and the new `h` differs from the prior one.

## The key swap (`d957529`)

The keys change at exactly one frame boundary, and it falls *after* our message 2: "Noise message 2 is still encrypted under the pre-re-handshake transport keys; the first frame each side sends after the handshake completes uses the new keys."

`encodeAndSwap` encrypts under the current keys and installs the next ones inside a single hold of the send mutex. Two calls would look correct in every single-threaded test and fail under load - one frame encrypted under the old keys, arriving after the peer moved on, AEAD failure, silent close. A test races twenty `client/time` sends against a swap and asserts the key sequence never goes backwards.

Receive swaps at the same instant (the peer's next frame is already under the new keys), and fragment reassembly is reset, since a half-reassembled message cannot survive a key change.

## Driving it (`770e5ad`)

`RehandshakeDriver` lives in `shared` because `ClientIdentity.privateKeyBytes()` is `internal` to that module - a responder can only be constructed there. **That access modifier shaped the design, and for the better:** the app hands over session facts and gets back a reply or a reason to close, never touching key material, and the driver became independently testable.

`SessionFacts` retains `server_id`, the server static key, the suite and `h`, because none of it is re-sent and there is no second chance to read it. `h` advances on every promotion, so a chained re-handshake works.

Selection runs against candidates rebuilt at that moment, not a connect-time snapshot: a record persisted seconds earlier by a pairing must be visible to this very selection.

After the swap the channel is *promoted, not replaced*. `resetForRehandshake` clears only the message sequence; transport, group membership and the time filter survive untouched, so audio does not stop. The next `server/activate` is treated as a first activation, so a server omitting `active_roles` clears them rather than inheriting roles granted at a lower trust level.

## Deviations from the plan in #223

- **No `SendSpinChannel`.** `NoiseWireCodec` was already the only place that sees plaintexts and already owned the send mutex; phase and key swap went there rather than creating a second owner.
- **No `ChannelPhase` enum.** The phase is implied by `sessionFacts == null`, and `onRehandshakeMessage` rejects when it is. An enum would be a second representation of the same fact.
- **`NoiseCrypto` replaced the encrypt/decrypt function-ref seam** added for the fragmentation tests, so there is one way to substitute crypto instead of two.

## Deliberately NOT included

Stating these plainly rather than letting the PR read as complete:

- **Outbound gating during the exchange** (plan step 7). The exchange is synchronous within one dispatch today, so there is no window where another producer can interleave - but the gate is not built, and it will matter when `client/time` runs concurrently.
- **The 30-second timeout** (step 9). Nothing currently awaits across a suspension point, so there is no stall to guard, but the timer does not exist.
- **`DiagnosticSnapshot` counters** (step 10).

## Verification

19 tests. 722 app tests and the shared suite pass.

On device against a live Music Assistant: handshake completes on `SENTINEL`, `server/activate` accepted with all four roles, `trust_level: none`, clock sync converging, **zero re-handshake failures and zero candidate-set failures**.

That is a negative result by design - an unpaired Sentinel session gives the server no reason to re-handshake. It confirms the new dispatch path does not perturb the ordinary connection. Exercising a real promotion needs #206 to complete a pairing, which is the next item and the one this unblocks.
