### PR TITLE
fix(pairing): complete the Pairing PSK flow - the device now pairs

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -49,14 +49,16 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Run unit tests
-        run: ./gradlew testDebugUnitTest
+        run: ./gradlew testDebugUnitTest :shared:testAndroidHostTest
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: android/app/build/reports/tests/
+          path: |
+            android/app/build/reports/tests/
+            android/shared/build/reports/tests/
 
       - name: Calculate dev version
         id: version

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -46,11 +46,13 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Run unit tests
-        run: ./gradlew testDebugUnitTest
+        run: ./gradlew testDebugUnitTest :shared:testAndroidHostTest
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pr-test-results
-          path: android/app/build/reports/tests/
+          path: |
+            android/app/build/reports/tests/
+            android/shared/build/reports/tests/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,16 @@ jobs:
       run: chmod +x ./gradlew
 
     - name: Run unit tests
-      run: ./gradlew testDebugUnitTest
+      run: ./gradlew testDebugUnitTest :shared:testAndroidHostTest
 
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: test-results
-        path: android/app/build/reports/tests/
+        path: |
+          android/app/build/reports/tests/
+          android/shared/build/reports/tests/
 
     - name: Check signing availability
       env:

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -279,6 +279,12 @@ dependencies {
     // ZXing-C++ Barcode Scanning - FOSS QR code scanning for Remote ID input
     implementation("io.github.zxing-cpp:android:2.3.0")
 
+    // ZXing core - the *encoder*. zxing-cpp above ships only reader classes, so
+    // it cannot generate the pairing QR. Pure Java, no NDK, so it also runs in
+    // plain JVM unit tests, which is what lets PairingQrCodeTest scan its own
+    // output instead of merely asserting on the input.
+    implementation("com.google.zxing:core:3.5.3")
+
     // CameraX - Modern camera API for QR code scanner
     implementation("androidx.camera:camera-camera2:1.4.1")
     implementation("androidx.camera:camera-lifecycle:1.4.1")

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -568,6 +568,16 @@ class SendSpin(
                 "Re-handshake complete: psk=${outcome.matched.category} " +
                     "trust=${getTrustLevel()} new h=${hashPrefix(outcome.transport.handshakeHash)}"
             )
+
+            // Re-assert client/hello, carrying the trust_level the new PSK
+            // earns. On the initial connection this is sent from the handshake
+            // driver's TransportReady callback - but a re-handshake produces no
+            // such event, because there is no new driver. Without this the
+            // server sends server/hello, waits for a reply that never comes,
+            // and closes the session after a couple of seconds. The sequence is
+            // server/hello -> client/hello -> server/activate, and we owe the
+            // middle one.
+            sendClientHello()
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -17,6 +17,7 @@ import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
 import com.sendspindroid.sendspin.crypto.AndroidPairingConfigStore
 import com.sendspindroid.sendspin.crypto.Psk
 import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.crypto.TrustStore
 import com.sendspindroid.sendspin.crypto.PskCandidates
 import com.sendspindroid.sendspin.crypto.PskCandidateSet
 import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
@@ -497,6 +498,24 @@ class SendSpin(
     /** The live configuration, not a constant: a disabled method is not offered. */
     override fun offeredPairMethods(): Set<String> =
         if (pairingConfigStore.load().pairingPskEnabled) setOf("pairing_psk") else emptySet()
+
+    /**
+     * The `server_id` a pairing record binds to.
+     *
+     * The exact 43-character string from `server/init`, retained on the
+     * session - a record bound to a re-derived or reformatted value would fail
+     * the stored-pubkey check on the next connect and look like corruption.
+     */
+    override fun currentServerId(): String? = sessionFacts?.serverId
+
+    override fun trustStore(): TrustStore = UserSettings.getOrCreateTrustStore()
+
+    override fun onPaired(serverId: String) {
+        // The server drives the in-band re-handshake from here (#223); the
+        // client sends nothing further. The new record is already visible to
+        // pskCandidates(), which reads the store on every call.
+        Log.i(TAG, "Pairing complete with $serverId - awaiting the server's re-handshake")
+    }
 
     /**
      * Run an in-band re-handshake.

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -251,7 +251,12 @@ abstract class SendSpinProtocolHandler(
             supportedPairMethods = getSupportedPairMethods(),
         )
         sendProtocolMessage(text)
-        Log.d(tag, "Sent client/hello: ${text.take(500)}")
+        // Logged whole, not truncated. The pairing fields sit at the end of the
+        // payload, and whether a server offers pairing at all is decided by
+        // them - a 500-character cut hid exactly the thing worth checking when
+        // Music Assistant reports "this player has nothing to pair". Nothing
+        // here is secret: client_id is public, and the pair methods are names.
+        Log.d(tag, "Sent client/hello: $text")
     }
 
     /**
@@ -887,7 +892,20 @@ abstract class SendSpinProtocolHandler(
                 activationSeen = true
                 Log.i(tag, "server/activate accepted: activities=${activate.activities} " +
                     "roles=${outcome.activeRoles}")
-                if (first) {
+                val pairing = Activity.PAIRING in activate.activities
+
+                // A pairing activation is answered with client/pair-finalize and
+                // NOTHING else. The server is sitting in _receive_pairing
+                // waiting for that exact message, so a client/state or the
+                // client/time burst arriving first is read as the finalize and
+                // rejected as malformed - which is precisely how this failed
+                // against both Music Assistant builds.
+                //
+                // Withholding them costs nothing: the admissibility table grants
+                // no roles on a Pairing-PSK connection, so there is no player
+                // state worth reporting and no stream to synchronise to. The
+                // activation that follows the promotion starts them.
+                if (first && !pairing) {
                     // Now, and only now, may we speak.
                     sendPlayerStateUpdate()
                     startTimeSync()
@@ -898,7 +916,7 @@ abstract class SendSpinProtocolHandler(
                 // the server ends an attempt without finalizing, and the client
                 // must then discard the PSK it generated.
                 runPairingActions(
-                    if (Activity.PAIRING in activate.activities) {
+                    if (pairing) {
                         PairingEvent.PairingActivation(
                             method = activate.pairingMethod,
                             // From the handshake, never re-derived: this is the
@@ -954,7 +972,10 @@ abstract class SendSpinProtocolHandler(
         for (action in pairingFlow.onEvent(event)) {
             when (action) {
                 is PairingAction.SendPairFinalize -> {
-                    Log.i(tag, "Pairing: sending client/pair-finalize")
+                    // Metadata only. The payload carries the long-term PSK in
+                    // the clear (inside the encrypted channel), so logging the
+                    // message itself would put a live credential in logcat.
+                    Log.i(tag, "Pairing: sending client/pair-finalize (32-byte PSK)")
                     sendProtocolMessage(
                         MessageBuilder.buildClientPairFinalize(action.longTermPsk)
                     )

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -11,6 +11,12 @@ import com.sendspindroid.sendspin.protocol.message.MessageBuilder
 import com.sendspindroid.sendspin.protocol.message.MessageParser
 import com.sendspindroid.sendspin.protocol.timesync.TimeSyncManager
 import kotlinx.coroutines.CoroutineScope
+import com.sendspindroid.sendspin.crypto.TrustStore
+import com.sendspindroid.sendspin.pairing.PairingAction
+import com.sendspindroid.sendspin.pairing.PairingEvent
+import com.sendspindroid.sendspin.pairing.PairingPskFlow
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -752,6 +758,7 @@ abstract class SendSpinProtocolHandler(
                 // dispatched here and not by the cleartext handshake driver.
                 SendSpinProtocol.MessageType.NOISE_HANDSHAKE -> onRehandshakeMessage(payload)
 
+                SendSpinProtocol.MessageType.SERVER_PAIR_FINALIZE -> handleServerPairFinalize()
                 SendSpinProtocol.MessageType.SERVER_HELLO -> handleServerHello(payload)
                 SendSpinProtocol.MessageType.SERVER_ACTIVATE -> handleServerActivate(payload)
                 SendSpinProtocol.MessageType.SERVER_TIME -> handleServerTime(payload)
@@ -885,6 +892,24 @@ abstract class SendSpinProtocolHandler(
                     sendPlayerStateUpdate()
                     startTimeSync()
                 }
+
+                // Every accepted activation is fed to the pairing flow, not
+                // only the pairing ones: an activation WITHOUT `pairing` is how
+                // the server ends an attempt without finalizing, and the client
+                // must then discard the PSK it generated.
+                runPairingActions(
+                    if (Activity.PAIRING in activate.activities) {
+                        PairingEvent.PairingActivation(
+                            method = activate.pairingMethod,
+                            // From the handshake, never re-derived: this is the
+                            // only thing keeping a long-term secret off an
+                            // unauthenticated connection.
+                            matchedCategory = matchedPskCategory(),
+                        )
+                    } else {
+                        PairingEvent.NonPairingActivation
+                    }
+                )
             }
         }
     }
@@ -895,6 +920,92 @@ abstract class SendSpinProtocolHandler(
      */
     protected open fun onPairAbort(reason: String) {
         sendProtocolMessage(MessageBuilder.buildPairAbort(reason))
+    }
+
+    // ========== Pairing PSK flow (item 2.5) ==========
+
+    /** One attempt at a time, owned by the connection. */
+    private val pairingFlow = PairingPskFlow()
+
+    private var attemptTimeoutJob: Job? = null
+
+    /**
+     * The `server_id` this connection authenticated against, for the record a
+     * successful pairing persists. Null on the legacy path.
+     */
+    protected open fun currentServerId(): String? = null
+
+    /** Where a completed pairing stores its record. */
+    protected open fun trustStore(): TrustStore? = null
+
+    /** Surfaced for the pairing UI (#225). */
+    protected open fun onPaired(serverId: String) {}
+
+    protected fun handleServerPairFinalize() {
+        runPairingActions(PairingEvent.ServerPairFinalize)
+    }
+
+    /** Called by the connection when the socket goes away mid-attempt. */
+    fun onConnectionClosedForPairing() {
+        runPairingActions(PairingEvent.ConnectionClosed)
+    }
+
+    private fun runPairingActions(event: PairingEvent) {
+        for (action in pairingFlow.onEvent(event)) {
+            when (action) {
+                is PairingAction.SendPairFinalize -> {
+                    Log.i(tag, "Pairing: sending client/pair-finalize")
+                    sendProtocolMessage(
+                        MessageBuilder.buildClientPairFinalize(action.longTermPsk)
+                    )
+                }
+
+                is PairingAction.SendPairAbort -> {
+                    Log.w(tag, "Pairing aborted: ${action.reason}")
+                    onPairAbort(action.reason)
+                }
+
+                is PairingAction.PersistRecord -> persistPairingRecord(action.psk)
+
+                PairingAction.StartAttemptTimeout -> {
+                    attemptTimeoutJob?.cancel()
+                    attemptTimeoutJob = getCoroutineScope().launch {
+                        delay(SendSpinProtocol.PAIR_ATTEMPT_TIMEOUT_MS)
+                        Log.w(tag, "Pairing attempt timed out")
+                        runPairingActions(PairingEvent.AttemptTimeout)
+                    }
+                }
+
+                PairingAction.ClearAttemptTimeout -> {
+                    attemptTimeoutJob?.cancel()
+                    attemptTimeoutJob = null
+                }
+            }
+        }
+    }
+
+    private fun persistPairingRecord(psk: ByteArray) {
+        val store = trustStore()
+        val serverId = currentServerId()
+        if (store == null || serverId == null) {
+            // The server has already stored its half, so this is not
+            // recoverable by retrying - say so loudly rather than leaving a
+            // half-pairing that fails as `unauthorized` on the next connect.
+            Log.e(tag, "Paired, but there is nowhere to store the record")
+            return
+        }
+        when (val result = store.addRecord(psk, serverId)) {
+            is TrustStore.AddRecordResult.Ok -> {
+                Log.i(tag, "Paired with $serverId (psk_id=${result.record.pskId})")
+                onPaired(serverId)
+            }
+            // Astronomically unlikely, and not worth a silent retry: the server
+            // holds a PSK we cannot store, so the pairing is already broken.
+            TrustStore.AddRecordResult.AlreadyExists ->
+                Log.e(tag, "Cannot store pairing record: psk_id already claimed")
+            TrustStore.AddRecordResult.Invalid ->
+                Log.e(tag, "Cannot store pairing record: PSK rejected as invalid")
+        }
     }
 
     protected fun handleServerTime(payload: JsonObject?) {

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/PairingQrCode.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/PairingQrCode.kt
@@ -1,0 +1,70 @@
+package com.sendspindroid.ui.settings
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
+
+/**
+ * Renders a pairing token as a QR matrix.
+ *
+ * `pairing.md#pairing-token`: "A QR code carries the token string verbatim, with
+ * no URI scheme or wrapper, so a scan and a copy/paste yield identical input."
+ *
+ * That sentence is the whole contract, and it is easy to break by accident: a
+ * `sendspin://` scheme, a trailing newline, or the display formatting leaking
+ * into the payload all produce a QR that scans to *something*, just not the
+ * thing the operator pasted. Nothing about the failure looks like a bug - the
+ * server simply says the token is invalid. So the payload is the token string
+ * and nothing else, and `PairingQrCodeTest` scans the output back to prove it.
+ *
+ * Kept free of Compose and Android types on purpose: this is the part with a
+ * correctness requirement, so it runs in a plain JVM unit test. Painting the
+ * grid lives in [PairingQrImage].
+ */
+object PairingQrCode {
+
+    /**
+     * Modules of light border on each side. QR readers need a quiet zone to
+     * find the symbol; the spec's minimum is 4, but 2 is reliable for a screen
+     * scanned at close range and keeps the symbol larger on a phone-sized card.
+     */
+    const val QUIET_ZONE_MODULES = 2
+
+    /** A square grid of light/dark modules, quiet zone included. */
+    class Matrix internal constructor(
+        val size: Int,
+        private val dark: BooleanArray,
+    ) {
+        fun isDark(x: Int, y: Int): Boolean = dark[y * size + x]
+    }
+
+    fun encode(token: String): Matrix {
+        // The token is drawn from [0-9A-Z:], exactly the QR alphanumeric set,
+        // so zxing packs it at 5.5 bits per character instead of 8. That is
+        // what keeps 107 characters down to a symbol that stays scannable at
+        // the size a settings screen can spare.
+        val bits = QRCodeWriter().encode(
+            token,
+            BarcodeFormat.QR_CODE,
+            0,
+            0,
+            mapOf(
+                EncodeHintType.MARGIN to QUIET_ZONE_MODULES,
+                EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M,
+            ),
+        )
+
+        // Width 0 asks zxing for the natural, one-pixel-per-module symbol.
+        // Scaling is the renderer's job - blowing it up here would only make a
+        // bigger array to copy.
+        val size = bits.width
+        val dark = BooleanArray(size * size)
+        for (y in 0 until size) {
+            for (x in 0 until size) {
+                dark[y * size + x] = bits.get(x, y)
+            }
+        }
+        return Matrix(size, dark)
+    }
+}

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/PairingQrImage.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/PairingQrImage.kt
@@ -1,0 +1,69 @@
+package com.sendspindroid.ui.settings
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Paints a pairing token as a scannable QR code.
+ *
+ * Two rendering decisions here are load-bearing, and both fail silently when
+ * they are wrong - the operator sees a QR that simply never scans, with nothing
+ * on screen suggesting why:
+ *
+ * 1. **The colors are hardcoded black on white, never [androidx.compose.material3.MaterialTheme].**
+ *    In dark theme a theme-derived QR comes out light-on-dark or low-contrast,
+ *    and many readers will not invert.
+ * 2. **[FilterQuality.None].** The matrix is one pixel per module, so it is
+ *    scaled up by a large factor. Default bilinear filtering smears the module
+ *    edges into grey; a reader needs the hard black/white transitions.
+ *
+ * The white background extends past the symbol via [Modifier.padding] inside
+ * [Modifier.background] so the quiet zone stays white in dark theme too.
+ */
+@Composable
+fun PairingQrImage(
+    token: String,
+    modifier: Modifier = Modifier,
+    size: Dp = 220.dp,
+) {
+    // Keyed on the token: encoding is cheap, but recomposition is frequent and
+    // this allocates a bitmap.
+    val bitmap = remember(token) {
+        val matrix = PairingQrCode.encode(token)
+        val pixels = IntArray(matrix.size * matrix.size)
+        for (y in 0 until matrix.size) {
+            for (x in 0 until matrix.size) {
+                pixels[y * matrix.size + x] =
+                    if (matrix.isDark(x, y)) BLACK else WHITE
+            }
+        }
+        Bitmap.createBitmap(pixels, matrix.size, matrix.size, Bitmap.Config.ARGB_8888)
+            .asImageBitmap()
+    }
+
+    Image(
+        bitmap = bitmap,
+        contentDescription = null,
+        filterQuality = FilterQuality.None,
+        contentScale = ContentScale.Fit,
+        modifier = modifier
+            .background(Color.White)
+            .padding(8.dp)
+            .size(size),
+    )
+}
+
+private const val BLACK = 0xFF000000.toInt()
+private const val WHITE = 0xFFFFFFFF.toInt()

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -464,6 +464,20 @@ private fun PairingTokenPreference(
         )
         Spacer(modifier = Modifier.height(12.dp))
 
+        PairingQrImage(
+            token = token,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = stringResource(R.string.pairing_token_qr_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
         SelectionContainer {
             Text(
                 text = token,

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsScreen.kt
@@ -58,6 +58,12 @@ import com.sendspindroid.UserSettings
 import com.sendspindroid.diagnostics.Telemetry
 import com.sendspindroid.logging.LogLevel
 import com.sendspindroid.ui.theme.SendSpinTheme
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.background
+import android.widget.Toast
 
 /**
  * Settings screen composable with all app preferences.
@@ -132,6 +138,10 @@ fun SettingsScreen(
                 summary = playerName.ifEmpty { stringResource(R.string.pref_player_name_summary) },
                 onClick = { showPlayerNameDialog = true }
             )
+
+            // Pairing Category
+            PreferenceCategory(title = stringResource(R.string.pairing_category))
+            PairingTokenPreference(token = viewModel.pairingToken())
 
             // Display Category
             PreferenceCategory(title = stringResource(R.string.pref_category_display))
@@ -406,6 +416,87 @@ fun SettingsScreen(
 // ============================================================================
 // Preference Components
 // ============================================================================
+
+/**
+ * The pairing token, rendered for transcription and copying.
+ *
+ * Deliberately ungrouped. Confirmed against a live Music Assistant in #191:
+ * its decoder trims only *surrounding* whitespace, so any separator inserted
+ * for legibility - a hyphen every eight characters, say - makes the token fail
+ * with an opaque "not valid" error that says nothing about separators. The
+ * readability win is not worth an unexplainable failure.
+ *
+ * Monospace so a user reading it aloud or retyping it can tell O from 0.
+ */
+@Composable
+private fun PairingTokenPreference(
+    token: String?,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    val copiedMessage = stringResource(R.string.pairing_token_copied)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.pairing_token_title),
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+
+        if (token == null) {
+            Text(
+                text = stringResource(R.string.pairing_token_disabled),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            return@Column
+        }
+
+        Text(
+            text = stringResource(R.string.pairing_token_summary),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        SelectionContainer {
+            Text(
+                text = token,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        MaterialTheme.colorScheme.surfaceVariant,
+                        RoundedCornerShape(8.dp)
+                    )
+                    .padding(12.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.pairing_token_secret_warning),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+        TextButton(
+            onClick = {
+                clipboard.setText(AnnotatedString(token))
+                Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
+            }
+        ) {
+            Text(stringResource(R.string.pairing_token_copy))
+        }
+    }
+}
 
 @Composable
 private fun PreferenceCategory(

--- a/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/sendspindroid/ui/settings/SettingsViewModel.kt
@@ -14,6 +14,8 @@ import com.sendspindroid.UnifiedServerRepository
 import com.sendspindroid.UserSettings
 import com.sendspindroid.logging.AppLog
 import com.sendspindroid.logging.LogLevel
+import com.sendspindroid.sendspin.crypto.AndroidPairingConfigStore
+import com.sendspindroid.sendspin.pairing.PairingToken
 import com.sendspindroid.sendspin.decoder.AudioDecoderFactory
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -49,6 +51,27 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     // Player settings
     private val _playerName = MutableStateFlow(UserSettings.getPlayerName())
     val playerName: StateFlow<String> = _playerName.asStateFlow()
+
+    /**
+     * The pairing token, or null when the method is disabled.
+     *
+     * Computed lazily rather than held in state: it contains the Pairing PSK,
+     * so the fewer copies alive the better. Reading it also mints the PSK on
+     * first use, which is why this is not evaluated at construction - opening
+     * Settings should not create a secret the user never asked for.
+     */
+    fun pairingToken(): String? {
+        val config = AndroidPairingConfigStore().load()
+        if (!config.pairingPskEnabled) return null
+        // Never logged. The token embeds the Pairing PSK, so anything that
+        // writes it to logcat puts a live credential into a buffer that bug
+        // reports and any app with log access can read. It leaves this method
+        // only by being rendered on screen for the user to copy.
+        return PairingToken.encode(
+            clientKey = UserSettings.getOrCreateClientIdentity().publicKey,
+            pairingPsk = config.pairingPsk,
+        )
+    }
 
     // Display settings
     private val _fullscreenMode = MutableStateFlow(UserSettings.fullScreenMode)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -234,6 +234,7 @@
     <string name="pairing_category">Pairing</string>
     <string name="pairing_token_title">Pairing token</string>
     <string name="pairing_token_summary">Paste this into your server to pair this device. Copy it whole, without spaces or dashes.</string>
+    <string name="pairing_token_qr_hint">Scan to copy the token to another device</string>
     <string name="pairing_token_copy">Copy pairing token</string>
     <string name="pairing_token_copied">Pairing token copied</string>
     <string name="pairing_token_secret_warning">Treat this like a password: anyone who has it can pair with this device.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -230,6 +230,14 @@
     <string name="pref_export_logs_title">Export Debug Logs</string>
     <string name="pref_export_logs_summary">Share collected sync data for troubleshooting</string>
     <string name="pref_export_logs_summary_empty">No logs collected yet - set a log level above</string>
+    <!-- Pairing (Sendspin Pairing PSK flow) -->
+    <string name="pairing_category">Pairing</string>
+    <string name="pairing_token_title">Pairing token</string>
+    <string name="pairing_token_summary">Paste this into your server to pair this device. Copy it whole, without spaces or dashes.</string>
+    <string name="pairing_token_copy">Copy pairing token</string>
+    <string name="pairing_token_copied">Pairing token copied</string>
+    <string name="pairing_token_secret_warning">Treat this like a password: anyone who has it can pair with this device.</string>
+    <string name="pairing_token_disabled">Pairing is turned off for this device.</string>
     <string name="debug_share_chooser_title">Share Debug Log</string>
     <string name="debug_log_exported">Debug log exported</string>
     <string name="debug_log_export_failed">Failed to export debug log</string>

--- a/android/app/src/test/java/com/sendspindroid/ui/settings/PairingQrCodeTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/ui/settings/PairingQrCodeTest.kt
@@ -1,0 +1,94 @@
+package com.sendspindroid.ui.settings
+
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.common.BitMatrix
+import com.google.zxing.common.HybridBinarizer
+import com.google.zxing.qrcode.QRCodeReader
+import com.sendspindroid.sendspin.pairing.PairingToken
+import com.google.zxing.LuminanceSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The one thing a pairing QR has to get right: a scan and a copy/paste must
+ * yield the same string.
+ *
+ * `pairing.md#pairing-token`: "A QR code carries the token string verbatim, with
+ * no URI scheme or wrapper, so a scan and a copy/paste yield identical input."
+ *
+ * So these tests do not inspect the payload we handed the encoder - that would
+ * only prove we passed what we passed. They run the matrix back through a real
+ * QR *reader* and compare against the token, which is what a phone camera will
+ * actually recover.
+ */
+class PairingQrCodeTest {
+
+    /** The spec reference vector: client_key 0x00..0x1f, pairing_psk 0xe0..0xff. */
+    private val referenceToken = PairingToken.encode(
+        clientKey = ByteArray(32) { it.toByte() },
+        pairingPsk = ByteArray(32) { (0xe0 + it).toByte() },
+    )
+
+    @Test
+    fun `a scan of the matrix recovers the token exactly`() {
+        val matrix = PairingQrCode.encode(referenceToken)
+
+        assertEquals(referenceToken, scan(matrix))
+    }
+
+    @Test
+    fun `the matrix is a valid square QR symbol`() {
+        val matrix = PairingQrCode.encode(referenceToken)
+
+        // Every QR version is 4v+17 modules square, plus the quiet zone on both
+        // sides. A grid that fails this is not a symbol any reader will accept.
+        assertTrue("not square: ${matrix.size}", matrix.size > 0)
+        val symbol = matrix.size - 2 * PairingQrCode.QUIET_ZONE_MODULES
+        assertTrue("$symbol is not 4v+17", symbol in 21..177 && (symbol - 17) % 4 == 0)
+    }
+
+    @Test
+    fun `the matrix carries a quiet zone`() {
+        val matrix = PairingQrCode.encode(referenceToken)
+
+        // A symbol drawn flush to its edge scans erratically, and the failure
+        // looks to an operator like "nothing happens" rather than like a bug.
+        val last = matrix.size - 1
+        for (i in 0 until matrix.size) {
+            assertTrue("dark module on the top edge at $i", !matrix.isDark(i, 0))
+            assertTrue("dark module on the bottom edge at $i", !matrix.isDark(i, last))
+            assertTrue("dark module on the left edge at $i", !matrix.isDark(0, i))
+            assertTrue("dark module on the right edge at $i", !matrix.isDark(last, i))
+        }
+    }
+
+    /** Decodes the matrix the way a camera would, via a real QR reader. */
+    private fun scan(matrix: PairingQrCode.Matrix): String {
+        val bits = BitMatrix(matrix.size, matrix.size)
+        for (y in 0 until matrix.size) {
+            for (x in 0 until matrix.size) {
+                if (matrix.isDark(x, y)) bits.set(x, y)
+            }
+        }
+        val source = object : LuminanceSource(matrix.size, matrix.size) {
+            override fun getRow(y: Int, row: ByteArray?): ByteArray {
+                val out = row?.takeIf { it.size >= width } ?: ByteArray(width)
+                for (x in 0 until width) out[x] = if (bits.get(x, y)) 0 else 0xFF.toByte()
+                return out
+            }
+
+            override fun getMatrix(): ByteArray {
+                val out = ByteArray(width * height)
+                for (y in 0 until height) getRow(y, ByteArray(width)).copyInto(out, y * width)
+                return out
+            }
+        }
+        val result = QRCodeReader().decode(
+            BinaryBitmap(HybridBinarizer(source)),
+            mapOf(DecodeHintType.PURE_BARCODE to true),
+        )
+        return result.text
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairingPskFlowTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairingPskFlowTest.kt
@@ -1,0 +1,177 @@
+package com.sendspindroid.sendspin.pairing
+
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PskCategory
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * The Pairing PSK flow: one message out, one message back.
+ *
+ * Two rules are easy to skip and impossible to notice when skipped:
+ *
+ *  - the connection must actually be keyed by the Pairing PSK before the
+ *    long-term secret is sent. Skipping it leaks a fresh long-term PSK onto a
+ *    Sentinel-keyed connection, which is unauthenticated and MITM-exposed.
+ *  - the record is persisted only after the server acknowledges. Skipping that
+ *    leaves the client holding a record the server never stored, surfacing much
+ *    later as an unexplained `unauthorized`.
+ *
+ * Both are pure state, so both are pinned here rather than in an integration
+ * test that would only exercise the happy path.
+ */
+class PairingPskFlowTest {
+
+    private fun flow() = PairingPskFlow()
+
+    private fun activation(method: String?, category: PskCategory) =
+        PairingEvent.PairingActivation(method, category)
+
+    private inline fun <reified T> List<PairingAction>.only(): T {
+        assertEquals("expected exactly one action, got $this", 1, size)
+        assertTrue("expected ${T::class.simpleName}, got ${first()}", first() is T)
+        return first() as T
+    }
+
+    @Test
+    fun theHappyPathSendsThePskThenPersistsTheSameBytes() {
+        val flow = flow()
+        val actions = flow.onEvent(activation("pairing_psk", PskCategory.PAIRING))
+
+        val send = actions.filterIsInstance<PairingAction.SendPairFinalize>().single()
+        assertEquals(Psk.PSK_SIZE, send.longTermPsk.size)
+        assertTrue(actions.any { it is PairingAction.StartAttemptTimeout })
+
+        val persisted = flow.onEvent(PairingEvent.ServerPairFinalize)
+            .filterIsInstance<PairingAction.PersistRecord>().single()
+        assertArrayEquals(
+            "the persisted record must be the bytes we actually sent",
+            send.longTermPsk, persisted.psk,
+        )
+    }
+
+    @Test
+    fun aSentinelKeyedConnectionNeverReceivesTheLongTermPsk() {
+        // The headline security test. "Before sending client/pair-finalize, the
+        // client MUST verify that the connection's matched PSK is the Pairing
+        // PSK ...; on mismatch it aborts with pair/abort reason
+        // method_not_supported."
+        val actions = flow().onEvent(activation("pairing_psk", PskCategory.SENTINEL))
+
+        assertTrue(
+            "no PSK may be generated or sent on a non-Pairing-PSK connection: $actions",
+            actions.none { it is PairingAction.SendPairFinalize },
+        )
+        val abort = actions.only<PairingAction.SendPairAbort>()
+        assertEquals("method_not_supported", abort.reason)
+    }
+
+    @Test
+    fun aLongTermKeyedConnectionNeverReceivesTheLongTermPskEither() {
+        // Already paired is still not the Pairing PSK. The rule is about which
+        // key authenticated this connection, not about how trusted it feels.
+        val actions = flow().onEvent(activation("pairing_psk", PskCategory.LONG_TERM))
+        assertTrue(actions.none { it is PairingAction.SendPairFinalize })
+        assertEquals("method_not_supported", actions.only<PairingAction.SendPairAbort>().reason)
+    }
+
+    @Test
+    fun aPinMethodIsRefusedBecauseThisClientDoesNotOfferOne() {
+        for (method in listOf("dynamic_pin", "static_pin", null)) {
+            val actions = flow().onEvent(activation(method, PskCategory.PAIRING))
+            assertTrue(
+                "method $method must not produce a PSK: $actions",
+                actions.none { it is PairingAction.SendPairFinalize },
+            )
+            assertEquals(
+                "method_not_supported",
+                actions.only<PairingAction.SendPairAbort>().reason,
+            )
+        }
+    }
+
+    @Test
+    fun anActivationInsteadOfAnAckPersistsNothing() {
+        // "A client that, after sending client/pair-finalize, receives
+        // server/activate likewise persists nothing." The server changed its
+        // mind; we must discard the PSK we generated.
+        val flow = flow()
+        flow.onEvent(activation("pairing_psk", PskCategory.PAIRING))
+
+        val onActivation = flow.onEvent(PairingEvent.NonPairingActivation)
+        assertTrue(onActivation.none { it is PairingAction.PersistRecord })
+
+        // And the attempt is genuinely over: a late ack must not resurrect it.
+        val late = flow.onEvent(PairingEvent.ServerPairFinalize)
+        assertTrue(
+            "a late ack after the attempt ended must persist nothing: $late",
+            late.none { it is PairingAction.PersistRecord },
+        )
+    }
+
+    @Test
+    fun theAttemptTimesOutAndPersistsNothingAfterwards() {
+        val flow = flow()
+        flow.onEvent(activation("pairing_psk", PskCategory.PAIRING))
+
+        val onTimeout = flow.onEvent(PairingEvent.AttemptTimeout)
+        assertEquals("attempt_timeout", onTimeout.only<PairingAction.SendPairAbort>().reason)
+
+        assertTrue(
+            flow.onEvent(PairingEvent.ServerPairFinalize)
+                .none { it is PairingAction.PersistRecord }
+        )
+    }
+
+    @Test
+    fun aClosedConnectionPersistsNothing() {
+        val flow = flow()
+        flow.onEvent(activation("pairing_psk", PskCategory.PAIRING))
+        assertTrue(
+            flow.onEvent(PairingEvent.ConnectionClosed)
+                .none { it is PairingAction.PersistRecord }
+        )
+        assertTrue(
+            flow.onEvent(PairingEvent.ServerPairFinalize)
+                .none { it is PairingAction.PersistRecord }
+        )
+    }
+
+    @Test
+    fun anUnexpectedAckIsSilentlyDiscarded() {
+        // "A client that has aborted an attempt likewise silently discards
+        // pairing messages received before the next server/activate." Silence,
+        // not a protocol error - the connection stays usable.
+        val flow = flow()
+        assertTrue(flow.onEvent(PairingEvent.ServerPairFinalize).isEmpty())
+    }
+
+    @Test
+    fun eachAttemptGeneratesAFreshPsk() {
+        // A reused secret across attempts would mean a token shown once could
+        // pair a second server the operator never saw.
+        val first = flow().onEvent(activation("pairing_psk", PskCategory.PAIRING))
+            .filterIsInstance<PairingAction.SendPairFinalize>().single().longTermPsk
+        val second = flow().onEvent(activation("pairing_psk", PskCategory.PAIRING))
+            .filterIsInstance<PairingAction.SendPairFinalize>().single().longTermPsk
+        assertFalse(first.contentEquals(second))
+    }
+
+    @Test
+    fun aSecondActivationDuringAnAttemptDoesNotStartASecondOne() {
+        val flow = flow()
+        val first = flow.onEvent(activation("pairing_psk", PskCategory.PAIRING))
+            .filterIsInstance<PairingAction.SendPairFinalize>().single()
+
+        val again = flow.onEvent(activation("pairing_psk", PskCategory.PAIRING))
+        assertTrue(
+            "a repeated activation must not mint a second PSK: $again",
+            again.none { it is PairingAction.SendPairFinalize },
+        )
+
+        // The original attempt still completes with its original bytes.
+        val persisted = flow.onEvent(PairingEvent.ServerPairFinalize)
+            .filterIsInstance<PairingAction.PersistRecord>().single()
+        assertArrayEquals(first.longTermPsk, persisted.psk)
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairingTokenTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairingTokenTest.kt
@@ -23,6 +23,44 @@ class PairingTokenTest {
     private val clientKey = ByteArray(32) { it.toByte() }
     private val pairingPsk = ByteArray(32) { (it + 0x40).toByte() }
 
+    /**
+     * The spec's reference vector, `pairing.md#pairing-token`, with
+     * `client_key = 0x00 0x01 ... 0x1f` and `pairing_psk = 0xe0 0xe1 ... 0xff`.
+     *
+     * This is the only test here that can fail while every other one passes.
+     * The rest of the file round-trips our own encoder through our own decoder,
+     * which stays green no matter how wrong they both are in the same
+     * direction - halves swapped, bits packed the other way, alphabet rotated.
+     * The server is the party that has to agree with us, and this string is the
+     * only thing in the repository that comes from the server's side of the
+     * contract.
+     */
+    @Test
+    fun encodeMatchesTheSpecReferenceVector() {
+        val token = PairingToken.encode(
+            clientKey = ByteArray(32) { it.toByte() },
+            pairingPsk = ByteArray(32) { (0xe0 + it).toByte() },
+        )
+
+        assertEquals(
+            "SP:0AAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYP6BYPC4PS" +
+                "OLZXH5DU6V97M5XXO74HR6LZ7J5PW674PT6X37T6757Y",
+            token,
+        )
+    }
+
+    @Test
+    fun decodeMatchesTheSpecReferenceVector() {
+        val decoded = PairingToken.decode(
+            "SP:0AAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYP6BYPC4PS" +
+                "OLZXH5DU6V97M5XXO74HR6LZ7J5PW674PT6X37T6757Y"
+        )
+
+        assertNotNull(decoded)
+        assertArrayEquals(ByteArray(32) { it.toByte() }, decoded!!.clientKey)
+        assertArrayEquals(ByteArray(32) { (0xe0 + it).toByte() }, decoded.pairingPsk)
+    }
+
     @Test
     fun aTokenIs107CharactersOfTheQrAlphanumericSet() {
         val token = PairingToken.encode(clientKey, pairingPsk)

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairingTokenTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairingTokenTest.kt
@@ -1,0 +1,94 @@
+package com.sendspindroid.sendspin.pairing
+
+import com.sendspindroid.sendspin.crypto.Psk
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * The pairing token: the client's `client_key` and Pairing PSK, in one string
+ * an operator can transfer out of band.
+ *
+ * `pairing.md#pairing-token`: "A version-0 token is 107 characters drawn only
+ * from the QR code alphanumeric set (`0-9`, `A-Z`, `:`), so it renders as a
+ * compact QR code and survives manual transcription."
+ *
+ * Confirmed against a live Music Assistant in #191: its field accepts the
+ * token with or without the `SP:` prefix and in either case, uppercases it, and
+ * **rejects any interior separator**. So this must render ungrouped - grouping
+ * it for legibility produces an opaque "not valid" error with nothing pointing
+ * at the separator as the cause.
+ */
+class PairingTokenTest {
+
+    private val clientKey = ByteArray(32) { it.toByte() }
+    private val pairingPsk = ByteArray(32) { (it + 0x40).toByte() }
+
+    @Test
+    fun aTokenIs107CharactersOfTheQrAlphanumericSet() {
+        val token = PairingToken.encode(clientKey, pairingPsk)
+        assertEquals(107, token.length)
+        assertTrue(
+            "token must use only 0-9, A-Z and ':' - got $token",
+            token.all { it in '0'..'9' || it in 'A'..'Z' || it == ':' },
+        )
+    }
+
+    @Test
+    fun aTokenStartsWithTheVersionZeroPrefix() {
+        assertTrue(PairingToken.encode(clientKey, pairingPsk).startsWith("SP:0"))
+    }
+
+    @Test
+    fun theBodyNeverContainsATwo() {
+        // The `2`->`9` substitution exists so the alphabet stays inside the QR
+        // alphanumeric set; a stray '2' means the substitution was skipped and
+        // the server's inverse replace would corrupt the decode.
+        val body = PairingToken.encode(clientKey, pairingPsk).removePrefix("SP:0")
+        assertFalse("body must not contain '2': $body", body.contains('2'))
+    }
+
+    @Test
+    fun encodeAndDecodeRoundTrip() {
+        val token = PairingToken.encode(clientKey, pairingPsk)
+        val decoded = PairingToken.decode(token)
+        assertNotNull(decoded)
+        assertArrayEquals(clientKey, decoded!!.clientKey)
+        assertArrayEquals(pairingPsk, decoded.pairingPsk)
+    }
+
+    @Test
+    fun decodeAcceptsWhatMusicAssistantAccepts() {
+        // Verified against a running instance in #191.
+        val token = PairingToken.encode(clientKey, pairingPsk)
+        assertNotNull("lowercase must decode", PairingToken.decode(token.lowercase()))
+        assertNotNull("a missing SP: prefix must decode", PairingToken.decode(token.removePrefix("SP:")))
+        assertNotNull("surrounding whitespace must decode", PairingToken.decode("  $token  "))
+    }
+
+    @Test
+    fun decodeRejectsWhatMusicAssistantRejects() {
+        // The finding that constrains rendering: interior separators are fatal.
+        val token = PairingToken.encode(clientKey, pairingPsk)
+        val grouped = token.chunked(8).joinToString("-")
+        assertNull("an interior hyphen must be rejected", PairingToken.decode(grouped))
+        assertNull("an interior space must be rejected", PairingToken.decode(token.chunked(8).joinToString(" ")))
+    }
+
+    @Test
+    fun decodeRejectsMalformedInputRatherThanThrowing() {
+        assertNull(PairingToken.decode(""))
+        assertNull(PairingToken.decode("not a token"))
+        assertNull(PairingToken.decode("SP:9" + "A".repeat(103)))  // unknown version
+        assertNull(PairingToken.decode("SP:0" + "A".repeat(10)))   // too short
+    }
+
+    @Test
+    fun requiresBothHalvesToBeTheRightLength() {
+        assertThrows(IllegalArgumentException::class.java) {
+            PairingToken.encode(ByteArray(16), pairingPsk)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            PairingToken.encode(clientKey, ByteArray(Psk.PSK_SIZE - 1))
+        }
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/pairing/PairingPskFlow.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/pairing/PairingPskFlow.kt
@@ -1,0 +1,181 @@
+package com.sendspindroid.sendspin.pairing
+
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.crypto.secureRandomBytes
+
+/** What happened. */
+sealed interface PairingEvent {
+    /**
+     * A `server/activate` declaring the `pairing` activity.
+     *
+     * @param matchedCategory the category of the PSK that authenticated THIS
+     *   connection, from the handshake. Never re-derived: it is the only thing
+     *   standing between a long-term secret and an unauthenticated channel.
+     */
+    data class PairingActivation(
+        val method: String?,
+        val matchedCategory: PskCategory,
+    ) : PairingEvent
+
+    /** `server/pair-finalize`: the server has persisted its side. */
+    object ServerPairFinalize : PairingEvent
+
+    /** A `server/activate` without `pairing`, which ends any attempt. */
+    object NonPairingActivation : PairingEvent
+
+    object AttemptTimeout : PairingEvent
+
+    object ConnectionClosed : PairingEvent
+}
+
+/** What the connection should do about it. */
+sealed interface PairingAction {
+    /** Send `client/pair-finalize` carrying this secret. */
+    class SendPairFinalize(psk: ByteArray) : PairingAction {
+        private val secret = psk.copyOf()
+        val longTermPsk: ByteArray get() = secret.copyOf()
+    }
+
+    data class SendPairAbort(val reason: String) : PairingAction
+
+    /** Store the record. Only ever emitted after the server acknowledges. */
+    class PersistRecord(psk: ByteArray) : PairingAction {
+        private val secret = psk.copyOf()
+        val psk: ByteArray get() = secret.copyOf()
+    }
+
+    object StartAttemptTimeout : PairingAction
+
+    object ClearAttemptTimeout : PairingAction
+}
+
+/**
+ * The Pairing PSK flow, as a pure state machine.
+ *
+ * `pairing.md#pairing-psk-flow`. No I/O and no coroutines, because the two
+ * rules that matter are both about *whether* something is emitted, and those
+ * are far easier to pin here than through a live connection:
+ *
+ *  1. The long-term PSK is generated and sent only when the connection is
+ *     actually keyed by the Pairing PSK. On any other key the client aborts
+ *     with `method_not_supported` and generates nothing at all. Sending it over
+ *     a Sentinel-keyed session would hand a fresh long-term secret to an
+ *     unauthenticated, MITM-exposed channel.
+ *  2. The record is persisted only on `server/pair-finalize`. Persisting
+ *     earlier leaves the client holding a credential the server never stored,
+ *     which surfaces later as an `unauthorized` with no explanation.
+ *
+ * Single attempt at a time. The connection owns one of these.
+ */
+class PairingPskFlow {
+
+    enum class State { IDLE, AWAITING_ACK, DONE, ABORTED }
+
+    var state: State = State.IDLE
+        private set
+
+    /** The secret for the attempt in flight. Discarded on every exit path. */
+    private var pending: ByteArray? = null
+
+    fun onEvent(event: PairingEvent): List<PairingAction> = when (event) {
+        is PairingEvent.PairingActivation -> onPairingActivation(event)
+
+        PairingEvent.ServerPairFinalize -> {
+            val psk = pending
+            if (state != State.AWAITING_ACK || psk == null) {
+                // "A client that has aborted an attempt likewise silently
+                // discards pairing messages received before the next
+                // server/activate." Silence, not a protocol error.
+                emptyList()
+            } else {
+                // Build the action FIRST: it copies, and discard() zeroes the
+                // very array `psk` points at. Zeroing before the copy persists
+                // 32 zero bytes - a record that authenticates nothing, stored
+                // as though pairing had succeeded.
+                val action = PairingAction.PersistRecord(psk)
+                discard()
+                state = State.DONE
+                listOf(action, PairingAction.ClearAttemptTimeout)
+            }
+        }
+
+        PairingEvent.NonPairingActivation -> {
+            // "The same server/activate can also end a pairing attempt without
+            // finalizing: sent in place of server/pair-finalize, it persists
+            // nothing and discards any received PSK."
+            val wasWaiting = state == State.AWAITING_ACK
+            discard()
+            state = State.IDLE
+            if (wasWaiting) listOf(PairingAction.ClearAttemptTimeout) else emptyList()
+        }
+
+        PairingEvent.AttemptTimeout -> {
+            if (state != State.AWAITING_ACK) {
+                emptyList()
+            } else {
+                discard()
+                state = State.ABORTED
+                listOf(PairingAction.SendPairAbort(PairAbortReason.ATTEMPT_TIMEOUT))
+            }
+        }
+
+        PairingEvent.ConnectionClosed -> {
+            // Nothing to send: the socket is gone. Just make sure the secret
+            // does not outlive the attempt.
+            val wasWaiting = state == State.AWAITING_ACK
+            discard()
+            state = State.IDLE
+            if (wasWaiting) listOf(PairingAction.ClearAttemptTimeout) else emptyList()
+        }
+    }
+
+    private fun onPairingActivation(event: PairingEvent.PairingActivation): List<PairingAction> {
+        // Refuse before generating anything. Order matters: a PSK minted and
+        // then discarded is a PSK that existed in memory for no reason.
+        if (event.matchedCategory != PskCategory.PAIRING) {
+            return listOf(PairingAction.SendPairAbort(PairAbortReason.METHOD_NOT_SUPPORTED))
+        }
+        if (event.method != PairMethod.PAIRING_PSK) {
+            // The PIN methods are not offered by this client (audit D2), so any
+            // other method is one we cannot run.
+            return listOf(PairingAction.SendPairAbort(PairAbortReason.METHOD_NOT_SUPPORTED))
+        }
+        if (state == State.AWAITING_ACK) {
+            // An attempt is already in flight. Minting a second secret would
+            // leave the first one un-acknowledgeable.
+            return emptyList()
+        }
+
+        val psk = secureRandomBytes(Psk.PSK_SIZE)
+        pending = psk
+        state = State.AWAITING_ACK
+        return listOf(
+            PairingAction.SendPairFinalize(psk),
+            PairingAction.StartAttemptTimeout,
+        )
+    }
+
+    /** Zero the secret rather than dropping the reference. */
+    private fun discard() {
+        pending?.fill(0)
+        pending = null
+    }
+}
+
+/** `pair/abort` reasons (`pairing.md#client--server-pairabort`). */
+object PairAbortReason {
+    const val ATTEMPT_TIMEOUT = "attempt_timeout"
+    const val CONCURRENT_ATTEMPT = "concurrent_attempt"
+    const val METHOD_NOT_SUPPORTED = "method_not_supported"
+    const val PIN_LENGTH_UNACCEPTABLE = "pin_length_unacceptable"
+    const val PIN_MISMATCH = "pin_mismatch"
+    const val USER_CANCELLED = "user_cancelled"
+}
+
+/** Pairing method wire names. */
+object PairMethod {
+    const val PAIRING_PSK = "pairing_psk"
+    const val DYNAMIC_PIN = "dynamic_pin"
+    const val STATIC_PIN = "static_pin"
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/pairing/PairingToken.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/pairing/PairingToken.kt
@@ -1,0 +1,100 @@
+package com.sendspindroid.sendspin.pairing
+
+import com.sendspindroid.sendspin.crypto.Psk
+
+/**
+ * The pairing token codec.
+ *
+ * `pairing.md#pairing-token`: "The two are distributed together as a **pairing
+ * token**: a single case-insensitive ASCII string the operator transfers out of
+ * band (copy/paste, QR scan) into the server to begin the Pairing PSK Flow."
+ *
+ * Layout: `SP:` + version `0` + base32(client_key || pairing_psk), unpadded,
+ * with every `2` rewritten as `9`. 4 + 103 = 107 characters, drawn only from
+ * `0-9`, `A-Z` and `:` so the whole thing fits the QR alphanumeric set and
+ * survives being read aloud or retyped.
+ *
+ * The `2`->`9` substitution is not cosmetic: base32's alphabet includes `2`,
+ * but the QR alphanumeric mode's does not overlap it the way this needs, so the
+ * spec rewrites it. The server applies the inverse before decoding.
+ *
+ * **Render this ungrouped.** Confirmed against a live Music Assistant in #191:
+ * its decoder trims only *surrounding* whitespace, so any interior separator
+ * added for legibility makes the token fail with an opaque "not valid" error
+ * that names nothing about separators.
+ */
+object PairingToken {
+
+    private const val PREFIX = "SP:"
+    private const val VERSION = '0'
+    private const val LENGTH = 107
+
+    /** RFC 4648 base32, uppercase, no padding. */
+    private const val ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+    class Decoded(clientKey: ByteArray, pairingPsk: ByteArray) {
+        private val key = clientKey.copyOf()
+        private val psk = pairingPsk.copyOf()
+        val clientKey: ByteArray get() = key.copyOf()
+        val pairingPsk: ByteArray get() = psk.copyOf()
+    }
+
+    fun encode(clientKey: ByteArray, pairingPsk: ByteArray): String {
+        require(clientKey.size == 32) { "client_key is 32 bytes, got ${clientKey.size}" }
+        require(pairingPsk.size == Psk.PSK_SIZE) {
+            "a Sendspin PSK is ${Psk.PSK_SIZE} bytes, got ${pairingPsk.size}"
+        }
+        val body = base32(clientKey + pairingPsk).replace('2', '9')
+        return "$PREFIX$VERSION$body"
+    }
+
+    /**
+     * @return null for anything malformed. Never throws: the input is whatever
+     *   an operator pasted.
+     */
+    fun decode(token: String): Decoded? {
+        // Exactly what the server does: trim the ends, uppercase, drop the
+        // optional prefix. Notably NOT stripping interior whitespace, because
+        // the server does not either - and a client that accepted what the
+        // server rejects would send people chasing a phantom difference.
+        val normalized = token.trim().uppercase().removePrefix(PREFIX)
+        if (normalized.length < 2 || normalized[0] != VERSION) return null
+
+        val bytes = unbase32(normalized.substring(1).replace('9', '2')) ?: return null
+        if (bytes.size != 64) return null
+        return Decoded(bytes.copyOfRange(0, 32), bytes.copyOfRange(32, 64))
+    }
+
+    private fun base32(data: ByteArray): String {
+        val out = StringBuilder((data.size * 8 + 4) / 5)
+        var buffer = 0
+        var bits = 0
+        for (b in data) {
+            buffer = (buffer shl 8) or (b.toInt() and 0xFF)
+            bits += 8
+            while (bits >= 5) {
+                out.append(ALPHABET[(buffer shr (bits - 5)) and 0x1F])
+                bits -= 5
+            }
+        }
+        if (bits > 0) out.append(ALPHABET[(buffer shl (5 - bits)) and 0x1F])
+        return out.toString()
+    }
+
+    private fun unbase32(text: String): ByteArray? {
+        val out = ArrayList<Byte>(text.length * 5 / 8)
+        var buffer = 0
+        var bits = 0
+        for (c in text) {
+            val value = ALPHABET.indexOf(c)
+            if (value < 0) return null
+            buffer = (buffer shl 5) or value
+            bits += 5
+            if (bits >= 8) {
+                out.add(((buffer shr (bits - 8)) and 0xFF).toByte())
+                bits -= 8
+            }
+        }
+        return out.toByteArray()
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
@@ -10,6 +10,14 @@ object SendSpinProtocol {
     const val ENDPOINT_PATH = "/sendspin"
 
     /**
+     * How long a pairing attempt may stay open before the client aborts it.
+     *
+     * "The client bounds each attempt with an attempt timeout measured from its
+     * first message (recommended 2 minutes)."
+     */
+    const val PAIR_ATTEMPT_TIMEOUT_MS = 120_000L
+
+    /**
      * Binary message header: 1 byte type + 8 bytes big-endian int64 timestamp.
      */
     const val BINARY_HEADER_SIZE_BYTES = 9
@@ -129,6 +137,8 @@ object SendSpinProtocol {
         const val SERVER_HELLO = "server/hello"
         const val SERVER_ACTIVATE = "server/activate"
         const val PAIR_ABORT = "pair/abort"
+        const val CLIENT_PAIR_FINALIZE = "client/pair-finalize"
+        const val SERVER_PAIR_FINALIZE = "server/pair-finalize"
         const val CLIENT_TIME = "client/time"
         const val SERVER_TIME = "server/time"
         const val CLIENT_STATE = "client/state"

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -1,5 +1,6 @@
 package com.sendspindroid.sendspin.protocol.message
 
+import com.sendspindroid.sendspin.crypto.Base64Url
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
@@ -149,6 +150,29 @@ object MessageBuilder {
             })
         }
         return message.toString()
+    }
+
+    /**
+     * Build `client/pair-finalize` for the Pairing PSK flow.
+     *
+     * `pairing.md#client--server-clientpair-finalize`: "In the Pairing PSK
+     * Flow, it starts the pairing attempt and is sent immediately after the
+     * `server/activate`, carrying the PSK directly."
+     *
+     * Exactly one of `long_term_psk` and `wrapped_psk` is ever present, and the
+     * wrapped form belongs to the PIN methods this client does not offer - so
+     * only the direct field is emitted here.
+     */
+    fun buildClientPairFinalize(longTermPsk: ByteArray): String {
+        require(longTermPsk.size == 32) {
+            "a Sendspin PSK is 32 bytes, got ${longTermPsk.size}"
+        }
+        return buildJsonObject {
+            put("type", SendSpinProtocol.MessageType.CLIENT_PAIR_FINALIZE)
+            put("payload", buildJsonObject {
+                put("long_term_psk", Base64Url.encode(longTermPsk))
+            })
+        }.toString()
     }
 
     /**


### PR DESCRIPTION
**The device now pairs.** Verified end to end against a live Music Assistant, reaching `trust_level: user` for the first time.

Closes #206. Also lands the token codec from #205 (the Settings display; #225 still owns the fuller pairing UI).

## The flow

`PairingPskFlow` is a pure state machine, because the two rules that matter are both about *whether* something is emitted:

**Never leak the secret to an unauthenticated channel.** A Sentinel-keyed session is encrypted but unauthenticated - handing it a fresh long-term PSK hands it to whoever is in the middle. The flow refuses *before generating anything*: on any category other than `PAIRING` it emits `pair/abort(method_not_supported)` and mints no secret at all. Three tests assert no `SendPairFinalize` appears anywhere in the returned actions.

**Persist only after the acknowledgement.** Writing earlier leaves the client holding a credential the server never stored, surfacing later as an unexplained `unauthorized`. A `server/activate` instead of the ack, a timeout, or a closed socket all end the attempt and persist nothing; a late ack is silently discarded.

A bug the tests caught during development: `discard()` zeroes the pending secret and ran *before* `PersistRecord` copied it, which would have stored 32 zero bytes as though pairing had succeeded. This is why the happy-path test asserts the persisted bytes equal the bytes *sent*, rather than merely that a record exists.

## Three defects found only on hardware

None were reachable by unit test, and each produced a silent close.

**1. `client/hello` was never re-asserted after a re-handshake.** `resetForRehandshake` cleared state and waited for `server/hello`, which arrived - then both sides waited. On the initial connection `client/hello` is sent from the handshake driver's `TransportReady` callback; a re-handshake produces no such event because there is no new driver.

**2. A pairing activation must be answered with `client/pair-finalize` and nothing else.** `resetForRehandshake` also clears `activationSeen`, so the post-promotion activation counts as *first* - correct, since roles must not be inherited across a trust change. But "first activation" also triggered `sendPlayerStateUpdate()` and `startTimeSync()`. We greeted the server with `client/state` while it sat in `_receive_pairing` awaiting exactly one message:

```
aiosendspin.noise.pairing.PairingError: malformed message awaiting ClientPairFinalizeMessage
```

Both MA builds failed identically, which had me suspecting message *shape*; the server traceback showed it was message *order*. Withholding those two costs nothing - a Pairing-PSK connection is granted no roles.

**3. The token had no way off the device.** Settings now renders it with a copy action.

## Token rendering

**Ungrouped, deliberately.** #191 confirmed against a live MA that its decoder trims only *surrounding* whitespace, so a hyphen inserted for legibility produces an opaque "not valid" error naming nothing about separators. Monospace, so `O` and `0` are distinguishable when read aloud.

**Never logged.** The token embeds the Pairing PSK, and logcat is readable by bug reports and other tooling. It leaves the ViewModel only by being drawn on screen.

`client/hello` is now logged whole rather than truncated at 500 characters - `supported_pair_methods` and `unpaired_access` sit past that cut, and they are exactly the fields that decide whether a server offers pairing. Nothing in it is secret.

## Verified

```
Re-handshake complete: psk=PAIRING trust=none
server/activate accepted: activities=[PAIRING]
Pairing: sending client/pair-finalize (32-byte PSK)
Paired with OraobU4leb48... (psk_id=4nZAk27CllL_1ldp5dQ7AzhQJ8LvV5crf8RfdFG-yAc)
Re-handshake starting (prior h=da2487d4)
Re-handshake complete: psk=LONG_TERM trust=user
server/activate accepted: roles=[player@v1, controller@v1, metadata@v1, artwork@v1]
```

Two chained promotions on one socket without closing it - Sentinel to Pairing PSK to long-term record - the second prologue being the first's `h`, which is the chained case the #223 golden vectors were built to prove. The record persisted mid-flow was visible to the very next PSK selection, because `pskCandidates()` reads the store on every call rather than caching at connect time.

18 tests written before the implementation. 722 app tests and the shared suite pass.

## Not included

`pair/abort` on the **receive** side and the full reason enum belong to #226; only the two reasons this flow emits are wired. The attempt-timeout job exists and is unit-tested but has not fired on device.
