### PR TITLE
feat(protocol): handle server/unpair across all three record branches

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -23,6 +23,7 @@ import com.sendspindroid.sendspin.crypto.PskCandidateSet
 import com.sendspindroid.sendspin.protocol.SendSpinHandshakeDriver
 import kotlinx.serialization.json.JsonObject
 import com.sendspindroid.sendspin.protocol.RehandshakeDriver
+import com.sendspindroid.sendspin.protocol.GoodbyeReason
 import com.sendspindroid.sendspin.protocol.SendSpinProtocolHandler
 import com.sendspindroid.sendspin.protocol.StreamConfig
 import com.sendspindroid.sendspin.protocol.TrackMetadata
@@ -166,6 +167,18 @@ class SendSpin(
          * that don't render audio.
          */
         fun onSyncMuteChanged(muted: Boolean) {}
+
+        /**
+         * The server dropped its pairing with this device.
+         *
+         * Without surfacing this, an unpair is indistinguishable from a network
+         * drop: the player simply stops appearing, and the app looks broken
+         * rather than deliberately disconnected.
+         *
+         * @param serverId null when a shared-PSK record was matched, whose
+         *   record is deliberately retained.
+         */
+        fun onUnpaired(serverId: String?) {}
     }
 
     /**
@@ -246,6 +259,17 @@ class SendSpin(
 
     // Reconnection state
     private val userInitiatedDisconnect = AtomicBoolean(false)
+
+    /**
+     * Set when the server unpairs us; blocks automatic reconnection only.
+     *
+     * Separate from [userInitiatedDisconnect] because the two answer different
+     * questions and are reported differently to the UI. Cleared when the user
+     * deliberately connects again, which is the only thing that can make
+     * reconnecting sensible: the credential the server dropped is gone, so
+     * every automatic attempt would just be refused.
+     */
+    private val suppressAutoReconnect = AtomicBoolean(false)
     private val reconnectAttempts = AtomicInteger(0)
     private val reconnecting = AtomicBoolean(false)
     private var reconnectJob: Job? = null  // Pending reconnect coroutine - cancelled on disconnect
@@ -515,6 +539,27 @@ class SendSpin(
         // client sends nothing further. The new record is already visible to
         // pskCandidates(), which reads the store on every call.
         Log.i(TAG, "Pairing complete with $serverId - awaiting the server's re-handshake")
+    }
+
+    /** The PSK that admitted this session; the re-handshake swaps it. */
+    override fun matchedPsk(): Psk? = matchedPsk
+
+    override fun onUnpaired(pskId: String, serverId: String?) {
+        Log.i(TAG, "Unpaired by ${serverId ?: "a server holding a shared PSK"} (psk_id=$pskId)")
+
+        // "Server should not auto-reconnect." On a client-initiated topology
+        // that guidance lands on us: reconnecting would just hand the server a
+        // credential it has dropped, once per backoff step, forever.
+        suppressAutoReconnect.set(true)
+
+        callback?.onUnpaired(serverId)
+    }
+
+    override fun closeConnectionAfterGoodbye() {
+        // closeAfterFlush, not close: close() cancels the connection job, and
+        // the sender coroutine is its child, so a goodbye still sitting in the
+        // outgoing channel dies with it.
+        transport?.closeAfterFlush(1000, "unpaired")
     }
 
     /**
@@ -1038,6 +1083,7 @@ class SendSpin(
         reconnectJob = null
 
         userInitiatedDisconnect.set(false)
+        suppressAutoReconnect.set(false)
         reconnectAttempts.set(0)
         reconnecting.set(false)
         waitingForNetwork.set(false)
@@ -1153,7 +1199,7 @@ class SendSpin(
         // Spec reason enum is another_server | shutdown | restart |
         // user_request. "restart" fits: we will reconnect (after the outer
         // loop re-selects the transport) and the server should auto-reconnect.
-        sendGoodbye("restart")
+        sendGoodbye(GoodbyeReason.RESTART)
         // Clear the transport listener BEFORE closing to prevent the async onClosed
         // callback from firing a second onDisconnected after we fire one synchronously below.
         transport?.setListener(null)
@@ -1178,7 +1224,7 @@ class SendSpin(
         stopTimeSync()
         reconnecting.set(false)
         waitingForNetwork.set(false)
-        sendGoodbye("user_request")
+        sendGoodbye(GoodbyeReason.USER_REQUEST)
         // Clear the transport listener BEFORE closing to prevent the async onClosed
         // callback from firing a second onDisconnected after we fire one synchronously below.
         transport?.setListener(null)
@@ -1409,6 +1455,11 @@ class SendSpin(
 
         if (userInitiatedDisconnect.get()) {
             Log.d(TAG, "Not reconnecting: user-initiated disconnect")
+            return
+        }
+
+        if (suppressAutoReconnect.get()) {
+            Log.i(TAG, "Not reconnecting: this server unpaired us")
             return
         }
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -5,6 +5,7 @@ import com.sendspindroid.sendspin.AdaptiveBufferPolicy
 import com.sendspindroid.sendspin.SendspinTimeFilter
 import com.sendspindroid.sendspin.crypto.NoiseCrypto
 import com.sendspindroid.sendspin.crypto.NoiseTransport
+import com.sendspindroid.sendspin.crypto.Psk
 import com.sendspindroid.sendspin.crypto.PskCategory
 import com.sendspindroid.sendspin.protocol.message.BinaryMessageParser
 import com.sendspindroid.sendspin.protocol.message.MessageBuilder
@@ -269,7 +270,15 @@ abstract class SendSpinProtocolHandler(
 
     /**
      * Send goodbye message before disconnecting.
+     *
+     * Note the [handshakeComplete] gate, which means "server/hello seen". A
+     * goodbye is legitimate before that, as soon as the Noise handshake
+     * finishes, so this swallows one silently. `server/unpair` sidesteps it by
+     * sending its own goodbye - it has to sequence the send against the close
+     * anyway - but item 2.9's `concurrent_attempt` will need this relaxed.
      */
+    protected fun sendGoodbye(reason: GoodbyeReason) = sendGoodbye(reason.wire)
+
     protected fun sendGoodbye(reason: String) {
         if (!handshakeComplete) return
         sendProtocolMessage(MessageBuilder.buildGoodbye(reason))
@@ -692,13 +701,29 @@ abstract class SendSpinProtocolHandler(
             return
         }
         // encodeJson takes the send mutex, so this has to be in a coroutine.
-        getCoroutineScope().launch {
-            try {
-                codec.encodeJson(text).forEach { sendBinaryFrame(it) }
-            } catch (e: Exception) {
-                Log.e(tag, "Failed to encrypt outbound message", e)
-                onProtocolFailure("outbound encryption failed: ${e.message}")
-            }
+        getCoroutineScope().launch { sendProtocolMessageAwaiting(text) }
+    }
+
+    /**
+     * [sendProtocolMessage], but the caller can tell when the frames have been
+     * handed to the transport.
+     *
+     * Needed wherever something must happen strictly after a message is on the
+     * wire - closing the connection after a goodbye, for instance. The
+     * fire-and-forget version returns while the encrypt is still queued, so
+     * "send, then close" written in that order does not execute in it.
+     */
+    protected suspend fun sendProtocolMessageAwaiting(text: String) {
+        val codec = wireCodec
+        if (codec == null) {
+            sendTextMessage(text)
+            return
+        }
+        try {
+            codec.encodeJson(text).forEach { sendBinaryFrame(it) }
+        } catch (e: Exception) {
+            Log.e(tag, "Failed to encrypt outbound message", e)
+            onProtocolFailure("outbound encryption failed: ${e.message}")
         }
     }
 
@@ -762,6 +787,11 @@ abstract class SendSpinProtocolHandler(
                 // JSON message inside the current channel, which is why it is
                 // dispatched here and not by the cleartext handshake driver.
                 SendSpinProtocol.MessageType.NOISE_HANDSHAKE -> onRehandshakeMessage(payload)
+
+                // Deliberately not gated on `activities`, and deliberately
+                // discarding the payload: "Valid at any time regardless of the
+                // current `activities`", and the message has no fields.
+                SendSpinProtocol.MessageType.SERVER_UNPAIR -> handleServerUnpair()
 
                 SendSpinProtocol.MessageType.SERVER_PAIR_FINALIZE -> handleServerPairFinalize()
                 SendSpinProtocol.MessageType.SERVER_HELLO -> handleServerHello(payload)
@@ -958,6 +988,100 @@ abstract class SendSpinProtocolHandler(
 
     /** Surfaced for the pairing UI (#225). */
     protected open fun onPaired(serverId: String) {}
+
+    // ========== server/unpair (item 2.7) ==========
+
+    /**
+     * The PSK that admitted this connection, or null before the handshake.
+     *
+     * This is the single source of truth for the session's trust level, and
+     * `server/unpair` must read it rather than ask "do we hold a record for
+     * this server?". The two differ in a case that matters: during a pairing
+     * handshake we may well hold a record for that same server from a previous
+     * pairing, while the current session was admitted by the Pairing PSK and is
+     * `trust_level: none`. Deciding on the record would delete it.
+     *
+     * A re-handshake replaces it at the key swap, so an unpair arriving just
+     * after a promotion sees the post-swap value.
+     */
+    protected open fun matchedPsk(): Psk? = null
+
+    /** The record this connection dropped. Drives the UI and reconnect policy. */
+    protected open fun onUnpaired(pskId: String, serverId: String?) {}
+
+    /**
+     * Close the connection once the goodbye is on the wire.
+     *
+     * Separate from an ordinary close because the frame must actually be
+     * flushed first; see [handleServerUnpair].
+     */
+    protected open fun closeConnectionAfterGoodbye() {}
+
+    /** One unpair per connection; a repeat is a no-op. */
+    private var unpairHandled = false
+
+    /**
+     * `messaging.md#server--client-serverunpair`: "Remove the matched pairing
+     * record, send `client/goodbye` reason `'unpaired'`, and close the
+     * connection."
+     *
+     * Takes no payload: the message has no fields, and ignoring whatever
+     * arrives is exactly the required tolerance for unknown ones.
+     */
+    protected fun handleServerUnpair() {
+        val matched = matchedPsk()
+
+        // "If the connection's `trust_level` is `'none'` (e.g., an in-flight
+        // pairing handshake), ignore the message and continue unchanged." Not
+        // an error, and specifically not a close: the connection carries on.
+        if (matched == null || matched.category != PskCategory.LONG_TERM) {
+            Log.i(tag, "server/unpair at trust_level none (psk=${matched?.category}) - ignoring")
+            return
+        }
+
+        if (unpairHandled) {
+            Log.d(tag, "server/unpair already handled on this connection - ignoring")
+            return
+        }
+
+        if (matched.serverId == null) {
+            // "If the matched record is a shared-PSK record ... the client MUST
+            // NOT remove it." The same PSK may authenticate other servers, and
+            // none of them asked to be unpaired. Wholesale removal is
+            // management/remove-record's job.
+            Log.i(tag, "server/unpair matched shared-PSK record ${matched.pskId} - retaining it")
+        } else {
+            val store = trustStore()
+            if (store == null) {
+                Log.e(tag, "server/unpair with no trust store - cannot drop the record")
+                return
+            }
+            // Durable before we say a word. A crash between the two must not
+            // leave a record the server has already forgotten, and telling the
+            // server we unpaired while the record survives is worse still: the
+            // device keeps authenticating with a credential that is gone, and
+            // it looks like a working pairing until the next handshake fails.
+            try {
+                store.removeRecord(matched.pskId)
+            } catch (e: Exception) {
+                Log.e(tag, "server/unpair could not remove record ${matched.pskId}", e)
+                return
+            }
+            Log.i(tag, "server/unpair removed record ${matched.pskId} for ${matched.serverId}")
+        }
+
+        unpairHandled = true
+        onUnpaired(matched.pskId, matched.serverId)
+
+        // The goodbye has to reach the wire before the close, and on the
+        // encrypted path sending is a suspending encrypt. Sequencing them in
+        // one coroutine is what makes "send then close" true rather than
+        // merely written in that order.
+        getCoroutineScope().launch {
+            sendProtocolMessageAwaiting(MessageBuilder.buildGoodbye(GoodbyeReason.UNPAIRED))
+            closeConnectionAfterGoodbye()
+        }
+    }
 
     protected fun handleServerPairFinalize() {
         runPairingActions(PairingEvent.ServerPairFinalize)

--- a/android/app/src/test/java/com/sendspindroid/sendspin/protocol/ServerUnpairTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/protocol/ServerUnpairTest.kt
@@ -1,0 +1,340 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.SendspinTimeFilter
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.crypto.PskRecord
+import com.sendspindroid.sendspin.crypto.TrustStore
+import com.sendspindroid.sendspin.protocol.message.MessageBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * `server/unpair`.
+ *
+ * `messaging.md#server--client-serverunpair`: "Sent by a paired server to drop
+ * its own pairing record from the client. Valid at any time regardless of the
+ * current `activities`; does not require `'management'` in the activity set."
+ *
+ * Three branches that behave differently, and the middle one is a MUST NOT:
+ *
+ * | matched PSK                        | record       | goodbye | close |
+ * |------------------------------------|--------------|---------|-------|
+ * | long-term, bound to a `server_id`  | removed      | yes     | yes   |
+ * | long-term, shared (no `server_id`) | **retained** | yes     | yes   |
+ * | Sentinel or Pairing (trust none)   | untouched    | no      | no    |
+ *
+ * Treating all records alike would delete a shared PSK that may authenticate
+ * other servers, none of which asked to be unpaired.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerUnpairTest {
+
+    private val unpair = """{"type":"server/unpair"}"""
+
+    // ========== Stored-pubkey record: removed ==========
+
+    @Test
+    fun `a bound record is removed`() {
+        val (handler, psk) = handlerPairedWith(serverId = "srv1")
+
+        handler.handleTextMessageForTest(unpair)
+
+        assertNull(handler.store.findByPskId(psk.pskId))
+    }
+
+    @Test
+    fun `unpairing sends exactly one goodbye with reason unpaired`() {
+        val (handler, _) = handlerPairedWith(serverId = "srv1")
+
+        handler.handleTextMessageForTest(unpair)
+
+        val goodbyes = handler.sent.filter { it.type() == "client/goodbye" }
+        assertEquals(1, goodbyes.size)
+        assertEquals("unpaired", goodbyes.single().reason())
+    }
+
+    @Test
+    fun `the goodbye is sent before the connection is closed`() {
+        val (handler, _) = handlerPairedWith(serverId = "srv1")
+
+        handler.handleTextMessageForTest(unpair)
+
+        // If the frame never lands the server applies its no-goodbye
+        // heuristic, which for a playback connection means "assume restart,
+        // reconnect" - the exact opposite of unpairing.
+        assertEquals(listOf("send:client/goodbye", "close"), handler.events)
+    }
+
+    // ========== Shared-PSK record: retained ==========
+
+    @Test
+    fun `a shared record is NOT removed`() {
+        val (handler, psk) = handlerPairedWith(serverId = null)
+
+        handler.handleTextMessageForTest(unpair)
+
+        assertNotNull(
+            "a shared-PSK record may back other servers; removing it is a MUST NOT",
+            handler.store.findByPskId(psk.pskId),
+        )
+    }
+
+    @Test
+    fun `a shared record still gets a goodbye and a close`() {
+        val (handler, _) = handlerPairedWith(serverId = null)
+
+        handler.handleTextMessageForTest(unpair)
+
+        assertEquals(listOf("send:client/goodbye", "close"), handler.events)
+        assertEquals("unpaired", handler.sent.single().reason())
+    }
+
+    // ========== Trust level none: ignored ==========
+
+    @Test
+    fun `a sentinel session ignores the unpair entirely`() {
+        val handler = handlerMatching(Psk(ByteArray(32) { 1 }, PskCategory.SENTINEL))
+        val other = handler.store.seed(Psk(ByteArray(32) { 9 }, PskCategory.LONG_TERM, "srv1"))
+
+        handler.handleTextMessageForTest(unpair)
+
+        assertEquals(emptyList<String>(), handler.events)
+        assertNotNull(handler.store.findByPskId(other))
+    }
+
+    @Test
+    fun `a pairing session ignores the unpair entirely`() {
+        // The dangerous case: a prior pairing may well have left a record for
+        // this very server, but THIS session was admitted by the Pairing PSK
+        // and is trust_level none. Deciding the branch on "do we hold a record
+        // for this server_id" rather than on the matched PSK deletes it.
+        val handler = handlerMatching(Psk(ByteArray(32) { 2 }, PskCategory.PAIRING))
+        val existing = handler.store.seed(Psk(ByteArray(32) { 9 }, PskCategory.LONG_TERM, "srv1"))
+
+        handler.handleTextMessageForTest(unpair)
+
+        assertEquals(emptyList<String>(), handler.events)
+        assertNotNull(handler.store.findByPskId(existing))
+    }
+
+    @Test
+    fun `an ignored unpair leaves the connection usable`() {
+        val handler = handlerMatching(Psk(ByteArray(32) { 1 }, PskCategory.SENTINEL))
+
+        handler.handleTextMessageForTest(unpair)
+        handler.handleTextMessageForTest("""{"type":"server/state","payload":{}}""")
+
+        assertFalse("the connection must continue unchanged", handler.events.contains("close"))
+    }
+
+    // ========== Valid at any time ==========
+
+    @Test
+    fun `unpair is handled before the first server hello`() {
+        // The likeliest way to gate this by accident. `handshakeComplete` is
+        // set by server/hello, and sendGoodbye used to return early without it,
+        // so an unpair arriving straight after the Noise handshake would be
+        // swallowed with no log and no goodbye.
+        val (handler, psk) = handlerPairedWith(serverId = "srv1", handshakeComplete = false)
+
+        handler.handleTextMessageForTest(unpair)
+
+        assertNull(handler.store.findByPskId(psk.pskId))
+        assertEquals(listOf("send:client/goodbye", "close"), handler.events)
+    }
+
+    // ========== Payload tolerance ==========
+
+    @Test
+    fun `unknown payload fields are ignored`() {
+        val (handler, psk) = handlerPairedWith(serverId = "srv1")
+
+        handler.handleTextMessageForTest("""{"type":"server/unpair","payload":{"future":1}}""")
+
+        assertNull(handler.store.findByPskId(psk.pskId))
+        assertEquals(listOf("send:client/goodbye", "close"), handler.events)
+    }
+
+    // ========== Idempotency ==========
+
+    @Test
+    fun `a second unpair is a no-op`() {
+        val (handler, _) = handlerPairedWith(serverId = "srv1")
+
+        handler.handleTextMessageForTest(unpair)
+        handler.handleTextMessageForTest(unpair)
+
+        assertEquals(1, handler.sent.count { it.type() == "client/goodbye" })
+        assertEquals(1, handler.store.removals)
+    }
+
+    // ========== Fail closed ==========
+
+    @Test
+    fun `a store that cannot persist the removal sends no goodbye`() {
+        val (handler, _) = handlerPairedWith(serverId = "srv1")
+        handler.store.failRemovals = true
+
+        handler.handleTextMessageForTest(unpair)
+
+        // Telling the server we unpaired while the record survives leaves the
+        // device authenticating with a credential the server has dropped - and
+        // it looks like a working pairing until the next handshake fails.
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    @Test
+    fun `the unpaired callback reports the record it acted on`() {
+        val (handler, psk) = handlerPairedWith(serverId = "srv1")
+
+        handler.handleTextMessageForTest(unpair)
+
+        assertEquals(listOf(psk.pskId to "srv1"), handler.unpaired)
+    }
+
+    // ========== Helpers ==========
+
+    private fun handlerPairedWith(
+        serverId: String?,
+        handshakeComplete: Boolean = true,
+    ): Pair<UnpairTestHandler, Psk> {
+        val psk = Psk(ByteArray(32) { 7 }, PskCategory.LONG_TERM, serverId)
+        val handler = handlerMatching(psk, handshakeComplete)
+        handler.store.seed(psk)
+        return handler to psk
+    }
+
+    private fun handlerMatching(
+        psk: Psk,
+        handshakeComplete: Boolean = true,
+    ): UnpairTestHandler {
+        val handler = UnpairTestHandler(psk)
+        if (handshakeComplete) handler.setHandshakeCompleteForTest()
+        return handler
+    }
+
+    private fun String.type(): String? =
+        Json.parseToJsonElement(this).jsonObject["type"]?.jsonPrimitive?.content
+
+    private fun String.reason(): String? =
+        Json.parseToJsonElement(this).jsonObject["payload"]
+            ?.jsonObject?.get("reason")?.jsonPrimitive?.content
+}
+
+/**
+ * A handler whose session matched [matched], recording what reaches the wire.
+ *
+ * The scope is unconfined so a coroutine launched by the handler runs to its
+ * first real suspension inline - which is what makes the send/close ordering
+ * assertions deterministic without a scheduler dance.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class UnpairTestHandler(
+    private val matched: Psk,
+) : SendSpinProtocolHandler("UnpairTest") {
+
+    val store = FakeTrustStore()
+    val sent = mutableListOf<String>()
+    val unpaired = mutableListOf<Pair<String, String?>>()
+
+    /** Sends and the close, in the order they happened. */
+    val events = mutableListOf<String>()
+
+    private val scope = CoroutineScope(UnconfinedTestDispatcher())
+    private val timeFilter = SendspinTimeFilter()
+
+    fun setHandshakeCompleteForTest() { handshakeComplete = true }
+
+    fun handleTextMessageForTest(text: String) = handleTextMessage(text)
+
+    override fun matchedPsk(): Psk = matched
+
+    override fun trustStore(): TrustStore = store
+
+    override fun onUnpaired(pskId: String, serverId: String?) {
+        unpaired.add(pskId to serverId)
+    }
+
+    override fun closeConnectionAfterGoodbye() {
+        events.add("close")
+    }
+
+    override fun sendTextMessage(text: String) {
+        sent.add(text)
+        val type = Json.parseToJsonElement(text).jsonObject["type"]?.jsonPrimitive?.content
+        events.add("send:$type")
+    }
+
+    override fun sendBinaryFrame(bytes: ByteArray) = Unit
+
+    override fun getCoroutineScope(): CoroutineScope = scope
+
+    override fun getTimeFilter(): SendspinTimeFilter = timeFilter
+
+    override fun isLowMemoryMode(): Boolean = false
+    override fun getClientId(): String = "test-client"
+    override fun getDeviceName(): String = "Test"
+    override fun getManufacturer(): String = "Test"
+    override fun getSoftwareVersion(): String = "0.0.0"
+    override fun getSupportedFormats(): List<MessageBuilder.FormatEntry> = emptyList()
+
+    override fun onHandshakeComplete(serverName: String, serverId: String) = Unit
+    override fun onMetadataUpdate(metadata: TrackMetadata) = Unit
+    override fun onPlaybackStateChanged(state: String) = Unit
+    override fun onVolumeCommand(volume: Int) = Unit
+    override fun onMuteCommand(muted: Boolean) = Unit
+    override fun onGroupUpdate(info: GroupInfo) = Unit
+    override fun onStreamStart(config: StreamConfig) = Unit
+    override fun onStreamClear() = Unit
+    override fun onStreamEnd() = Unit
+    override fun onAudioChunk(timestampMicros: Long, audioData: ByteArray) = Unit
+    override fun onArtwork(channel: Int, payload: ByteArray) = Unit
+    override fun onSyncOffsetApplied(offsetMs: Double, source: String) = Unit
+    override fun onSyncMuteChanged(muted: Boolean) = Unit
+}
+
+/** In-memory [TrustStore] that can count and fail removals. */
+class FakeTrustStore : TrustStore {
+
+    private val records = mutableMapOf<String, PskRecord>()
+
+    var removals = 0
+        private set
+
+    var failRemovals = false
+
+    /** @return the seeded record's `psk_id`. */
+    fun seed(psk: Psk): String {
+        records[psk.pskId] = PskRecord(psk.pskId, psk.bytes, psk.serverId)
+        return psk.pskId
+    }
+
+    override fun listRecords(): List<PskRecord> = records.values.toList()
+
+    override fun findByPskId(pskId: String): PskRecord? = records[pskId]
+
+    override fun addRecord(psk: ByteArray, serverId: String?): TrustStore.AddRecordResult =
+        throw UnsupportedOperationException("not used by these tests")
+
+    override fun removeRecord(pskId: String): Boolean {
+        if (failRemovals) throw IllegalStateException("storage unavailable")
+        removals++
+        return records.remove(pskId) != null
+    }
+
+    override fun markUsed(pskId: String) = Unit
+
+    override fun candidates(): List<Psk> = records.values.map { it.toPsk() }
+
+    override val storageIsEncrypted: Boolean get() = true
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/GoodbyeReasonTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/GoodbyeReasonTest.kt
@@ -1,0 +1,57 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.protocol.message.MessageBuilder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * `client/goodbye` reasons.
+ *
+ * `messaging.md#client--server-clientgoodbye` defines a closed set. The server
+ * reads the reason to decide whether to reconnect, so an unrecognised or
+ * misspelled value is not a cosmetic problem: it falls back to the
+ * no-goodbye heuristic and the server reconnects to a client that just told it
+ * to stop.
+ */
+class GoodbyeReasonTest {
+
+    @Test
+    fun theEnumIsExactlyTheSpecSet() {
+        // Pinned deliberately. A new reason must be added to the spec first,
+        // and a removed one must not linger as a value we can still send.
+        assertEquals(
+            setOf(
+                "another_server",
+                "shutdown",
+                "restart",
+                "user_request",
+                "unauthorized",
+                "pairing_required",
+                "concurrent_attempt",
+                "unpaired",
+            ),
+            GoodbyeReason.entries.map { it.wire }.toSet(),
+        )
+    }
+
+    @Test
+    fun everyReasonHasADistinctWireValue() {
+        assertEquals(GoodbyeReason.entries.size, GoodbyeReason.entries.map { it.wire }.toSet().size)
+    }
+
+    @Test
+    fun buildGoodbyeCarriesTheReasonAndNothingElse() {
+        val json = Json.parseToJsonElement(
+            MessageBuilder.buildGoodbye(GoodbyeReason.UNPAIRED)
+        ).jsonObject
+
+        assertEquals("client/goodbye", json["type"]?.jsonPrimitive?.content)
+        val payload = json["payload"]!!.jsonObject
+        assertEquals("unpaired", payload["reason"]?.jsonPrimitive?.content)
+        assertEquals(setOf("reason"), payload.keys)
+        assertEquals(setOf("type", "payload"), json.keys)
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/GoodbyeReason.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/GoodbyeReason.kt
@@ -1,0 +1,43 @@
+package com.sendspindroid.sendspin.protocol
+
+/**
+ * Why the client is closing the connection.
+ *
+ * `messaging.md#client--server-clientgoodbye` defines this set, and the server
+ * reads it to decide whether to reconnect. That makes a misspelled or invented
+ * value worse than sending nothing coherent: the server falls back to the
+ * no-goodbye heuristic and reconnects to a client that just asked it not to.
+ *
+ * An enum rather than string literals so the set can be pinned by a test and so
+ * a call site cannot invent a reason - see `GoodbyeReasonTest`.
+ */
+enum class GoodbyeReason(val wire: String) {
+
+    /** Switching to a different server. */
+    ANOTHER_SERVER("another_server"),
+
+    /** The client is shutting down and will not return. */
+    SHUTDOWN("shutdown"),
+
+    /** The client is restarting and expects to reconnect. */
+    RESTART("restart"),
+
+    /** The user asked to disconnect. */
+    USER_REQUEST("user_request"),
+
+    /** The server is not authorised to talk to this client. */
+    UNAUTHORIZED("unauthorized"),
+
+    /** The client requires a pairing that has not happened. */
+    PAIRING_REQUIRED("pairing_required"),
+
+    /** Another connection attempt superseded this one. */
+    CONCURRENT_ATTEMPT("concurrent_attempt"),
+
+    /**
+     * The client has processed `server/unpair` from this server.
+     *
+     * "Server should not auto-reconnect."
+     */
+    UNPAIRED("unpaired"),
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
@@ -146,6 +146,12 @@ object SendSpinProtocol {
         const val CLIENT_COMMAND = "client/command"
         const val SERVER_COMMAND = "server/command"
         const val CLIENT_GOODBYE = "client/goodbye"
+
+        /**
+         * Valid at any time regardless of `activities`; notably it does NOT
+         * require `'management'`, so it must never be gated on the activity set.
+         */
+        const val SERVER_UNPAIR = "server/unpair"
         const val GROUP_UPDATE = "group/update"
         const val STREAM_START = "stream/start"
         const val STREAM_END = "stream/end"

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -1,6 +1,7 @@
 package com.sendspindroid.sendspin.protocol.message
 
 import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.protocol.GoodbyeReason
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
@@ -186,6 +187,10 @@ object MessageBuilder {
         put("type", SendSpinProtocol.MessageType.PAIR_ABORT)
         put("payload", buildJsonObject { put("reason", reason) })
     }.toString()
+
+    /** The typed form. Prefer this: a bare string can invent a reason. */
+    fun buildGoodbye(reason: GoodbyeReason): String =
+        buildGoodbye(reason.wire)
 
     fun buildGoodbye(reason: String): String {
         val message = buildJsonObject {

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/BaseWebSocketTransport.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/BaseWebSocketTransport.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
@@ -41,6 +42,9 @@ abstract class BaseWebSocketTransport(
 ) : SendSpinTransport {
 
     companion object {
+        /** A goodbye is best-effort; a wedged socket must not stall the close. */
+        private const val FLUSH_TIMEOUT_MS = 500L
+
         /**
          * Create a default Ktor HttpClient configured for WebSocket connections.
          *
@@ -64,6 +68,10 @@ abstract class BaseWebSocketTransport(
 
     // Channel for outgoing messages (text or binary)
     private var outgoingChannel: Channel<OutgoingMessage>? = null
+
+    // Held so closeAfterFlush can wait for the queue to drain. The sender is a
+    // child of connectionJob, so cancelling that kills it mid-queue.
+    private var senderJob: Job? = null
 
     private sealed class OutgoingMessage {
         data class Text(val text: String) : OutgoingMessage()
@@ -165,7 +173,7 @@ abstract class BaseWebSocketTransport(
                     listener?.onConnected()
 
                     // Launch sender coroutine
-                    val senderJob = launch {
+                    val sender = launch {
                         try {
                             for (msg in sendChannel) {
                                 when (msg) {
@@ -179,6 +187,7 @@ abstract class BaseWebSocketTransport(
                             // Coroutine cancelled
                         }
                     }
+                    senderJob = sender
 
                     // Receive loop
                     try {
@@ -211,7 +220,7 @@ abstract class BaseWebSocketTransport(
                         // Normal cancellation during close
                     }
 
-                    senderJob.cancel()
+                    sender.cancel()
 
                     // Session ended normally
                     val reason = closeReason.await()
@@ -258,6 +267,31 @@ abstract class BaseWebSocketTransport(
         outgoingChannel?.close()
         connectionJob?.cancel()
         connectionJob = null
+    }
+
+    /**
+     * Closing the channel stops new sends but leaves what is already buffered
+     * deliverable, so the sender's `for (msg in channel)` loop drains and then
+     * completes on its own. Waiting for that completion before cancelling is
+     * the whole difference from [close], which cancels the sender's parent and
+     * takes the queue down with it.
+     *
+     * Bounded: a wedged socket must not hold the close open indefinitely, and a
+     * goodbye is best-effort by nature.
+     */
+    override fun closeAfterFlush(code: Int, reason: String) {
+        Log.d(tag, "Closing WebSocket after flush: code=$code reason=$reason")
+        val sender = senderJob
+        outgoingChannel?.close()
+        if (sender == null) {
+            close(code, reason)
+            return
+        }
+        scope.launch {
+            val drained = withTimeoutOrNull(FLUSH_TIMEOUT_MS) { sender.join() } != null
+            if (!drained) Log.w(tag, "Outgoing queue did not drain in ${FLUSH_TIMEOUT_MS}ms")
+            close(code, reason)
+        }
     }
 
     override fun destroy() {

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/SendSpinTransport.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/transport/SendSpinTransport.kt
@@ -60,6 +60,19 @@ interface SendSpinTransport {
     fun close(code: Int = 1000, reason: String = "")
 
     /**
+     * Close, but let already-queued frames reach the wire first.
+     *
+     * [send] only *queues*; [close] can then discard what it queued. That
+     * matters for exactly one kind of message: the last one. A `client/goodbye`
+     * that never lands leaves the server applying its no-goodbye heuristic -
+     * for a playback connection, "assume restart and reconnect" - which is the
+     * opposite of what every goodbye reason asks for.
+     *
+     * Defaults to [close] for transports that cannot distinguish the two.
+     */
+    fun closeAfterFlush(code: Int = 1000, reason: String = "") = close(code, reason)
+
+    /**
      * Release all resources associated with this transport.
      * Should be called when the transport is no longer needed.
      */


### PR DESCRIPTION
Closes #224.

A paired server had no way to tell this client to drop its record. Remove the player in Music Assistant and the tablet kept a record bound to that `server_id`, kept offering it, and failed PSK selection on every reconnect - with no exit but clearing app data.

## The three branches

The middle one is a MUST NOT, and treating all records alike would delete credentials for servers that never asked to be unpaired.

| matched PSK | record | goodbye | close |
|---|---|---|---|
| long-term, bound to a `server_id` | removed | yes | yes |
| long-term, shared (no `server_id`) | **retained** | yes | yes |
| Sentinel or Pairing (`trust_level: none`) | untouched | no | no |

The branch is chosen from the PSK that admitted the session, never from "do we hold a record for this server". The two differ in a case that loses data: during a pairing handshake the client may well hold a record for that same server from an earlier pairing, while *this* session is `trust_level: none`. There is a test for exactly that.

Removal is durable before the goodbye is sent, and a store that cannot persist sends nothing at all. Claiming to have unpaired while the record survives leaves the device authenticating with a credential the server dropped, and it looks like a working pairing until the next handshake.

## Two silent ordering hazards

Both would have produced a client that looks correct and behaves backwards.

**`close()` discards queued frames.** It cancels the connection job, and the sender coroutine is its child, so a goodbye still sitting in the outgoing channel died with it. The server would then apply its no-goodbye heuristic - for a playback connection, "assume `restart` and reconnect" - the exact opposite of unpairing. Adds `SendSpinTransport.closeAfterFlush`, which drains the queue with a bounded 500 ms wait before cancelling, and defaults to `close()` for transports that cannot tell the two apart.

**`sendProtocolMessage` returns before the frame exists.** On the encrypted path it launches a coroutine to encrypt, so "send, then close" written in that order does not execute in it. Adds a suspending variant so the unpair can sequence the two for real.

## Verification

16 tests. Both key behaviours mutation-checked:

- Removing the shared-PSK branch fails only the MUST NOT test.
- Reordering the send and close fails four ordering tests.

`GoodbyeReason` is pinned by a test to exactly the eight spec strings, and the two string-literal call sites now use it.

**Not verified on a real socket:** the drain inside `BaseWebSocketTransport`. It needs a live WebSocket, and there is no Ktor server dependency here. More to the point, `server/unpair` is not implemented in `aiosendspin` 9.1.0 at all - zero occurrences - so neither Music Assistant nor the local dev server can send one. There is currently nothing to receive it from. The handler-level sequencing is tested; the transport-level flush rests on reading the cancellation semantics.

## Related finding

Verifying this turned up why MA's device-management dialog hangs: it re-activates into `['management']` and asks for `management/get-pairing-config`, which is unhandled, so MA waits 10 s and closes. Evidence recorded on #228. That dialog is the entry point to MA's device management UI, so anything behind it - including whatever unpair action lives there - is unreachable until #227/#228 land.
