### PR TITLE
feat(pairing): pair/abort in both directions, with the attempt timeout

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -555,7 +555,7 @@ class SendSpin(
         callback?.onUnpaired(serverId)
     }
 
-    override fun closeConnectionAfterGoodbye() {
+    override fun closeConnectionAfterFlush() {
         // closeAfterFlush, not close: close() cancels the connection job, and
         // the sender coroutine is its child, so a goodbye still sitting in the
         // outgoing channel dies with it.

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -13,6 +13,7 @@ import com.sendspindroid.sendspin.protocol.message.MessageParser
 import com.sendspindroid.sendspin.protocol.timesync.TimeSyncManager
 import kotlinx.coroutines.CoroutineScope
 import com.sendspindroid.sendspin.crypto.TrustStore
+import com.sendspindroid.sendspin.pairing.PairAbortReason
 import com.sendspindroid.sendspin.pairing.PairingAction
 import com.sendspindroid.sendspin.pairing.PairingEvent
 import com.sendspindroid.sendspin.pairing.PairingPskFlow
@@ -793,6 +794,7 @@ abstract class SendSpinProtocolHandler(
                 // current `activities`", and the message has no fields.
                 SendSpinProtocol.MessageType.SERVER_UNPAIR -> handleServerUnpair()
 
+                SendSpinProtocol.MessageType.PAIR_ABORT -> handlePairAbort(payload)
                 SendSpinProtocol.MessageType.SERVER_PAIR_FINALIZE -> handleServerPairFinalize()
                 SendSpinProtocol.MessageType.SERVER_HELLO -> handleServerHello(payload)
                 SendSpinProtocol.MessageType.SERVER_ACTIVATE -> handleServerActivate(payload)
@@ -963,11 +965,54 @@ abstract class SendSpinProtocolHandler(
     }
 
     /**
-     * Send `pair/abort`. Item 2.9 (#226) owns the full reason enum and the
-     * attempt state machine; this is the one path 1.6 can already reach.
+     * Send `pair/abort`.
+     *
+     * "With reason `concurrent_attempt` the sender closes the connection after
+     * sending, otherwise the connection stays open." The close is the sender's
+     * job only - see [handlePairAbort] for the receiving side, which never
+     * closes.
+     *
+     * The send and the close are sequenced in one coroutine for the same reason
+     * the unpair goodbye is: `sendProtocolMessage` returns while the encrypt is
+     * still queued, so a close issued after it can outrun the frame.
+     */
+    protected fun sendPairAbort(reason: String) {
+        Log.w(tag, "Pairing aborted (sent): reason=$reason")
+        val closes = reason in PairAbortReason.CLOSES_CONNECTION
+        getCoroutineScope().launch {
+            sendProtocolMessageAwaiting(MessageBuilder.buildPairAbort(reason))
+            if (closes) closeConnectionAfterFlush()
+        }
+    }
+
+    /**
+     * Kept as an override point for the legacy call sites in 1.6's activation
+     * handling, which abort before any attempt exists.
      */
     protected open fun onPairAbort(reason: String) {
-        sendProtocolMessage(MessageBuilder.buildPairAbort(reason))
+        sendPairAbort(reason)
+    }
+
+    /**
+     * `pair/abort` from the server.
+     *
+     * Never closes the connection, for any reason including
+     * `concurrent_attempt`: the spec makes the *sender* close, and closing here
+     * too would race the peer's close and report the wrong reason for it.
+     *
+     * The reason is passed through unvalidated on purpose. A reason we do not
+     * recognise still means the peer has abandoned the attempt, and treating it
+     * as a protocol error would leave us waiting on an attempt that is over.
+     */
+    protected fun handlePairAbort(payload: JsonObject?) {
+        val reason = payload?.get("reason")?.jsonPrimitive?.contentOrNull ?: "unspecified"
+        Log.w(tag, "Pairing aborted (received): reason=$reason")
+        runPairingActions(PairingEvent.PairAbortReceived(reason))
+    }
+
+    /** The operator cancelled pairing from the UI. Leaves the connection open. */
+    fun cancelPairing() {
+        runPairingActions(PairingEvent.UserCancelled)
     }
 
     // ========== Pairing PSK flow (item 2.5) ==========
@@ -1015,7 +1060,7 @@ abstract class SendSpinProtocolHandler(
      * Separate from an ordinary close because the frame must actually be
      * flushed first; see [handleServerUnpair].
      */
-    protected open fun closeConnectionAfterGoodbye() {}
+    protected open fun closeConnectionAfterFlush() {}
 
     /** One unpair per connection; a repeat is a no-op. */
     private var unpairHandled = false
@@ -1079,7 +1124,7 @@ abstract class SendSpinProtocolHandler(
         // merely written in that order.
         getCoroutineScope().launch {
             sendProtocolMessageAwaiting(MessageBuilder.buildGoodbye(GoodbyeReason.UNPAIRED))
-            closeConnectionAfterGoodbye()
+            closeConnectionAfterFlush()
         }
     }
 
@@ -1105,10 +1150,7 @@ abstract class SendSpinProtocolHandler(
                     )
                 }
 
-                is PairingAction.SendPairAbort -> {
-                    Log.w(tag, "Pairing aborted: ${action.reason}")
-                    onPairAbort(action.reason)
-                }
+                is PairingAction.SendPairAbort -> sendPairAbort(action.reason)
 
                 is PairingAction.PersistRecord -> persistPairingRecord(action.psk)
 

--- a/android/app/src/test/java/com/sendspindroid/sendspin/protocol/PairAbortTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/protocol/PairAbortTest.kt
@@ -1,0 +1,314 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.SendspinTimeFilter
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.crypto.TrustStore
+import com.sendspindroid.sendspin.pairing.PairAbortReason
+import com.sendspindroid.sendspin.protocol.message.MessageBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `pair/abort`, both directions, and the attempt timeout that bounds every
+ * attempt.
+ *
+ * `pairing.md#client--server-pairabort`: "With reason `concurrent_attempt` the
+ * sender closes the connection after sending, otherwise the connection stays
+ * open. A `pair/abort` received after the receiver has itself ended the attempt
+ * has no effect."
+ *
+ * The two behaviours worth guarding are asymmetric and easy to invert: only the
+ * *sender* of `concurrent_attempt` closes, and a received abort never closes
+ * anything.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PairAbortTest {
+
+    private val pairingActivation =
+        """{"type":"server/activate","payload":{"activities":["pairing"],"pairing":{"method":"pairing_psk"}}}"""
+
+    // ========== Sending ==========
+
+    @Test
+    fun `concurrent_attempt is sent and then closes the connection`() {
+        val handler = handler()
+
+        handler.sendPairAbortForTest(PairAbortReason.CONCURRENT_ATTEMPT)
+        handler.scope.runCurrent()
+
+        // The frame must be out before the close, not merely queued before it.
+        assertEquals(listOf("send:pair/abort", "close"), handler.events)
+    }
+
+    @Test
+    fun `every other reason leaves the connection open`() {
+        for (reason in PairAbortReason.ALL - PairAbortReason.CLOSES_CONNECTION) {
+            val handler = handler()
+
+            handler.sendPairAbortForTest(reason)
+            handler.scope.runCurrent()
+
+            assertEquals("reason $reason", listOf("send:pair/abort"), handler.events)
+            assertEquals(reason, handler.sent.single().reason())
+        }
+    }
+
+    // ========== The attempt timeout ==========
+
+    @Test
+    fun `the attempt times out and aborts without closing`() {
+        val handler = handler(matched = PskCategory.PAIRING)
+        handler.handleTextMessageForTest(pairingActivation)
+        handler.scope.runCurrent()
+        handler.clearEvents()
+
+        handler.scope.advanceTimeBy(SendSpinProtocol.PAIR_ATTEMPT_TIMEOUT_MS + 1)
+        handler.scope.runCurrent()
+
+        assertEquals(listOf("send:pair/abort"), handler.events)
+        assertEquals(PairAbortReason.ATTEMPT_TIMEOUT, handler.sent.last().reason())
+    }
+
+    @Test
+    fun `the attempt has not timed out one millisecond early`() {
+        val handler = handler(matched = PskCategory.PAIRING)
+        handler.handleTextMessageForTest(pairingActivation)
+        handler.scope.runCurrent()
+        handler.clearEvents()
+
+        handler.scope.advanceTimeBy(SendSpinProtocol.PAIR_ATTEMPT_TIMEOUT_MS - 1)
+        handler.scope.runCurrent()
+
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    @Test
+    fun `a successful pairing cancels the timeout`() {
+        val handler = handler(matched = PskCategory.PAIRING)
+        handler.handleTextMessageForTest(pairingActivation)
+        handler.scope.runCurrent()
+        handler.handleTextMessageForTest("""{"type":"server/pair-finalize"}""")
+        handler.scope.runCurrent()
+        handler.clearEvents()
+
+        handler.scope.advanceTimeBy(SendSpinProtocol.PAIR_ATTEMPT_TIMEOUT_MS * 2)
+        handler.scope.runCurrent()
+
+        // A timer left running after success aborts a pairing that already
+        // worked, two minutes later, for no reason the user can see.
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    @Test
+    fun `a received abort cancels the timeout`() {
+        val handler = handler(matched = PskCategory.PAIRING)
+        handler.handleTextMessageForTest(pairingActivation)
+        handler.scope.runCurrent()
+        handler.clearEvents()
+
+        handler.handleTextMessageForTest(abort(PairAbortReason.USER_CANCELLED))
+        handler.scope.advanceTimeBy(SendSpinProtocol.PAIR_ATTEMPT_TIMEOUT_MS * 2)
+        handler.scope.runCurrent()
+
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    // ========== Receiving ==========
+
+    @Test
+    fun `a received abort sends nothing and closes nothing`() {
+        val handler = handler(matched = PskCategory.PAIRING)
+        handler.handleTextMessageForTest(pairingActivation)
+        handler.scope.runCurrent()
+        handler.clearEvents()
+
+        handler.handleTextMessageForTest(abort(PairAbortReason.PIN_MISMATCH))
+        handler.scope.runCurrent()
+
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    @Test
+    fun `a received concurrent_attempt does not close our end`() {
+        val handler = handler(matched = PskCategory.PAIRING)
+        handler.handleTextMessageForTest(pairingActivation)
+        handler.scope.runCurrent()
+        handler.clearEvents()
+
+        handler.handleTextMessageForTest(abort(PairAbortReason.CONCURRENT_ATTEMPT))
+        handler.scope.runCurrent()
+
+        // The spec makes the SENDER close. Closing as receiver too would race
+        // the peer's close and report the wrong close reason.
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    @Test
+    fun `an abort outside any attempt is ignored`() {
+        val handler = handler()
+
+        handler.handleTextMessageForTest(abort(PairAbortReason.ATTEMPT_TIMEOUT))
+        handler.scope.runCurrent()
+
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    @Test
+    fun `an unknown reason is accepted rather than treated as an error`() {
+        val handler = handler(matched = PskCategory.PAIRING)
+        handler.handleTextMessageForTest(pairingActivation)
+        handler.scope.runCurrent()
+        handler.clearEvents()
+
+        handler.handleTextMessageForTest(abort("future_reason"))
+        handler.scope.runCurrent()
+
+        // A newer peer's reason must still end the attempt. Rejecting it would
+        // leave us waiting on an attempt the other side has abandoned.
+        assertEquals(emptyList<String>(), handler.events)
+        handler.scope.advanceTimeBy(SendSpinProtocol.PAIR_ATTEMPT_TIMEOUT_MS * 2)
+        handler.scope.runCurrent()
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    @Test
+    fun `unknown payload fields are ignored`() {
+        val handler = handler(matched = PskCategory.PAIRING)
+        handler.handleTextMessageForTest(pairingActivation)
+        handler.scope.runCurrent()
+        handler.clearEvents()
+
+        handler.handleTextMessageForTest(
+            """{"type":"pair/abort","payload":{"reason":"user_cancelled","future":1}}"""
+        )
+        handler.scope.advanceTimeBy(SendSpinProtocol.PAIR_ATTEMPT_TIMEOUT_MS * 2)
+        handler.scope.runCurrent()
+
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    // ========== Operator cancellation ==========
+
+    @Test
+    fun `cancelling the attempt sends user_cancelled and stays open`() {
+        val handler = handler(matched = PskCategory.PAIRING)
+        handler.handleTextMessageForTest(pairingActivation)
+        handler.scope.runCurrent()
+        handler.clearEvents()
+
+        handler.cancelPairing()
+        handler.scope.runCurrent()
+
+        assertEquals(listOf("send:pair/abort"), handler.events)
+        assertEquals(PairAbortReason.USER_CANCELLED, handler.sent.last().reason())
+    }
+
+    @Test
+    fun `cancelling with no attempt in flight sends nothing`() {
+        val handler = handler()
+
+        handler.cancelPairing()
+        handler.scope.runCurrent()
+
+        assertEquals(emptyList<String>(), handler.events)
+    }
+
+    // ========== Helpers ==========
+
+    private fun abort(reason: String) =
+        """{"type":"pair/abort","payload":{"reason":"$reason"}}"""
+
+    private fun handler(matched: PskCategory = PskCategory.SENTINEL): AbortTestHandler {
+        val handler = AbortTestHandler(matched)
+        handler.setHandshakeCompleteForTest()
+        return handler
+    }
+
+    private fun String.reason(): String? =
+        Json.parseToJsonElement(this).jsonObject["payload"]
+            ?.jsonObject?.get("reason")?.jsonPrimitive?.content
+}
+
+/** A handler on a session keyed by [matchedCategory], recording what it sends. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AbortTestHandler(
+    private val matchedCategory: PskCategory,
+) : SendSpinProtocolHandler("AbortTest") {
+
+    val scope = TestScope()
+    val sent = mutableListOf<String>()
+    val events = mutableListOf<String>()
+
+    private val timeFilter = SendspinTimeFilter()
+    private val store = FakeTrustStore()
+
+    fun setHandshakeCompleteForTest() { handshakeComplete = true }
+
+    fun handleTextMessageForTest(text: String) = handleTextMessage(text)
+
+    fun sendPairAbortForTest(reason: String) = sendPairAbort(reason)
+
+    fun clearEvents() {
+        events.clear()
+        sent.clear()
+    }
+
+    override fun matchedPskCategory(): PskCategory = matchedCategory
+
+    override fun matchedPsk(): Psk? =
+        if (matchedCategory == PskCategory.LONG_TERM) {
+            Psk(ByteArray(32) { 3 }, PskCategory.LONG_TERM, "srv1")
+        } else {
+            Psk(ByteArray(32) { 3 }, matchedCategory)
+        }
+
+    override fun trustStore(): TrustStore = store
+
+    override fun currentServerId(): String = "srv1"
+
+    override fun closeConnectionAfterFlush() {
+        events.add("close")
+    }
+
+    override fun sendTextMessage(text: String) {
+        sent.add(text)
+        events.add("send:" + Json.parseToJsonElement(text).jsonObject["type"]?.jsonPrimitive?.content)
+    }
+
+    override fun sendBinaryFrame(bytes: ByteArray) = Unit
+
+    override fun getCoroutineScope(): CoroutineScope = scope
+
+    override fun getTimeFilter(): SendspinTimeFilter = timeFilter
+
+    override fun isLowMemoryMode(): Boolean = false
+    override fun getClientId(): String = "test-client"
+    override fun getDeviceName(): String = "Test"
+    override fun getManufacturer(): String = "Test"
+    override fun getSoftwareVersion(): String = "0.0.0"
+    override fun getSupportedFormats(): List<MessageBuilder.FormatEntry> = emptyList()
+
+    override fun onHandshakeComplete(serverName: String, serverId: String) = Unit
+    override fun onMetadataUpdate(metadata: TrackMetadata) = Unit
+    override fun onPlaybackStateChanged(state: String) = Unit
+    override fun onVolumeCommand(volume: Int) = Unit
+    override fun onMuteCommand(muted: Boolean) = Unit
+    override fun onGroupUpdate(info: GroupInfo) = Unit
+    override fun onStreamStart(config: StreamConfig) = Unit
+    override fun onStreamClear() = Unit
+    override fun onStreamEnd() = Unit
+    override fun onAudioChunk(timestampMicros: Long, audioData: ByteArray) = Unit
+    override fun onArtwork(channel: Int, payload: ByteArray) = Unit
+    override fun onSyncOffsetApplied(offsetMs: Double, source: String) = Unit
+    override fun onSyncMuteChanged(muted: Boolean) = Unit
+}

--- a/android/app/src/test/java/com/sendspindroid/sendspin/protocol/ServerUnpairTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/protocol/ServerUnpairTest.kt
@@ -265,7 +265,7 @@ class UnpairTestHandler(
         unpaired.add(pskId to serverId)
     }
 
-    override fun closeConnectionAfterGoodbye() {
+    override fun closeConnectionAfterFlush() {
         events.add("close")
     }
 

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairAbortReasonTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairAbortReasonTest.kt
@@ -1,0 +1,47 @@
+package com.sendspindroid.sendspin.pairing
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The `pair/abort` reason set.
+ *
+ * `pairing.md#client--server-pairabort` fixes both the vocabulary and one
+ * behavioural split: "With reason `concurrent_attempt` the sender closes the
+ * connection after sending, otherwise the connection stays open."
+ *
+ * Pinned rather than merely declared, because both halves drift silently. An
+ * extra reason is one a peer will not recognise; a missing one leaves a real
+ * situation with no way to say what happened. And getting the close set wrong
+ * either hangs a connection the spec says to close, or drops one the peer still
+ * expects to use.
+ */
+class PairAbortReasonTest {
+
+    @Test
+    fun theReasonSetIsExactlyTheSpecSet() {
+        assertEquals(
+            setOf(
+                "attempt_timeout",
+                "concurrent_attempt",
+                "method_not_supported",
+                "pin_length_unacceptable",
+                "pin_mismatch",
+                "user_cancelled",
+            ),
+            PairAbortReason.ALL,
+        )
+    }
+
+    @Test
+    fun onlyConcurrentAttemptClosesTheConnection() {
+        assertEquals(setOf("concurrent_attempt"), PairAbortReason.CLOSES_CONNECTION)
+    }
+
+    @Test
+    fun everyClosingReasonIsAReason() {
+        // Guards the copy-paste failure where CLOSES_CONNECTION names a string
+        // that is not in ALL, which would make the close branch unreachable.
+        assertEquals(emptySet<String>(), PairAbortReason.CLOSES_CONNECTION - PairAbortReason.ALL)
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairingAbortFlowTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/pairing/PairingAbortFlowTest.kt
@@ -1,0 +1,135 @@
+package com.sendspindroid.sendspin.pairing
+
+import com.sendspindroid.sendspin.crypto.PskCategory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Ending a pairing attempt short of success.
+ *
+ * `pairing.md#client--server-pairabort`: "A `pair/abort` received after the
+ * receiver has itself ended the attempt has no effect."
+ *
+ * `pairing.md#entering-and-leaving-pairing`: "On receipt the client abandons
+ * the attempt, discarding all pairing state ... an abandoned attempt is not an
+ * inner-authentication failure and does not touch the failure counter."
+ */
+class PairingAbortFlowTest {
+
+    private fun startedAttempt(): PairingPskFlow {
+        val flow = PairingPskFlow()
+        val actions = flow.onEvent(
+            PairingEvent.PairingActivation(PairMethod.PAIRING_PSK, PskCategory.PAIRING)
+        )
+        assertTrue(actions.any { it is PairingAction.SendPairFinalize })
+        return flow
+    }
+
+    // ========== Receiving an abort ==========
+
+    @Test
+    fun aReceivedAbortEndsTheAttemptAndSendsNothingBack() {
+        val flow = startedAttempt()
+
+        val actions = flow.onEvent(PairingEvent.PairAbortReceived(PairAbortReason.USER_CANCELLED))
+
+        // Answering an abort with an abort would have the two sides bouncing
+        // the attempt back and forth; the spec has the receiver simply stop.
+        assertEquals(emptyList<PairingAction>(), actions.filterIsInstance<PairingAction.SendPairAbort>())
+        assertEquals(listOf(PairingAction.ClearAttemptTimeout), actions)
+    }
+
+    @Test
+    fun aReceivedAbortPersistsNothingAfterwards() {
+        val flow = startedAttempt()
+        flow.onEvent(PairingEvent.PairAbortReceived(PairAbortReason.PIN_MISMATCH))
+
+        // The server changing its mind and acknowledging anyway must not
+        // resurrect a record for a secret we have already discarded.
+        val actions = flow.onEvent(PairingEvent.ServerPairFinalize)
+
+        assertEquals(emptyList<PairingAction>(), actions)
+    }
+
+    @Test
+    fun anAbortWithNoAttemptInFlightHasNoEffect() {
+        val flow = PairingPskFlow()
+
+        for (reason in PairAbortReason.ALL) {
+            assertEquals(
+                "reason $reason produced actions with no attempt in flight",
+                emptyList<PairingAction>(),
+                flow.onEvent(PairingEvent.PairAbortReceived(reason)),
+            )
+        }
+    }
+
+    @Test
+    fun aSecondAbortIsANoOp() {
+        val flow = startedAttempt()
+        flow.onEvent(PairingEvent.PairAbortReceived(PairAbortReason.USER_CANCELLED))
+
+        assertEquals(
+            emptyList<PairingAction>(),
+            flow.onEvent(PairingEvent.PairAbortReceived(PairAbortReason.USER_CANCELLED)),
+        )
+    }
+
+    @Test
+    fun anAbortAfterSuccessHasNoEffect() {
+        // The race that actually happens: the server's abort and its
+        // pair-finalize cross on the wire. The record is already persisted and
+        // must stay.
+        val flow = startedAttempt()
+        flow.onEvent(PairingEvent.ServerPairFinalize)
+
+        assertEquals(
+            emptyList<PairingAction>(),
+            flow.onEvent(PairingEvent.PairAbortReceived(PairAbortReason.ATTEMPT_TIMEOUT)),
+        )
+    }
+
+    @Test
+    fun anAttemptCanStartAgainAfterTheNextActivation() {
+        val flow = startedAttempt()
+        flow.onEvent(PairingEvent.PairAbortReceived(PairAbortReason.USER_CANCELLED))
+
+        val actions = flow.onEvent(
+            PairingEvent.PairingActivation(PairMethod.PAIRING_PSK, PskCategory.PAIRING)
+        )
+
+        assertTrue(
+            "a new server/activate must be able to start a fresh attempt",
+            actions.any { it is PairingAction.SendPairFinalize },
+        )
+    }
+
+    // ========== Operator cancellation ==========
+
+    @Test
+    fun theOperatorCancellingSendsUserCancelled() {
+        val flow = startedAttempt()
+
+        val actions = flow.onEvent(PairingEvent.UserCancelled)
+
+        val abort = actions.filterIsInstance<PairingAction.SendPairAbort>().single()
+        assertEquals(PairAbortReason.USER_CANCELLED, abort.reason)
+        assertTrue(actions.contains(PairingAction.ClearAttemptTimeout))
+    }
+
+    @Test
+    fun cancellingWithNoAttemptInFlightSendsNothing() {
+        val flow = PairingPskFlow()
+
+        assertEquals(emptyList<PairingAction>(), flow.onEvent(PairingEvent.UserCancelled))
+    }
+
+    @Test
+    fun aCancelledAttemptPersistsNothingAfterwards() {
+        val flow = startedAttempt()
+        flow.onEvent(PairingEvent.UserCancelled)
+
+        assertEquals(emptyList<PairingAction>(), flow.onEvent(PairingEvent.ServerPairFinalize))
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/pairing/PairingPskFlow.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/pairing/PairingPskFlow.kt
@@ -26,6 +26,19 @@ sealed interface PairingEvent {
 
     object AttemptTimeout : PairingEvent
 
+    /**
+     * The server ended the attempt.
+     *
+     * "On receipt the client abandons the attempt, discarding all pairing
+     * state, and proceeds under the declared activities; an abandoned attempt
+     * is not an inner-authentication failure and does not touch the failure
+     * counter." So: not an error, and specifically not a disconnect.
+     */
+    data class PairAbortReceived(val reason: String) : PairingEvent
+
+    /** The operator cancelled through a local UI. */
+    object UserCancelled : PairingEvent
+
     object ConnectionClosed : PairingEvent
 }
 
@@ -120,6 +133,34 @@ class PairingPskFlow {
             }
         }
 
+        is PairingEvent.PairAbortReceived -> {
+            if (state != State.AWAITING_ACK) {
+                // "A pair/abort received after the receiver has itself ended
+                // the attempt has no effect." Covers the duplicate abort and
+                // the race where the server's abort crosses its own ack.
+                emptyList()
+            } else {
+                discard()
+                state = State.ABORTED
+                // Nothing sent back: answering an abort with an abort would
+                // have both sides bouncing the attempt between them.
+                listOf(PairingAction.ClearAttemptTimeout)
+            }
+        }
+
+        PairingEvent.UserCancelled -> {
+            if (state != State.AWAITING_ACK) {
+                emptyList()
+            } else {
+                discard()
+                state = State.ABORTED
+                listOf(
+                    PairingAction.SendPairAbort(PairAbortReason.USER_CANCELLED),
+                    PairingAction.ClearAttemptTimeout,
+                )
+            }
+        }
+
         PairingEvent.ConnectionClosed -> {
             // Nothing to send: the socket is gone. Just make sure the secret
             // does not outlive the attempt.
@@ -165,12 +206,42 @@ class PairingPskFlow {
 
 /** `pair/abort` reasons (`pairing.md#client--server-pairabort`). */
 object PairAbortReason {
+    /** The attempt did not complete within the attempt timeout. Client only. */
     const val ATTEMPT_TIMEOUT = "attempt_timeout"
+
+    /** Another attempt is already in progress with this client. Client only. */
     const val CONCURRENT_ATTEMPT = "concurrent_attempt"
+
+    /** The activation's method is one the matched PSK disallows, or one we do not offer. */
     const val METHOD_NOT_SUPPORTED = "method_not_supported"
+
+    /** `pin_length` below `min_pin_length` or outside 4-12. No call site until 4.4 (#220). */
     const val PIN_LENGTH_UNACCEPTABLE = "pin_length_unacceptable"
+
+    /** PAKE key confirmation or PIN binding failed. No call site until 4.4 (#220). */
     const val PIN_MISMATCH = "pin_mismatch"
+
+    /** The operator aborted through a local UI. Either side may send it. */
     const val USER_CANCELLED = "user_cancelled"
+
+    val ALL = setOf(
+        ATTEMPT_TIMEOUT,
+        CONCURRENT_ATTEMPT,
+        METHOD_NOT_SUPPORTED,
+        PIN_LENGTH_UNACCEPTABLE,
+        PIN_MISMATCH,
+        USER_CANCELLED,
+    )
+
+    /**
+     * "With reason `concurrent_attempt` the sender closes the connection after
+     * sending, otherwise the connection stays open."
+     *
+     * A set rather than an `if` at the call site so the rule is stated once and
+     * can be pinned by a test. Note it governs the *sender*: a client receiving
+     * `concurrent_attempt` does not close, it waits for the peer to.
+     */
+    val CLOSES_CONNECTION = setOf(CONCURRENT_ATTEMPT)
 }
 
 /** Pairing method wire names. */


### PR DESCRIPTION
Closes #226. **Stacked on #247** - base it there, or merge #247 first.

`pair/abort` had a message-type constant and no dispatch case, so an abort from the server landed in `Unhandled message type` and the attempt sat there until its own two-minute timer fired. A server that gave up said so, and the client ignored it.

## The two asymmetries

Both are easy to invert, and both inversions look reasonable in isolation.

| | sender | receiver |
|---|---|---|
| `concurrent_attempt` | **closes** after sending | does **not** close - waits for the peer's close |
| every other reason | stays open | stays open |

Closing as receiver would race the peer's close and report the wrong reason for it. Answering an abort with an abort would have both sides bouncing the attempt between them, so a received abort is never answered.

An abort arriving after the attempt has already ended is a no-op. That covers the duplicate abort and the real race - the server's abort crossing its own `server/pair-finalize` - where the record is already persisted and must stay.

Unrecognised reasons are accepted and end the attempt. A newer peer's reason still means it has abandoned the attempt; rejecting it as a protocol error would leave us waiting on something that is over. Same for unknown payload fields.

## What was already there

#206 built the state machine, the six reason constants, and the timeout *action*. This adds the receive path, the `UserCancelled` path, the send helper with the close rule, and `ALL` / `CLOSES_CONNECTION` as pinned sets.

One behavioural fix beyond wiring: flow-driven aborts went through `onPairAbort`, which sent without consulting the close rule. They now share the one send path, so `concurrent_attempt` closes wherever it originates rather than only at call sites that remembered to.

## Verification

25 tests - 12 on the state machine, 13 on the handler including the timer under virtual time (fires at 120000 ms, not at 119999 ms, and is cancelled by success, by a received abort, and by connection close).

Mutation-checked:

- Making the sender always close fails three tests.
- Closing on a *received* `concurrent_attempt` fails exactly one - the test written for that asymmetry.

## Rename

`closeConnectionAfterGoodbye` -> `closeConnectionAfterFlush`. It was introduced in #247 for the unpair goodbye, and `concurrent_attempt` needs the same flush-close for a message that is not a goodbye.

## Not exercised end to end

Same limitation as #224: `aiosendspin` 9.1.0 has no `pair/abort` send path, so no available server can produce one. The receive path is tested against constructed frames.
