### PR TITLE
feat(management): request routing, pairing config, and record operations

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/UserSettings.kt
+++ b/android/app/src/main/java/com/sendspindroid/UserSettings.kt
@@ -63,6 +63,7 @@ object UserSettings {
     const val KEY_PAIRING_PSK = "sendspin_pairing_psk"
     const val KEY_PAIRING_PSK_ENABLED = "sendspin_pairing_psk_enabled"
     const val KEY_UNPAIRED_ACCESS = "sendspin_unpaired_access"
+    const val KEY_RECORD_MODE_PSK_ID = "sendspin_record_mode_psk_id"
 
     // Remote access preference keys (stored in encrypted prefs)
     const val KEY_REMOTE_SERVERS = "remote_servers"
@@ -305,16 +306,27 @@ object UserSettings {
     fun getPairingPskEnabled(): Boolean =
         sensitivePrefs?.getBoolean(KEY_PAIRING_PSK_ENABLED, true) ?: true
 
-    fun setPairingPskEnabled(enabled: Boolean) {
-        sensitivePrefs?.edit()?.putBoolean(KEY_PAIRING_PSK_ENABLED, enabled)?.commit()
-    }
+    /**
+     * @return false if the change was not persisted.
+     *
+     * `commit()` rather than `apply()`, and the result is propagated, because
+     * management answers `ok` only once "any state change has been persisted".
+     * The rest of this file uses `apply()`; a management write cannot.
+     */
+    fun setPairingPskEnabled(enabled: Boolean): Boolean =
+        sensitivePrefs?.edit()?.putBoolean(KEY_PAIRING_PSK_ENABLED, enabled)?.commit() ?: false
 
     fun getUnpairedAccessEnabled(): Boolean =
         sensitivePrefs?.getBoolean(KEY_UNPAIRED_ACCESS, true) ?: true
 
-    fun setUnpairedAccessEnabled(enabled: Boolean) {
-        sensitivePrefs?.edit()?.putBoolean(KEY_UNPAIRED_ACCESS, enabled)?.commit()
-    }
+    fun setUnpairedAccessEnabled(enabled: Boolean): Boolean =
+        sensitivePrefs?.edit()?.putBoolean(KEY_UNPAIRED_ACCESS, enabled)?.commit() ?: false
+
+    fun getRecordModePskId(): String? =
+        sensitivePrefs?.getString(KEY_RECORD_MODE_PSK_ID, null)
+
+    fun setRecordModePskId(pskId: String): Boolean =
+        sensitivePrefs?.edit()?.putString(KEY_RECORD_MODE_PSK_ID, pskId)?.commit() ?: false
 
     fun getPlayerId(): String {
         // Fast path: prefs available and ID already stored

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -537,6 +537,11 @@ class SendSpin(
 
     override fun pairingConfigStore(): PairingConfigStore = pairingConfigStore
 
+    override fun onManagementSessionRevoked() {
+        Log.i(TAG, "Our pairing record was removed by the server - not reconnecting")
+        suppressAutoReconnect.set(true)
+    }
+
     override fun onPaired(serverId: String) {
         // The server drives the in-band re-handshake from here (#223); the
         // client sends nothing further. The new record is already visible to

--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -17,6 +17,7 @@ import com.sendspindroid.sendspin.crypto.NoiseHandshakeException
 import com.sendspindroid.sendspin.crypto.AndroidPairingConfigStore
 import com.sendspindroid.sendspin.crypto.Psk
 import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.crypto.PairingConfigStore
 import com.sendspindroid.sendspin.crypto.TrustStore
 import com.sendspindroid.sendspin.crypto.PskCandidates
 import com.sendspindroid.sendspin.crypto.PskCandidateSet
@@ -533,6 +534,8 @@ class SendSpin(
     override fun currentServerId(): String? = sessionFacts?.serverId
 
     override fun trustStore(): TrustStore = UserSettings.getOrCreateTrustStore()
+
+    override fun pairingConfigStore(): PairingConfigStore = pairingConfigStore
 
     override fun onPaired(serverId: String) {
         // The server drives the in-band re-handshake from here (#223); the

--- a/android/app/src/main/java/com/sendspindroid/sendspin/crypto/AndroidPairingConfigStore.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/crypto/AndroidPairingConfigStore.kt
@@ -28,17 +28,49 @@ class AndroidPairingConfigStore : PairingConfigStore {
             pairingPsk = psk,
             pairingPskEnabled = UserSettings.getPairingPskEnabled(),
             unpairedAccessEnabled = UserSettings.getUnpairedAccessEnabled(),
+            recordModePskId = recordModePskId(),
         )
     }
 
-    override fun setEnabled(enabled: Boolean) {
+    override fun setEnabled(enabled: Boolean): Boolean {
         // Only the flag moves. The secret stays, so re-enabling restores every
         // token already in circulation rather than silently invalidating them.
-        UserSettings.setPairingPskEnabled(enabled)
+        return UserSettings.setPairingPskEnabled(enabled)
     }
 
-    override fun setUnpairedAccess(enabled: Boolean) {
+    override fun setUnpairedAccess(enabled: Boolean): Boolean =
         UserSettings.setUnpairedAccessEnabled(enabled)
+
+    override fun setRecordModePskId(pskId: String): Boolean =
+        UserSettings.setRecordModePskId(pskId)
+
+    /**
+     * The shared-PSK record backing record mode, minted on first read.
+     *
+     * `management.md#record-mode` requires the reference to name a real
+     * shared-PSK record and `get-pairing-config` treats `record_mode` as
+     * non-optional, so one exists. It is device-specific and generated here
+     * ("MUST NOT be a fixed default shared across devices"), and it is never
+     * distributed: nothing offers it to a server, so nothing can authenticate
+     * under it. See the KDoc on [PairingConfig] for why it exists at all.
+     */
+    private fun recordModePskId(): String {
+        UserSettings.getRecordModePskId()?.let { return it }
+
+        val store = UserSettings.getOrCreateTrustStore()
+        val psk = secureRandomBytes(Psk.PSK_SIZE)
+        // serverId = null makes it a shared-PSK record, which is exactly what
+        // record mode must point at.
+        val result = store.addRecord(psk, serverId = null)
+        if (result !is TrustStore.AddRecordResult.Ok) {
+            Log.e(TAG, "Could not provision the record-mode record: $result")
+            return ""
+        }
+        if (!UserSettings.setRecordModePskId(result.record.pskId)) {
+            Log.e(TAG, "Could not persist the record-mode reference")
+        }
+        Log.i(TAG, "Provisioned the record-mode shared record (psk_id=${result.record.pskId})")
+        return result.record.pskId
     }
 
     override fun rotatePairingPsk(
@@ -52,7 +84,7 @@ class AndroidPairingConfigStore : PairingConfigStore {
         synchronized(lock) {
             if (!UserSettings.setPairingPskBlob(Base64Url.encode(newPsk))) {
                 Log.e(TAG, "Failed to persist rotated Pairing PSK: no storage available")
-                return PairingConfigStore.RotateResult.Invalid
+                return PairingConfigStore.RotateResult.StorageFailed
             }
             cachedPsk = newPsk.copyOf()
         }

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -7,6 +7,9 @@ import com.sendspindroid.sendspin.crypto.NoiseCrypto
 import com.sendspindroid.sendspin.crypto.NoiseTransport
 import com.sendspindroid.sendspin.crypto.Psk
 import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.protocol.management.ManagementRequestParser
+import com.sendspindroid.sendspin.protocol.management.ManagementService
+import com.sendspindroid.sendspin.protocol.management.ManagementSessionContext
 import com.sendspindroid.sendspin.protocol.message.BinaryMessageParser
 import com.sendspindroid.sendspin.protocol.message.MessageBuilder
 import com.sendspindroid.sendspin.protocol.message.MessageParser
@@ -806,7 +809,16 @@ abstract class SendSpinProtocolHandler(
                 SendSpinProtocol.MessageType.STREAM_END -> handleStreamEnd(payload)
                 SendSpinProtocol.MessageType.STREAM_CLEAR -> handleStreamClear()
                 SendSpinProtocol.MessageType.CLIENT_SYNC_OFFSET -> handleClientSyncOffset(payload)
-                else -> Log.d(tag, "Unhandled message type: $type")
+                // Before the else: every management request must be
+                // answered, including one we do not implement. Falling through
+                // to the unhandled log leaves the server waiting for a reply
+                // that never comes - which is exactly how MA's device-settings
+                // dialog hangs (#228).
+                else -> if (type.startsWith("management/")) {
+                    handleManagementRequest(type, payload)
+                } else {
+                    Log.d(tag, "Unhandled message type: $type")
+                }
             }
         } catch (e: Exception) {
             Log.e(tag, "Failed to parse message: ${text.take(100)}", e)
@@ -1008,6 +1020,47 @@ abstract class SendSpinProtocolHandler(
         val reason = payload?.get("reason")?.jsonPrimitive?.contentOrNull ?: "unspecified"
         Log.w(tag, "Pairing aborted (received): reason=$reason")
         runPairingActions(PairingEvent.PairAbortReceived(reason))
+    }
+
+    // ========== Management (item 3.1) ==========
+
+    private val managementService = ManagementService()
+
+    /**
+     * Answer one `management/` request.
+     *
+     * Handled to completion on the receive path, synchronously, and that is a
+     * requirement rather than a convenience: "At most one management request
+     * may be in flight per connection; in-order WebSocket delivery makes the
+     * reply unambiguous", and the reply carries no request identifier. The Nth
+     * result on the wire IS the answer to the Nth request. Moving the work to
+     * another dispatcher would let two replies race and be attributed to the
+     * wrong requests, with nothing in either frame to reveal the swap.
+     *
+     * If persistence ever has to leave this thread, it needs a single-consumer
+     * serialized queue, not a `launch`.
+     */
+    private fun handleManagementRequest(type: String, payload: JsonObject?) {
+        val request = ManagementRequestParser.parse(type, payload) ?: return
+
+        val outcome = managementService.handle(
+            request,
+            ManagementSessionContext(
+                hasManagementActivity = Activity.MANAGEMENT in activities,
+                // No PIN method is implemented (audit D2), so none can be on.
+                pinMethodEnabled = false,
+            ),
+        )
+
+        Log.i(tag, "management: $type -> ${outcome.code.wire}")
+        sendProtocolMessage(
+            MessageBuilder.buildManagementResult(outcome.code, outcome.data)
+        )
+
+        outcome.closeAfterReply?.let { reason ->
+            sendGoodbye(reason)
+            closeConnectionAfterFlush()
+        }
     }
 
     /** The operator cancelled pairing from the UI. Leaves the connection open. */

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -1046,25 +1046,46 @@ abstract class SendSpinProtocolHandler(
     private fun handleManagementRequest(type: String, payload: JsonObject?) {
         val request = ManagementRequestParser.parse(type, payload) ?: return
 
+        val matched = matchedPsk()
         val outcome = ManagementService(trustStore(), pairingConfigStore()).handle(
             request,
             ManagementSessionContext(
                 hasManagementActivity = Activity.MANAGEMENT in activities,
                 // No PIN method is implemented (audit D2), so none can be on.
                 pinMethodEnabled = false,
+                // Only a record identifies "our own record"; the Sentinel and
+                // the Pairing PSK are not records and cannot be removed.
+                matchedPskId = matched?.takeIf { it.category == PskCategory.LONG_TERM }?.pskId,
             ),
         )
 
         Log.i(tag, "management: $type -> ${outcome.code.wire}")
-        sendProtocolMessage(
-            MessageBuilder.buildManagementResult(outcome.code, outcome.data)
-        )
 
-        outcome.closeAfterReply?.let { reason ->
-            sendGoodbye(reason)
-            closeConnectionAfterFlush()
+        // Sequenced in one coroutine, and that is the contract: the result must
+        // reach the wire before the goodbye, because the result is the only
+        // thing that tells the server the operation happened. A close on its
+        // own reads as a failure. sendProtocolMessage returns while the encrypt
+        // is still queued, so the awaiting form is what makes the order real.
+        getCoroutineScope().launch {
+            sendProtocolMessageAwaiting(
+                MessageBuilder.buildManagementResult(outcome.code, outcome.data)
+            )
+            outcome.closeAfterReply?.let { reason ->
+                sendProtocolMessageAwaiting(MessageBuilder.buildGoodbye(reason))
+                onManagementSessionRevoked()
+                closeConnectionAfterFlush()
+            }
         }
     }
+
+    /**
+     * The client removed the record that authenticated this session.
+     *
+     * "Server should not auto-reconnect with the same activity set" - and we
+     * should not either: the credential is gone, so every attempt would fail
+     * the handshake PSK lookup and loop.
+     */
+    protected open fun onManagementSessionRevoked() {}
 
     /** The operator cancelled pairing from the UI. Leaves the connection open. */
     fun cancelPairing() {
@@ -1248,6 +1269,10 @@ abstract class SendSpinProtocolHandler(
                 Log.e(tag, "Cannot store pairing record: psk_id already claimed")
             TrustStore.AddRecordResult.Invalid ->
                 Log.e(tag, "Cannot store pairing record: PSK rejected as invalid")
+            TrustStore.AddRecordResult.StorageFailed ->
+                // The one failure a user could actually act on, so it names the
+                // cause rather than the symptom.
+                Log.e(tag, "Cannot store pairing record: the write did not persist")
         }
     }
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -7,6 +7,8 @@ import com.sendspindroid.sendspin.crypto.NoiseCrypto
 import com.sendspindroid.sendspin.crypto.NoiseTransport
 import com.sendspindroid.sendspin.crypto.Psk
 import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.crypto.PairingConfigStore
+import com.sendspindroid.sendspin.protocol.management.ManagementResultCode
 import com.sendspindroid.sendspin.protocol.management.ManagementRequestParser
 import com.sendspindroid.sendspin.protocol.management.ManagementService
 import com.sendspindroid.sendspin.protocol.management.ManagementSessionContext
@@ -1024,7 +1026,8 @@ abstract class SendSpinProtocolHandler(
 
     // ========== Management (item 3.1) ==========
 
-    private val managementService = ManagementService()
+    /** Where the pairing configuration lives. Null on the legacy path. */
+    protected open fun pairingConfigStore(): PairingConfigStore? = null
 
     /**
      * Answer one `management/` request.
@@ -1043,7 +1046,7 @@ abstract class SendSpinProtocolHandler(
     private fun handleManagementRequest(type: String, payload: JsonObject?) {
         val request = ManagementRequestParser.parse(type, payload) ?: return
 
-        val outcome = managementService.handle(
+        val outcome = ManagementService(trustStore(), pairingConfigStore()).handle(
             request,
             ManagementSessionContext(
                 hasManagementActivity = Activity.MANAGEMENT in activities,

--- a/android/app/src/test/java/com/sendspindroid/sendspin/protocol/ManagementDispatchTest.kt
+++ b/android/app/src/test/java/com/sendspindroid/sendspin/protocol/ManagementDispatchTest.kt
@@ -1,0 +1,98 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.protocol.management.ManagementResultCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * `management/...` on the live dispatch path.
+ *
+ * `management.md#management`: "If a `management/...` message arrives on a
+ * connection without `'management'` in activities, the client replies with
+ * `management/result` `permission_denied`."
+ *
+ * Replies are matched to requests by ordering alone - there is no request id -
+ * so the count and the order of `management/result` frames are the contract.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ManagementDispatchTest {
+
+    private val listRecords = """{"type":"management/list-records"}"""
+
+    @Test
+    fun `a request outside a management session is answered and not closed`() {
+        val handler = handler(activities = """["playback"]""")
+
+        handler.handleTextMessageForTest(listRecords)
+        handler.scope.runCurrent()
+
+        assertEquals(listOf("send:management/result"), handler.events)
+        assertEquals(ManagementResultCode.PERMISSION_DENIED.wire, handler.sent.single().result())
+    }
+
+    @Test
+    fun `an unknown management type is answered rather than dropped`() {
+        // The generic unhandled-message log would leave the server waiting for
+        // a reply that never arrives - which is exactly how MA's device
+        // dialog hangs today.
+        val handler = handler(activities = """["management"]""")
+
+        handler.handleTextMessageForTest("""{"type":"management/does-not-exist"}""")
+        handler.scope.runCurrent()
+
+        assertEquals(listOf("send:management/result"), handler.events)
+        assertEquals(ManagementResultCode.INVALID.wire, handler.sent.single().result())
+    }
+
+    @Test
+    fun `every request gets exactly one reply, in order`() {
+        val handler = handler(activities = """["management"]""")
+
+        handler.handleTextMessageForTest(listRecords)
+        handler.handleTextMessageForTest("""{"type":"management/does-not-exist"}""")
+        handler.handleTextMessageForTest("""{"type":"management/open-pairing-window"}""")
+        handler.scope.runCurrent()
+
+        assertEquals(3, handler.sent.size)
+        assertEquals(
+            listOf("send:management/result", "send:management/result", "send:management/result"),
+            handler.events,
+        )
+        // Second and third are known-invalid; if replies were reordered or
+        // coalesced the server would attribute them to the wrong request.
+        assertEquals(ManagementResultCode.INVALID.wire, handler.sent[1].result())
+        assertEquals(ManagementResultCode.INVALID.wire, handler.sent[2].result())
+    }
+
+    @Test
+    fun `a management request never closes the connection`() {
+        val handler = handler(activities = """["playback"]""")
+
+        handler.handleTextMessageForTest(listRecords)
+        handler.handleTextMessageForTest("""{"type":"management/add-record","payload":{}}""")
+        handler.scope.runCurrent()
+
+        assertEquals(emptyList<String>(), handler.events.filter { it == "close" })
+    }
+
+    private fun handler(activities: String): AbortTestHandler {
+        val handler = AbortTestHandler(PskCategory.LONG_TERM)
+        handler.setHandshakeCompleteForTest()
+        handler.handleTextMessageForTest(
+            """{"type":"server/activate","payload":{"activities":$activities,"roles":["player@v1"]}}"""
+        )
+        handler.scope.runCurrent()
+        handler.clearEvents()
+        return handler
+    }
+
+    private fun String.result(): String? =
+        Json.parseToJsonElement(this).jsonObject["payload"]
+            ?.jsonObject?.get("result")?.jsonPrimitive?.content
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskCandidatesTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskCandidatesTest.kt
@@ -24,6 +24,7 @@ class PskCandidatesTest {
             pairingPsk = psk(pairing),
             pairingPskEnabled = enabled,
             unpairedAccessEnabled = true,
+            recordModePskId = "record-mode-id",
         )
 
     @Test

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskSelectionTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/crypto/PskSelectionTest.kt
@@ -100,7 +100,7 @@ class PskSelectionTest {
         // "A PSK for a pairing method disabled in the client's pairing config is
         // excluded from the candidate set, so a handshake referencing it fails
         // as a lookup miss." Exercised end to end through PskCandidates.build.
-        val config = PairingConfig(psk(7), pairingPskEnabled = false, unpairedAccessEnabled = true)
+        val config = PairingConfig(psk(7), pairingPskEnabled = false, unpairedAccessEnabled = true, "record-mode-id")
         val built = PskCandidates.build(emptyList(), config)
         val set = PskCandidateSet.of(built).getOrThrow()
         assertTrue(set.select(config.pairingPskId, serverA) is PskCandidateSet.Selection.NoMatch)

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementRoutingTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementRoutingTest.kt
@@ -168,7 +168,7 @@ class ManagementRoutingTest {
 
     @Test
     fun everyRequestOutsideAManagementSessionIsDenied() {
-        val service = ManagementService()
+        val service = service()
 
         for (request in ALL_REQUESTS) {
             val outcome = service.handle(request, session(management = false))
@@ -181,7 +181,7 @@ class ManagementRoutingTest {
 
     @Test
     fun anUnknownRequestInsideASessionIsInvalid() {
-        val outcome = ManagementService()
+        val outcome = service()
             .handle(ManagementRequest.Unrecognized("management/nope"), session(management = true))
 
         assertEquals(ManagementResultCode.INVALID, outcome.code)
@@ -191,7 +191,7 @@ class ManagementRoutingTest {
     fun openingAPairingWindowIsInvalidWithNoPinMethod() {
         // "rejected as `invalid` when no PIN method is enabled." This client
         // implements neither PIN method (audit D2), so it is always invalid.
-        val outcome = ManagementService()
+        val outcome = service()
             .handle(ManagementRequest.OpenPairingWindow, session(management = true))
 
         assertEquals(ManagementResultCode.INVALID, outcome.code)
@@ -203,11 +203,17 @@ class ManagementRoutingTest {
         // is answered and the connection continues. Only an unauthorised
         // *activation* closes, and that is decided in ServerActivateRules.
         for (request in ALL_REQUESTS) {
-            assertNull(ManagementService().handle(request, session(management = false)).closeAfterReply)
+            assertNull(service().handle(request, session(management = false)).closeAfterReply)
         }
     }
 
     // ========== Helpers ==========
+
+    /** The gating tests do not touch storage; any consistent pair will do. */
+    private fun service() = ManagementService(
+        PairingConfigManagementTest.FakeTrust(),
+        PairingConfigManagementTest.FakeConfigStore(),
+    )
 
     private fun session(management: Boolean) = ManagementSessionContext(
         hasManagementActivity = management,

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementRoutingTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementRoutingTest.kt
@@ -1,0 +1,239 @@
+package com.sendspindroid.sendspin.protocol.management
+
+import com.sendspindroid.sendspin.protocol.message.MessageBuilder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The management routing spine: parsing requests, the result vocabulary, and
+ * the per-message permission gate.
+ *
+ * `management.md#management`: "All `management/...` requests are answered by a
+ * single `management/result` message. At most one management request may be in
+ * flight per connection; in-order WebSocket delivery makes the reply
+ * unambiguous."
+ *
+ * The distinction this file exists to protect: an unauthorised *activation*
+ * closes the connection, while an unauthorised *message* is answered with
+ * `permission_denied` and the connection stays open. Conflating them either
+ * drops a usable connection or leaves an unauthorised one alive.
+ */
+class ManagementRoutingTest {
+
+    // ========== The result vocabulary ==========
+
+    @Test
+    fun theResultCodesAreExactlyTheSpecSet() {
+        assertEquals(
+            setOf(
+                "ok",
+                "permission_denied",
+                "already_exists",
+                "invalid",
+                "not_found",
+                "storage_exhausted",
+            ),
+            ManagementResultCode.entries.map { it.wire }.toSet(),
+        )
+    }
+
+    @Test
+    fun aResultCarriesTheCodeAndNothingElse() {
+        val json = parse(MessageBuilder.buildManagementResult(ManagementResultCode.OK))
+
+        assertEquals("management/result", json["type"]?.jsonPrimitive?.content)
+        assertEquals(setOf("result"), json["payload"]!!.jsonObject.keys)
+        assertEquals("ok", json["payload"]!!.jsonObject["result"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun noResultCarriesAStorageObject() {
+        // "a client whose storage is effectively unbounded or of unknown size
+        // omits the key, and the server relies on storage_exhausted alone."
+        // Records are ~100 bytes in EncryptedSharedPreferences on a filesystem
+        // measured in gigabytes, so any capacity we invented would corrupt the
+        // server's free/cost arithmetic.
+        for (code in ManagementResultCode.entries) {
+            val payload = parse(MessageBuilder.buildManagementResult(code))["payload"]!!.jsonObject
+            assertFalse("$code carried a storage key", payload.containsKey("storage"))
+        }
+    }
+
+    @Test
+    fun noResultCarriesARequestIdentifier() {
+        // "The at-most-one-in-flight rule lets the server match each reply to
+        // its request by ordering alone, so no request-identifier field is
+        // carried." An invented id would be ignored at best.
+        val payload = parse(
+            MessageBuilder.buildManagementResult(
+                ManagementResultCode.OK,
+                buildJsonObject { put("records", "[]") },
+            )
+        )["payload"]!!.jsonObject
+
+        for (key in listOf("id", "request_id", "seq")) {
+            assertFalse("payload carried $key", payload.containsKey(key))
+        }
+    }
+
+    @Test
+    fun dataRidesAlongOnlyWithOk() {
+        val data = buildJsonObject { put("pairing_psk_enabled", true) }
+
+        val ok = parse(MessageBuilder.buildManagementResult(ManagementResultCode.OK, data))
+        assertEquals(true, ok["payload"]!!.jsonObject["pairing_psk_enabled"]?.jsonPrimitive?.content?.toBoolean())
+
+        // A failure carrying data invites the server to read state out of a
+        // reply that says the operation did not happen.
+        val denied = parse(
+            MessageBuilder.buildManagementResult(ManagementResultCode.PERMISSION_DENIED, data)
+        )
+        assertEquals(setOf("result"), denied["payload"]!!.jsonObject.keys)
+    }
+
+    // ========== Parsing ==========
+
+    @Test
+    fun nonManagementTypesAreNotOurs() {
+        for (type in listOf("server/state", "client/hello", "stream/start", "management")) {
+            assertNull(type, ManagementRequestParser.parse(type, null))
+        }
+    }
+
+    @Test
+    fun everyImplementedTypeParses() {
+        assertTrue(ManagementRequestParser.parse("management/list-records", null) is ManagementRequest.ListRecords)
+        assertTrue(ManagementRequestParser.parse("management/get-pairing-config", null) is ManagementRequest.GetPairingConfig)
+        assertTrue(ManagementRequestParser.parse("management/open-pairing-window", null) is ManagementRequest.OpenPairingWindow)
+
+        val add = ManagementRequestParser.parse(
+            "management/add-record",
+            buildJsonObject { put("psk", "AAAA"); put("server_id", "srv1") },
+        )
+        assertEquals(ManagementRequest.AddRecord("AAAA", "srv1"), add)
+
+        val remove = ManagementRequestParser.parse(
+            "management/remove-record",
+            buildJsonObject { put("psk_id", "abc") },
+        )
+        assertEquals(ManagementRequest.RemoveRecord("abc"), remove)
+
+        val set = ManagementRequestParser.parse(
+            "management/set-pairing-config",
+            buildJsonObject { put("pairing_psk_enabled", false) },
+        )
+        assertTrue(set is ManagementRequest.SetPairingConfig)
+    }
+
+    @Test
+    fun anUnknownManagementTypeIsStillOursToAnswer() {
+        // It must reach the service and come back as `invalid`, not fall
+        // through to the generic unhandled-message log where the server would
+        // wait for a reply that never comes.
+        val request = ManagementRequestParser.parse("management/does-not-exist", null)
+
+        assertEquals(ManagementRequest.Unrecognized("management/does-not-exist"), request)
+    }
+
+    @Test
+    fun theParserNeverThrowsOnBadPayloads() {
+        val nonsense = listOf(
+            null,
+            buildJsonObject { },
+            buildJsonObject { put("psk", 42) },
+            buildJsonObject { put("psk_id", true) },
+        )
+
+        for (payload in nonsense) {
+            for (type in MANAGEMENT_TYPES) {
+                // Field validation belongs to the service, which answers
+                // `invalid`. A throwing parser would take out the connection
+                // over a malformed field.
+                assertNotNull("$type with $payload", ManagementRequestParser.parse(type, payload))
+            }
+        }
+    }
+
+    // ========== The permission gate ==========
+
+    @Test
+    fun everyRequestOutsideAManagementSessionIsDenied() {
+        val service = ManagementService()
+
+        for (request in ALL_REQUESTS) {
+            val outcome = service.handle(request, session(management = false))
+
+            assertEquals("$request", ManagementResultCode.PERMISSION_DENIED, outcome.code)
+            assertNull("$request carried data", outcome.data)
+            assertNull("$request asked to close", outcome.closeAfterReply)
+        }
+    }
+
+    @Test
+    fun anUnknownRequestInsideASessionIsInvalid() {
+        val outcome = ManagementService()
+            .handle(ManagementRequest.Unrecognized("management/nope"), session(management = true))
+
+        assertEquals(ManagementResultCode.INVALID, outcome.code)
+    }
+
+    @Test
+    fun openingAPairingWindowIsInvalidWithNoPinMethod() {
+        // "rejected as `invalid` when no PIN method is enabled." This client
+        // implements neither PIN method (audit D2), so it is always invalid.
+        val outcome = ManagementService()
+            .handle(ManagementRequest.OpenPairingWindow, session(management = true))
+
+        assertEquals(ManagementResultCode.INVALID, outcome.code)
+    }
+
+    @Test
+    fun aDeniedRequestNeverClosesTheConnection() {
+        // The single most important behaviour here: an unauthorised *message*
+        // is answered and the connection continues. Only an unauthorised
+        // *activation* closes, and that is decided in ServerActivateRules.
+        for (request in ALL_REQUESTS) {
+            assertNull(ManagementService().handle(request, session(management = false)).closeAfterReply)
+        }
+    }
+
+    // ========== Helpers ==========
+
+    private fun session(management: Boolean) = ManagementSessionContext(
+        hasManagementActivity = management,
+        pinMethodEnabled = false,
+    )
+
+    private fun parse(text: String): JsonObject = Json.parseToJsonElement(text).jsonObject
+
+    private companion object {
+        val MANAGEMENT_TYPES = listOf(
+            "management/list-records",
+            "management/add-record",
+            "management/remove-record",
+            "management/get-pairing-config",
+            "management/set-pairing-config",
+            "management/open-pairing-window",
+        )
+
+        val ALL_REQUESTS = listOf(
+            ManagementRequest.ListRecords,
+            ManagementRequest.AddRecord("AAAA", "srv1"),
+            ManagementRequest.RemoveRecord("abc"),
+            ManagementRequest.GetPairingConfig,
+            ManagementRequest.SetPairingConfig(buildJsonObject { }),
+            ManagementRequest.OpenPairingWindow,
+            ManagementRequest.Unrecognized("management/nope"),
+        )
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/PairingConfigManagementTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/PairingConfigManagementTest.kt
@@ -343,10 +343,20 @@ class PairingConfigManagementTest {
             PskRecord(BOUND_RECORD_ID, BOUND_RECORD_PSK, serverId = "srv1"),
         )
 
+        var failAdds = false
+
         override fun listRecords(): List<PskRecord> = records.toList()
         override fun findByPskId(pskId: String): PskRecord? = records.find { it.pskId == pskId }
-        override fun addRecord(psk: ByteArray, serverId: String?) =
-            throw UnsupportedOperationException()
+
+        override fun addRecord(psk: ByteArray, serverId: String?): TrustStore.AddRecordResult {
+            if (psk.size != Psk.PSK_SIZE) return TrustStore.AddRecordResult.Invalid
+            val id = PskId.derive(psk)
+            if (records.any { it.pskId == id }) return TrustStore.AddRecordResult.AlreadyExists
+            if (failAdds) return TrustStore.AddRecordResult.StorageFailed
+            val record = PskRecord(id, psk, serverId)
+            records.add(record)
+            return TrustStore.AddRecordResult.Ok(record)
+        }
         override fun removeRecord(pskId: String): Boolean = records.removeAll { it.pskId == pskId }
         override fun markUsed(pskId: String) = Unit
         override fun candidates(): List<Psk> = records.map { it.toPsk() }

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/PairingConfigManagementTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/PairingConfigManagementTest.kt
@@ -1,0 +1,400 @@
+package com.sendspindroid.sendspin.protocol.management
+
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PairingConfig
+import com.sendspindroid.sendspin.crypto.PairingConfigStore
+import com.sendspindroid.sendspin.crypto.PskCategory
+import com.sendspindroid.sendspin.crypto.PskId
+import com.sendspindroid.sendspin.crypto.PskRecord
+import com.sendspindroid.sendspin.crypto.SentinelPsk
+import com.sendspindroid.sendspin.crypto.TrustStore
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `management/get-pairing-config` and `management/set-pairing-config`.
+ *
+ * `management.md#server--client-managementset-pairing-config`: "The request
+ * applies as a patch: only fields present in the payload are written, and any
+ * absent field (including an absent method object) leaves the corresponding
+ * stored value unchanged."
+ *
+ * Two traps, both of which produce a client that mostly works:
+ *
+ *  - **Presence is not nullness.** An absent field means "leave alone"; a field
+ *    present with a null value is malformed. Collapsing the two silently
+ *    rewrites configuration the server never asked to change.
+ *  - **A patch is atomic.** A patch that is invalid anywhere must write
+ *    nothing, or a rejected request still half-applies and the server's view of
+ *    the client diverges from the client's own.
+ */
+class PairingConfigManagementTest {
+
+    // ========== Reading ==========
+
+    @Test
+    fun theConfigReportsTheStoredFlags() {
+        for (enabled in listOf(true, false)) {
+            val service = service(pairingPskEnabled = enabled, unpairedAccess = !enabled)
+
+            val data = service.handle(ManagementRequest.GetPairingConfig, session()).okData()
+
+            assertEquals(enabled, data.bool("pairing_psk", "enabled"))
+            assertEquals(!enabled, data.bool("unpaired_access", "enabled"))
+        }
+    }
+
+    @Test
+    fun unimplementedMethodsAreAbsentRatherThanDisabled() {
+        // "A PIN-method object is absent if the client does not implement that
+        // method." Emitting {"enabled": false} would advertise a method we
+        // could be asked to turn on.
+        val data = service().handle(ManagementRequest.GetPairingConfig, session()).okData()
+
+        assertFalse("static_pin present", data.containsKey("static_pin"))
+        assertFalse("dynamic_pin present", data.containsKey("dynamic_pin"))
+    }
+
+    @Test
+    fun theConfigNeverCarriesTheSecret() {
+        // "Configured secrets (the Pairing PSK and the static PIN) are not
+        // returned; use management/set-pairing-config to rotate them."
+        val service = service()
+
+        val data = service.handle(ManagementRequest.GetPairingConfig, session()).okData()
+
+        val serialized = data.toString()
+        assertFalse(serialized.contains(base64Url(PAIRING_PSK)))
+        // The id is a hash of the secret and is safe; the bytes are not.
+        assertTrue(serialized.contains(SHARED_RECORD_ID))
+    }
+
+    @Test
+    fun recordModeNamesTheSharedRecord() {
+        val data = service().handle(ManagementRequest.GetPairingConfig, session()).okData()
+
+        assertEquals(SHARED_RECORD_ID, data.str("record_mode", "psk_id"))
+    }
+
+    // ========== Patching: presence semantics ==========
+
+    @Test
+    fun anEmptyPatchChangesNothing() {
+        val store = FakeConfigStore()
+        val service = service(store = store)
+
+        assertEquals(ManagementResultCode.OK, service.set("{}").code)
+        assertEquals(0, store.writes)
+    }
+
+    @Test
+    fun anAbsentFieldIsLeftAlone() {
+        val store = FakeConfigStore(pairingPskEnabled = true, unpairedAccess = true)
+        val service = service(store = store)
+
+        service.set("""{"pairing_psk":{"enabled":false}}""")
+
+        assertEquals(false, store.config.pairingPskEnabled)
+        assertEquals("unpaired_access was absent and must be untouched", true, store.config.unpairedAccessEnabled)
+    }
+
+    @Test
+    fun anEmptyMethodObjectSetsNothing() {
+        // "only fields present in the payload are written" - an object with no
+        // fields sets none, so it is a no-op rather than an error.
+        val store = FakeConfigStore(pairingPskEnabled = true)
+        val service = service(store = store)
+
+        assertEquals(ManagementResultCode.OK, service.set("""{"pairing_psk":{}}""").code)
+        assertEquals(true, store.config.pairingPskEnabled)
+    }
+
+    @Test
+    fun aNullMethodObjectIsMalformed() {
+        // Present but not an object. Treating null as "absent" would let a
+        // malformed patch pass silently as a no-op.
+        val store = FakeConfigStore(pairingPskEnabled = true)
+        val service = service(store = store)
+
+        assertEquals(ManagementResultCode.INVALID, service.set("""{"pairing_psk":null}""").code)
+        assertEquals(0, store.writes)
+    }
+
+    @Test
+    fun aNonObjectMethodValueIsMalformed() {
+        val store = FakeConfigStore()
+        val service = service(store = store)
+
+        assertEquals(ManagementResultCode.INVALID, service.set("""{"unpaired_access":5}""").code)
+        assertEquals(0, store.writes)
+    }
+
+    @Test
+    fun aNonBooleanEnabledIsMalformed() {
+        val store = FakeConfigStore()
+        val service = service(store = store)
+
+        assertEquals(
+            ManagementResultCode.INVALID,
+            service.set("""{"pairing_psk":{"enabled":"yes"}}""").code,
+        )
+        assertEquals(0, store.writes)
+    }
+
+    // ========== Patching: methods we do not implement ==========
+
+    @Test
+    fun settingAFieldOnAnUnimplementedMethodIsRejected() {
+        // "Fields set on a method the client does not implement are rejected as
+        // invalid."
+        for (patch in listOf(
+            """{"static_pin":{"enabled":true}}""",
+            """{"dynamic_pin":{"min_pin_length":6}}""",
+        )) {
+            val store = FakeConfigStore()
+            assertEquals(patch, ManagementResultCode.INVALID, service(store = store).set(patch).code)
+            assertEquals(0, store.writes)
+        }
+    }
+
+    @Test
+    fun anEmptyUnimplementedMethodObjectSetsNoFieldsAndIsAccepted() {
+        // The literal reading of the sentence above: it rejects field *sets*,
+        // and an empty object sets nothing. The conservative choice.
+        val store = FakeConfigStore()
+
+        assertEquals(ManagementResultCode.OK, service(store = store).set("""{"static_pin":{}}""").code)
+        assertEquals(0, store.writes)
+    }
+
+    // ========== Patching: atomicity ==========
+
+    @Test
+    fun aPatchThatFailsAnywhereWritesNothing() {
+        val store = FakeConfigStore(pairingPskEnabled = true)
+        val service = service(store = store)
+
+        val outcome = service.set(
+            """{"pairing_psk":{"enabled":false},"static_pin":{"enabled":true}}"""
+        )
+
+        assertEquals(ManagementResultCode.INVALID, outcome.code)
+        assertEquals("the valid half must not have been applied", true, store.config.pairingPskEnabled)
+        assertEquals(0, store.writes)
+    }
+
+    // ========== Rotation ==========
+
+    @Test
+    fun rotatingThePairingPskReplacesItAndLeavesRecordsAlone() {
+        val store = FakeConfigStore()
+        val trust = FakeTrust()
+        val service = service(store = store, trust = trust)
+        val fresh = ByteArray(32) { 0x5A }
+
+        val before = trust.listRecords().map { it.pskId }
+
+        val outcome = service.set("""{"pairing_psk":{"psk":"${base64Url(fresh)}"}}""")
+
+        assertEquals(ManagementResultCode.OK, outcome.code)
+        assertTrue(store.config.pairingPsk.contentEquals(fresh))
+        // "Rotation invalidates previously distributed copies but leaves
+        // established pairing records untouched."
+        assertEquals(before, trust.listRecords().map { it.pskId })
+    }
+
+    @Test
+    fun aPskThatIsNotThirtyTwoBytesIsMalformed() {
+        for (bad in listOf("", "AAAA", base64Url(ByteArray(31)), base64Url(ByteArray(33)), "not base64url!!")) {
+            val store = FakeConfigStore()
+            assertEquals(
+                "psk=$bad",
+                ManagementResultCode.INVALID,
+                service(store = store).set("""{"pairing_psk":{"psk":"$bad"}}""").code,
+            )
+            assertEquals(0, store.writes)
+        }
+    }
+
+    @Test
+    fun aPskCollidingWithAnotherCategoryIsRejected() {
+        // "The three PSK categories share one psk_id namespace, so a psk_id
+        // must be unique across them." A collision would make one wire psk_id
+        // map to two trust levels.
+        val trust = FakeTrust()
+        val store = FakeConfigStore()
+
+        val outcome = service(store = store, trust = trust)
+            .set("""{"pairing_psk":{"psk":"${base64Url(SHARED_RECORD_PSK)}"}}""")
+
+        assertEquals(ManagementResultCode.ALREADY_EXISTS, outcome.code)
+        assertEquals(0, store.writes)
+    }
+
+    @Test
+    fun rotatingToTheCurrentPairingPskIsANoOp() {
+        // Same category, so not a cross-category collision.
+        val store = FakeConfigStore()
+
+        val outcome = service(store = store).set("""{"pairing_psk":{"psk":"${base64Url(PAIRING_PSK)}"}}""")
+
+        assertEquals(ManagementResultCode.OK, outcome.code)
+        assertTrue(store.config.pairingPsk.contentEquals(PAIRING_PSK))
+    }
+
+    @Test
+    fun aFailedPersistReportsStorageExhausted() {
+        val store = FakeConfigStore().apply { failWrites = true }
+
+        val outcome = service(store = store).set("""{"pairing_psk":{"enabled":false}}""")
+
+        assertEquals(ManagementResultCode.STORAGE_EXHAUSTED, outcome.code)
+    }
+
+    // ========== Record mode ==========
+
+    @Test
+    fun recordModeMayPointAtASharedRecord() {
+        val store = FakeConfigStore()
+
+        val outcome = service(store = store).set("""{"record_mode":{"psk_id":"$SHARED_RECORD_ID"}}""")
+
+        assertEquals(ManagementResultCode.OK, outcome.code)
+        assertEquals(SHARED_RECORD_ID, store.config.recordModePskId)
+    }
+
+    @Test
+    fun recordModeMayNotPointAtAStoredPubkeyRecord() {
+        // "psk_id MUST reference a shared-PSK record ... any management request
+        // that would set psk_id to a missing or stored-pubkey record is
+        // rejected."
+        val store = FakeConfigStore()
+
+        val outcome = service(store = store).set("""{"record_mode":{"psk_id":"$BOUND_RECORD_ID"}}""")
+
+        assertEquals(ManagementResultCode.INVALID, outcome.code)
+        assertEquals(0, store.writes)
+    }
+
+    @Test
+    fun recordModeMayNotPointAtSomethingThatIsNotARecord() {
+        for (id in listOf("no-such-record", SentinelPsk.psk.pskId, PskId.derive(PAIRING_PSK))) {
+            val store = FakeConfigStore()
+            assertEquals(
+                "psk_id=$id",
+                ManagementResultCode.INVALID,
+                service(store = store).set("""{"record_mode":{"psk_id":"$id"}}""").code,
+            )
+        }
+    }
+
+    // ========== Helpers ==========
+
+    private fun ManagementService.set(patch: String): ManagementOutcome = handle(
+        ManagementRequest.SetPairingConfig(Json.parseToJsonElement(patch).jsonObject),
+        session(),
+    )
+
+    private fun session() = ManagementSessionContext(
+        hasManagementActivity = true,
+        pinMethodEnabled = false,
+    )
+
+    private fun service(
+        pairingPskEnabled: Boolean = true,
+        unpairedAccess: Boolean = true,
+        store: FakeConfigStore = FakeConfigStore(pairingPskEnabled, unpairedAccess),
+        trust: FakeTrust = FakeTrust(),
+    ) = ManagementService(trust, store)
+
+    private fun ManagementOutcome.okData(): JsonObject {
+        assertEquals(ManagementResultCode.OK, code)
+        return requireNotNull(data) { "an ok get-pairing-config must carry data" }
+    }
+
+    private fun JsonObject.bool(obj: String, key: String): Boolean =
+        this[obj]!!.jsonObject[key]!!.jsonPrimitive.content.toBoolean()
+
+    private fun JsonObject.str(obj: String, key: String): String =
+        this[obj]!!.jsonObject[key]!!.jsonPrimitive.content
+
+    companion object {
+        val PAIRING_PSK = ByteArray(32) { 0x11 }
+        val SHARED_RECORD_PSK = ByteArray(32) { 0x22 }
+        val BOUND_RECORD_PSK = ByteArray(32) { 0x33 }
+        val SHARED_RECORD_ID: String = PskId.derive(SHARED_RECORD_PSK)
+        val BOUND_RECORD_ID: String = PskId.derive(BOUND_RECORD_PSK)
+
+        fun base64Url(bytes: ByteArray): String =
+            com.sendspindroid.sendspin.crypto.Base64Url.encode(bytes)
+    }
+
+    /** Records: one shared-PSK (record mode's target) and one stored-pubkey. */
+    class FakeTrust : TrustStore {
+        private val records = mutableListOf(
+            PskRecord(SHARED_RECORD_ID, SHARED_RECORD_PSK, serverId = null),
+            PskRecord(BOUND_RECORD_ID, BOUND_RECORD_PSK, serverId = "srv1"),
+        )
+
+        override fun listRecords(): List<PskRecord> = records.toList()
+        override fun findByPskId(pskId: String): PskRecord? = records.find { it.pskId == pskId }
+        override fun addRecord(psk: ByteArray, serverId: String?) =
+            throw UnsupportedOperationException()
+        override fun removeRecord(pskId: String): Boolean = records.removeAll { it.pskId == pskId }
+        override fun markUsed(pskId: String) = Unit
+        override fun candidates(): List<Psk> = records.map { it.toPsk() }
+        override val storageIsEncrypted: Boolean get() = true
+    }
+
+    class FakeConfigStore(
+        pairingPskEnabled: Boolean = true,
+        unpairedAccess: Boolean = true,
+    ) : PairingConfigStore {
+
+        var config = PairingConfig(PAIRING_PSK, pairingPskEnabled, unpairedAccess, SHARED_RECORD_ID)
+            private set
+
+        var writes = 0
+            private set
+
+        var failWrites = false
+
+        override fun load(): PairingConfig = config
+
+        override fun setEnabled(enabled: Boolean): Boolean = write(config.withEnabled(enabled))
+
+        override fun setUnpairedAccess(enabled: Boolean): Boolean =
+            write(config.withUnpairedAccess(enabled))
+
+        override fun setRecordModePskId(pskId: String): Boolean =
+            write(config.withRecordModePskId(pskId))
+
+        override fun rotatePairingPsk(
+            newPsk: ByteArray,
+            claimedPskIds: Set<String>,
+        ): PairingConfigStore.RotateResult {
+            if (newPsk.size != Psk.PSK_SIZE) return PairingConfigStore.RotateResult.Invalid
+            val id = PskId.derive(newPsk)
+            if (id != config.pairingPskId && id in claimedPskIds) {
+                return PairingConfigStore.RotateResult.AlreadyExists
+            }
+            if (failWrites) return PairingConfigStore.RotateResult.StorageFailed
+            if (id != config.pairingPskId) write(config.withPairingPsk(newPsk))
+            return PairingConfigStore.RotateResult.Ok
+        }
+
+        private fun write(next: PairingConfig): Boolean {
+            if (failWrites) return false
+            config = next
+            writes++
+            return true
+        }
+    }
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/RecordManagementTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/management/RecordManagementTest.kt
@@ -1,0 +1,227 @@
+package com.sendspindroid.sendspin.protocol.management
+
+import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.protocol.GoodbyeReason
+import com.sendspindroid.sendspin.crypto.PskId
+import com.sendspindroid.sendspin.crypto.SentinelPsk
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `management/list-records`, `add-record` and `remove-record`.
+ *
+ * Mostly CRUD, with three sharp edges:
+ *
+ *  - The three PSK categories share one `psk_id` namespace, so a new record can
+ *    collide with the Sentinel or with our own Pairing PSK. "Two categories
+ *    sharing one would make a single wire `psk_id` map to two trust levels."
+ *  - The record named by `record_mode.psk_id` is pinned and cannot be removed.
+ *  - Removing the requester's own record must answer *before* the goodbye that
+ *    tears the session down.
+ */
+class RecordManagementTest {
+
+    private val trust = PairingConfigManagementTest.FakeTrust()
+    private val config = PairingConfigManagementTest.FakeConfigStore()
+    private val service = ManagementService(trust, config)
+
+    // ========== Listing ==========
+
+    @Test
+    fun aStoredPubkeyRecordReportsItsServer() {
+        val entry = list().first { it.str("psk_id") == PairingConfigManagementTest.BOUND_RECORD_ID }
+
+        assertEquals("srv1", entry.str("server_id"))
+        assertEquals(false, entry["used"]?.jsonPrimitive?.booleanOrNull)
+    }
+
+    @Test
+    fun aSharedRecordOmitsServerIdRatherThanNullingIt() {
+        // "present for stored-pubkey records, absent for shared-PSK records".
+        // An explicit null would read as "bound to nothing" rather than "not
+        // bound", and the two mean different things at handshake time.
+        val entry = list().first { it.str("psk_id") == PairingConfigManagementTest.SHARED_RECORD_ID }
+
+        assertFalse("server_id present on a shared record", entry.containsKey("server_id"))
+        assertNotNull(entry["used"])
+    }
+
+    @Test
+    fun listingPreservesStoreOrder() {
+        val ids = list().map { it.str("psk_id") }
+
+        assertEquals(trust.listRecords().map { it.pskId }, ids)
+    }
+
+    @Test
+    fun anEmptyStoreListsAnEmptyArrayRatherThanNothing() {
+        val empty = PairingConfigManagementTest.FakeTrust().apply {
+            listRecords().forEach { removeRecord(it.pskId) }
+        }
+
+        val data = ManagementService(empty, config)
+            .handle(ManagementRequest.ListRecords, session()).okData()
+
+        assertNotNull("records key must exist", data["records"])
+        assertEquals(0, data["records"]!!.jsonArray.size)
+    }
+
+    // ========== Adding ==========
+
+    @Test
+    fun aRecordCanBeAddedWithAndWithoutAServer() {
+        // A server_id is a Curve25519 public key, so it has the same shape as
+        // a psk_id - 43 base64url characters over 32 bytes.
+        val serverId = Base64Url.encode(ByteArray(32) { 0x51 })
+        val bound = ByteArray(32) { 0x41 }
+        assertEquals(ManagementResultCode.OK, add(bound, serverId).code)
+        assertEquals(serverId, trust.findByPskId(PskId.derive(bound))?.serverId)
+
+        val shared = ByteArray(32) { 0x42 }
+        assertEquals(ManagementResultCode.OK, add(shared, null).code)
+        assertNull(trust.findByPskId(PskId.derive(shared))?.serverId)
+    }
+
+    @Test
+    fun anAddedRecordStartsUnused() {
+        val psk = ByteArray(32) { 0x43 }
+
+        add(psk, null)
+
+        assertEquals(false, trust.findByPskId(PskId.derive(psk))?.used)
+    }
+
+    @Test
+    fun aMalformedPskIsRejected() {
+        for (bad in listOf(
+            "",
+            "AAAA",
+            Base64Url.encode(ByteArray(31)),
+            Base64Url.encode(ByteArray(33)),
+            Base64Url.encode(ByteArray(32)) + "=",
+            "not+base64url/at+all",
+        )) {
+            val before = trust.listRecords().size
+            val outcome = service.handle(
+                ManagementRequest.AddRecord(bad, null), session()
+            )
+            assertEquals("psk=$bad", ManagementResultCode.INVALID, outcome.code)
+            assertEquals("store changed for psk=$bad", before, trust.listRecords().size)
+        }
+    }
+
+    @Test
+    fun aCollisionWithAnyCategoryIsRejected() {
+        // All three categories in one namespace: an existing record, the
+        // published Sentinel, and our own Pairing PSK.
+        val colliding = listOf(
+            PairingConfigManagementTest.SHARED_RECORD_PSK,
+            SentinelPsk.psk.bytes,
+            PairingConfigManagementTest.PAIRING_PSK,
+        )
+
+        for (psk in colliding) {
+            val before = trust.listRecords().size
+            assertEquals(
+                "psk_id=${PskId.derive(psk)}",
+                ManagementResultCode.ALREADY_EXISTS,
+                add(psk, null).code,
+            )
+            assertEquals(before, trust.listRecords().size)
+        }
+    }
+
+    @Test
+    fun aMalformedServerIdIsRejected() {
+        val before = trust.listRecords().size
+
+        val outcome = add(ByteArray(32) { 0x44 }, "not-a-key")
+
+        assertEquals(ManagementResultCode.INVALID, outcome.code)
+        assertEquals(before, trust.listRecords().size)
+    }
+
+    @Test
+    fun aFailedWriteReportsStorageExhausted() {
+        trust.failAdds = true
+
+        assertEquals(ManagementResultCode.STORAGE_EXHAUSTED, add(ByteArray(32) { 0x45 }, null).code)
+    }
+
+    // ========== Removing ==========
+
+    @Test
+    fun aRecordCanBeRemoved() {
+        val outcome = remove(PairingConfigManagementTest.BOUND_RECORD_ID)
+
+        assertEquals(ManagementResultCode.OK, outcome.code)
+        assertNull(trust.findByPskId(PairingConfigManagementTest.BOUND_RECORD_ID))
+        assertNull("removing someone else's record must not close", outcome.closeAfterReply)
+    }
+
+    @Test
+    fun removingSomethingThatIsNotARecordIsNotFound() {
+        // The Sentinel and the Pairing PSK are not records, so they are
+        // not_found rather than invalid.
+        for (id in listOf("no-such-id", SentinelPsk.psk.pskId, PskId.derive(PairingConfigManagementTest.PAIRING_PSK))) {
+            assertEquals(id, ManagementResultCode.NOT_FOUND, remove(id).code)
+        }
+    }
+
+    @Test
+    fun theRecordModeRecordIsPinned() {
+        // "the referenced shared-PSK record cannot be removed while the
+        // reference exists ... rejected as invalid."
+        val outcome = remove(PairingConfigManagementTest.SHARED_RECORD_ID)
+
+        assertEquals(ManagementResultCode.INVALID, outcome.code)
+        assertNotNull(trust.findByPskId(PairingConfigManagementTest.SHARED_RECORD_ID))
+    }
+
+    @Test
+    fun removingOurOwnRecordAnswersThenAsksToClose() {
+        // "Removing the requester's own record closes the management session
+        // with client/goodbye reason 'unauthorized' AFTER the response."
+        val outcome = service.handle(
+            ManagementRequest.RemoveRecord(PairingConfigManagementTest.BOUND_RECORD_ID),
+            session(matchedPskId = PairingConfigManagementTest.BOUND_RECORD_ID),
+        )
+
+        assertEquals(ManagementResultCode.OK, outcome.code)
+        assertEquals(GoodbyeReason.UNAUTHORIZED.wire, outcome.closeAfterReply)
+    }
+
+    // ========== Helpers ==========
+
+    private fun list(): List<JsonObject> =
+        service.handle(ManagementRequest.ListRecords, session())
+            .okData()["records"]!!.jsonArray.map { it.jsonObject }
+
+    private fun add(psk: ByteArray, serverId: String?) =
+        service.handle(ManagementRequest.AddRecord(Base64Url.encode(psk), serverId), session())
+
+    private fun remove(pskId: String) =
+        service.handle(ManagementRequest.RemoveRecord(pskId), session())
+
+    private fun session(matchedPskId: String? = null) = ManagementSessionContext(
+        hasManagementActivity = true,
+        pinMethodEnabled = false,
+        matchedPskId = matchedPskId,
+    )
+
+    private fun ManagementOutcome.okData(): JsonObject {
+        assertEquals(ManagementResultCode.OK, code)
+        return requireNotNull(data)
+    }
+
+    private fun JsonObject.str(key: String): String = this[key]!!.jsonPrimitive.content
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PairingConfig.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PairingConfig.kt
@@ -15,11 +15,25 @@ package com.sendspindroid.sendspin.crypto
  *   miss, and the descriptor leaves `client/hello`.
  * @param unpairedAccessEnabled whether this client admits a server with no
  *   pairing record. Advertised as `unpaired_access.enabled`.
+ * @param recordModePskId the shared-PSK record backing record mode.
+ *
+ *   `management.md#record-mode` requires this to name a real shared-PSK record,
+ *   and `get-pairing-config` lists `record_mode` as a non-optional member of the
+ *   response - so the client ships exactly one pre-provisioned shared-PSK
+ *   record purely as this target. It is device-specific and CSPRNG-generated
+ *   ("MUST NOT be a fixed default shared across devices"), never leaves the
+ *   device, and is never used in practice: audit decision D4 puts us on the
+ *   stored-pubkey model, and Android storage is effectively unbounded, so the
+ *   storage-exhaustion path that would admit a server under record mode is
+ *   unreachable. Thirty-two bytes buys a well-formed `get-pairing-config` and
+ *   makes the `remove-record` referential constraint a real branch rather than
+ *   dead code.
  */
 class PairingConfig(
     pairingPsk: ByteArray,
     val pairingPskEnabled: Boolean,
     val unpairedAccessEnabled: Boolean,
+    val recordModePskId: String,
 ) {
     init {
         require(pairingPsk.size == Psk.PSK_SIZE) {
@@ -36,13 +50,16 @@ class PairingConfig(
     val pairingPskId: String by lazy { PskId.derive(secret) }
 
     fun withEnabled(enabled: Boolean): PairingConfig =
-        PairingConfig(secret, enabled, unpairedAccessEnabled)
+        PairingConfig(secret, enabled, unpairedAccessEnabled, recordModePskId)
 
     fun withUnpairedAccess(enabled: Boolean): PairingConfig =
-        PairingConfig(secret, pairingPskEnabled, enabled)
+        PairingConfig(secret, pairingPskEnabled, enabled, recordModePskId)
 
     fun withPairingPsk(psk: ByteArray): PairingConfig =
-        PairingConfig(psk, pairingPskEnabled, unpairedAccessEnabled)
+        PairingConfig(psk, pairingPskEnabled, unpairedAccessEnabled, recordModePskId)
+
+    fun withRecordModePskId(pskId: String): PairingConfig =
+        PairingConfig(secret, pairingPskEnabled, unpairedAccessEnabled, pskId)
 
     // Hand-written: a data class holding a ByteArray compares by reference.
     override fun equals(other: Any?): Boolean =
@@ -50,6 +67,7 @@ class PairingConfig(
             other is PairingConfig &&
                 pairingPskEnabled == other.pairingPskEnabled &&
                 unpairedAccessEnabled == other.unpairedAccessEnabled &&
+                recordModePskId == other.recordModePskId &&
                 secret.contentEquals(other.secret)
             )
 
@@ -57,11 +75,12 @@ class PairingConfig(
         var result = secret.contentHashCode()
         result = 31 * result + pairingPskEnabled.hashCode()
         result = 31 * result + unpairedAccessEnabled.hashCode()
+        result = 31 * result + recordModePskId.hashCode()
         return result
     }
 
     /** Never the bytes. */
     override fun toString(): String =
         "PairingConfig(pairingPskId=$pairingPskId, enabled=$pairingPskEnabled, " +
-            "unpairedAccess=$unpairedAccessEnabled)"
+            "unpairedAccess=$unpairedAccessEnabled, recordMode=$recordModePskId)"
 }

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PairingConfigStore.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/PairingConfigStore.kt
@@ -16,6 +16,9 @@ interface PairingConfigStore {
 
         /** Not a 32-byte PSK. */
         object Invalid : RotateResult
+
+        /** The bytes were fine; persisting them was not. */
+        object StorageFailed : RotateResult
     }
 
     /**
@@ -24,10 +27,19 @@ interface PairingConfigStore {
      */
     fun load(): PairingConfig
 
-    /** Offer or withdraw the `pairing_psk` method. Never discards the secret. */
-    fun setEnabled(enabled: Boolean)
+    /**
+     * Offer or withdraw the `pairing_psk` method. Never discards the secret.
+     *
+     * @return false if the change could not be persisted. Management answers
+     *   `ok` only once "any state change has been persisted", so a caller that
+     *   ignored this would claim a durability it does not have.
+     */
+    fun setEnabled(enabled: Boolean): Boolean
 
-    fun setUnpairedAccess(enabled: Boolean)
+    fun setUnpairedAccess(enabled: Boolean): Boolean
+
+    /** Point record mode at a different shared-PSK record. */
+    fun setRecordModePskId(pskId: String): Boolean
 
     /**
      * Replace the Pairing PSK.

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/TrustStore.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/crypto/TrustStore.kt
@@ -83,6 +83,9 @@ interface TrustStore {
 
         /** Not a 32-byte PSK. */
         object Invalid : AddRecordResult
+
+        /** The record was fine; persisting it was not. */
+        object StorageFailed : AddRecordResult
     }
 
     fun listRecords(): List<PskRecord>

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
@@ -158,6 +158,17 @@ object SendSpinProtocol {
         const val STREAM_CLEAR = "stream/clear"
         const val STREAM_REQUEST_FORMAT = "stream/request-format"
         const val CLIENT_SYNC_OFFSET = "client/sync_offset"
+
+        // Management. Every one of these is answered by exactly one
+        // MANAGEMENT_RESULT; ordering alone matches reply to request, so none
+        // of them carries an identifier.
+        const val MANAGEMENT_LIST_RECORDS = "management/list-records"
+        const val MANAGEMENT_ADD_RECORD = "management/add-record"
+        const val MANAGEMENT_REMOVE_RECORD = "management/remove-record"
+        const val MANAGEMENT_GET_PAIRING_CONFIG = "management/get-pairing-config"
+        const val MANAGEMENT_SET_PAIRING_CONFIG = "management/set-pairing-config"
+        const val MANAGEMENT_OPEN_PAIRING_WINDOW = "management/open-pairing-window"
+        const val MANAGEMENT_RESULT = "management/result"
     }
 
     /**

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementRequest.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementRequest.kt
@@ -1,0 +1,78 @@
+package com.sendspindroid.sendspin.protocol.management
+
+import com.sendspindroid.sendspin.protocol.SendSpinProtocol
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/** A management request as it arrived, before any field validation. */
+sealed interface ManagementRequest {
+
+    object ListRecords : ManagementRequest
+
+    data class AddRecord(val psk: String, val serverId: String?) : ManagementRequest
+
+    data class RemoveRecord(val pskId: String) : ManagementRequest
+
+    object GetPairingConfig : ManagementRequest
+
+    /** The raw patch. Absent keys mean "leave alone", so it cannot be flattened here. */
+    data class SetPairingConfig(val patch: JsonObject) : ManagementRequest
+
+    object OpenPairingWindow : ManagementRequest
+
+    /**
+     * A `management/` type this client does not implement.
+     *
+     * Modelled rather than dropped: every management request is answered, and
+     * a request that falls through to the generic unhandled-message log leaves
+     * the server waiting for a reply that never comes.
+     */
+    data class Unrecognized(val type: String) : ManagementRequest
+}
+
+/**
+ * Turns a wire type and payload into a [ManagementRequest].
+ *
+ * Never throws and never rejects. Field-level validation belongs to
+ * [ManagementService], which can answer `invalid` - a parser that threw would
+ * take out the whole connection over one malformed field.
+ */
+object ManagementRequestParser {
+
+    /** @return null when [type] is not a management request at all. */
+    fun parse(type: String, payload: JsonObject?): ManagementRequest? {
+        if (!type.startsWith(PREFIX)) return null
+
+        return when (type) {
+            SendSpinProtocol.MessageType.MANAGEMENT_LIST_RECORDS ->
+                ManagementRequest.ListRecords
+
+            SendSpinProtocol.MessageType.MANAGEMENT_ADD_RECORD ->
+                ManagementRequest.AddRecord(
+                    psk = payload.string("psk") ?: "",
+                    serverId = payload.string("server_id"),
+                )
+
+            SendSpinProtocol.MessageType.MANAGEMENT_REMOVE_RECORD ->
+                ManagementRequest.RemoveRecord(pskId = payload.string("psk_id") ?: "")
+
+            SendSpinProtocol.MessageType.MANAGEMENT_GET_PAIRING_CONFIG ->
+                ManagementRequest.GetPairingConfig
+
+            SendSpinProtocol.MessageType.MANAGEMENT_SET_PAIRING_CONFIG ->
+                ManagementRequest.SetPairingConfig(payload ?: JsonObject(emptyMap()))
+
+            SendSpinProtocol.MessageType.MANAGEMENT_OPEN_PAIRING_WINDOW ->
+                ManagementRequest.OpenPairingWindow
+
+            else -> ManagementRequest.Unrecognized(type)
+        }
+    }
+
+    private const val PREFIX = "management/"
+
+    /** Null for a missing key or a non-string value; the service decides what that means. */
+    private fun JsonObject?.string(key: String): String? =
+        runCatching { this?.get(key)?.jsonPrimitive?.contentOrNull }.getOrNull()
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementResultCode.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementResultCode.kt
@@ -1,0 +1,34 @@
+package com.sendspindroid.sendspin.protocol.management
+
+/**
+ * The result of a management request.
+ *
+ * `management.md#client--server-managementresult`. Exactly six codes, pinned by
+ * `ManagementRoutingTest`: the server branches on these, so an invented code is
+ * one it cannot interpret, and a missing one forces a wrong answer onto a real
+ * situation.
+ */
+enum class ManagementResultCode(val wire: String) {
+
+    /** "operation completed and any state change has been persisted". */
+    OK("ok"),
+
+    /** "the request was issued outside a valid management session". */
+    PERMISSION_DENIED("permission_denied"),
+
+    /** "the request conflicts with an existing entry on the client". */
+    ALREADY_EXISTS("already_exists"),
+
+    /**
+     * "the request payload is malformed, contains an out-of-range value, omits
+     * a field required for the chosen operation, or violates a referential
+     * constraint".
+     */
+    INVALID("invalid"),
+
+    /** "the request targets an identifier ... that does not exist on the client". */
+    NOT_FOUND("not_found"),
+
+    /** "the client cannot persist the change due to full storage". */
+    STORAGE_EXHAUSTED("storage_exhausted"),
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementService.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementService.kt
@@ -1,0 +1,76 @@
+package com.sendspindroid.sendspin.protocol.management
+
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * What the connection should do with a management request.
+ *
+ * @param closeAfterReply a `client/goodbye` reason to send *after* the result
+ *   frame, or null to leave the connection open. Only 3.3 (#229) produces one:
+ *   removing the record that authenticated this very session.
+ */
+data class ManagementOutcome(
+    val code: ManagementResultCode,
+    val data: JsonObject? = null,
+    val closeAfterReply: String? = null,
+)
+
+/**
+ * The session facts a management request is judged against.
+ *
+ * Deliberately not the whole connection: the service is pure, so the rules can
+ * be tested without a socket, a store, or a handshake.
+ */
+data class ManagementSessionContext(
+    val hasManagementActivity: Boolean,
+    val pinMethodEnabled: Boolean,
+)
+
+/**
+ * Answers `management/` requests.
+ *
+ * `management.md#management`: "If a `management/...` message arrives on a
+ * connection without `'management'` in activities, the client replies with
+ * `management/result` `permission_denied`."
+ *
+ * Note what that does *not* say: it does not close the connection. The other
+ * management gate - the server declaring `'management'` in `activities` on a
+ * connection whose matched PSK does not permit it - does close, and lives in
+ * `ServerActivateRules`. Keeping the two apart is the point of this class;
+ * conflating them either drops a usable connection or leaves an unauthorised
+ * one alive.
+ */
+class ManagementService {
+
+    fun handle(
+        request: ManagementRequest,
+        session: ManagementSessionContext,
+    ): ManagementOutcome {
+        if (!session.hasManagementActivity) {
+            // Answered, never closed, and never with data - a denial that
+            // carried state would leak exactly what the denial withholds.
+            return ManagementOutcome(ManagementResultCode.PERMISSION_DENIED)
+        }
+
+        return when (request) {
+            is ManagementRequest.Unrecognized ->
+                ManagementOutcome(ManagementResultCode.INVALID)
+
+            ManagementRequest.OpenPairingWindow ->
+                // "rejected as `invalid` when no PIN method is enabled". This
+                // client implements neither PIN method (audit D2), so no PIN
+                // method can be enabled and the answer is always invalid.
+                ManagementOutcome(ManagementResultCode.INVALID)
+
+            // The record and config operations land in #228 and #229. Until
+            // then they are answered rather than left hanging: a reply the
+            // server can act on beats a silence it has to time out.
+            ManagementRequest.ListRecords,
+            is ManagementRequest.AddRecord,
+            is ManagementRequest.RemoveRecord,
+            ManagementRequest.GetPairingConfig,
+            is ManagementRequest.SetPairingConfig ->
+                ManagementOutcome(ManagementResultCode.INVALID)
+        }
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementService.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementService.kt
@@ -26,6 +26,8 @@ data class ManagementOutcome(
 data class ManagementSessionContext(
     val hasManagementActivity: Boolean,
     val pinMethodEnabled: Boolean,
+    /** The record that authenticated this session, if it was a record at all. */
+    val matchedPskId: String? = null,
 )
 
 /**
@@ -63,6 +65,13 @@ class ManagementService(
             null
         }
 
+    private val records =
+        if (trustStore != null && configStore != null) {
+            RecordOperations(trustStore, configStore)
+        } else {
+            null
+        }
+
     fun handle(
         request: ManagementRequest,
         session: ManagementSessionContext,
@@ -91,13 +100,15 @@ class ManagementService(
                     pairingConfig?.set(request.patch) ?: ManagementResultCode.INVALID
                 )
 
-            // The record operations land in #229. Until then they are answered
-            // rather than left hanging: a reply the server can act on beats a
-            // silence it has to time out.
-            ManagementRequest.ListRecords,
-            is ManagementRequest.AddRecord,
+            ManagementRequest.ListRecords ->
+                records?.list() ?: ManagementOutcome(ManagementResultCode.INVALID)
+
+            is ManagementRequest.AddRecord ->
+                records?.add(request) ?: ManagementOutcome(ManagementResultCode.INVALID)
+
             is ManagementRequest.RemoveRecord ->
-                ManagementOutcome(ManagementResultCode.INVALID)
+                records?.remove(request.pskId, session.matchedPskId)
+                    ?: ManagementOutcome(ManagementResultCode.INVALID)
         }
     }
 }

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementService.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/ManagementService.kt
@@ -1,5 +1,7 @@
 package com.sendspindroid.sendspin.protocol.management
 
+import com.sendspindroid.sendspin.crypto.PairingConfigStore
+import com.sendspindroid.sendspin.crypto.TrustStore
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -40,7 +42,26 @@ data class ManagementSessionContext(
  * conflating them either drops a usable connection or leaves an unauthorised
  * one alive.
  */
-class ManagementService {
+class ManagementService(
+    trustStore: TrustStore?,
+    configStore: PairingConfigStore?,
+) {
+
+    /**
+     * Null only on the legacy path, where no storage is wired up.
+     *
+     * Nullable rather than required so the permission gate below can run
+     * without storage: whether a session may issue management commands is a
+     * property of the session, not of what we can read. Requiring a store to
+     * answer `permission_denied` would report `invalid` to an unauthorised
+     * caller - the wrong reason, and one that invites a retry.
+     */
+    private val pairingConfig =
+        if (trustStore != null && configStore != null) {
+            PairingConfigOperations(trustStore, configStore)
+        } else {
+            null
+        }
 
     fun handle(
         request: ManagementRequest,
@@ -62,14 +83,20 @@ class ManagementService {
                 // method can be enabled and the answer is always invalid.
                 ManagementOutcome(ManagementResultCode.INVALID)
 
-            // The record and config operations land in #228 and #229. Until
-            // then they are answered rather than left hanging: a reply the
-            // server can act on beats a silence it has to time out.
+            ManagementRequest.GetPairingConfig ->
+                pairingConfig?.get() ?: ManagementOutcome(ManagementResultCode.INVALID)
+
+            is ManagementRequest.SetPairingConfig ->
+                ManagementOutcome(
+                    pairingConfig?.set(request.patch) ?: ManagementResultCode.INVALID
+                )
+
+            // The record operations land in #229. Until then they are answered
+            // rather than left hanging: a reply the server can act on beats a
+            // silence it has to time out.
             ManagementRequest.ListRecords,
             is ManagementRequest.AddRecord,
-            is ManagementRequest.RemoveRecord,
-            ManagementRequest.GetPairingConfig,
-            is ManagementRequest.SetPairingConfig ->
+            is ManagementRequest.RemoveRecord ->
                 ManagementOutcome(ManagementResultCode.INVALID)
         }
     }

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/PairingConfigOperations.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/PairingConfigOperations.kt
@@ -1,0 +1,185 @@
+package com.sendspindroid.sendspin.protocol.management
+
+import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.crypto.PairingConfigStore
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PskId
+import com.sendspindroid.sendspin.crypto.SentinelPsk
+import com.sendspindroid.sendspin.crypto.TrustStore
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.put
+
+/**
+ * `get-pairing-config` and `set-pairing-config`.
+ *
+ * Split from [ManagementService] because the patch rules are where the subtlety
+ * lives and they deserve to be readable on their own.
+ */
+internal class PairingConfigOperations(
+    private val trustStore: TrustStore,
+    private val configStore: PairingConfigStore,
+) {
+
+    fun get(): ManagementOutcome {
+        val config = configStore.load()
+        val data = buildJsonObject {
+            put("pairing_psk", buildJsonObject { put("enabled", config.pairingPskEnabled) })
+            put("record_mode", buildJsonObject { put("psk_id", config.recordModePskId) })
+            put("unpaired_access", buildJsonObject { put("enabled", config.unpairedAccessEnabled) })
+            // static_pin and dynamic_pin are absent, not disabled: "A PIN-method
+            // object is absent if the client does not implement that method."
+            // Emitting {"enabled": false} would advertise a method a server
+            // could then ask us to turn on.
+        }
+        // Never the Pairing PSK itself. "Configured secrets ... are not
+        // returned; use management/set-pairing-config to rotate them."
+        return ManagementOutcome(ManagementResultCode.OK, data)
+    }
+
+    /**
+     * Apply a patch, or nothing at all.
+     *
+     * Validation runs over the whole patch before a single write, because a
+     * partially-applied rejected patch leaves the server's view of this client
+     * disagreeing with the client's own, with no message that says so.
+     */
+    fun set(patch: JsonObject): ManagementResultCode {
+        val plan = plan(patch) ?: return ManagementResultCode.INVALID
+        if (plan is Rejected) return plan.code
+        return apply(plan as Accepted)
+    }
+
+    // ========== Validation ==========
+
+    private sealed interface Plan
+    private data class Rejected(val code: ManagementResultCode) : Plan
+    private data class Accepted(
+        val pairingPskEnabled: Boolean? = null,
+        val unpairedAccessEnabled: Boolean? = null,
+        val recordModePskId: String? = null,
+        val rotateTo: ByteArray? = null,
+    ) : Plan
+
+    /** @return null for a malformed patch; otherwise the decision. */
+    private fun plan(patch: JsonObject): Plan? {
+        // A method we do not implement may appear, but may not set anything.
+        // "Fields set on a method the client does not implement are rejected as
+        // invalid" - an empty object sets no fields, so it is a no-op.
+        for (method in UNIMPLEMENTED_METHODS) {
+            val obj = patch.presentObject(method) ?: if (patch.containsKey(method)) return null else continue
+            if (obj.isNotEmpty()) return Rejected(ManagementResultCode.INVALID)
+        }
+
+        var accepted = Accepted()
+
+        patch.presentObjectOrFail("pairing_psk")?.let { result ->
+            val obj = result.getOrElse { return null }
+
+            obj.presentBoolean("enabled")?.let { enabled ->
+                accepted = accepted.copy(pairingPskEnabled = enabled.getOrElse { return null })
+            }
+
+            if (obj.containsKey("psk")) {
+                val encoded = (obj["psk"] as? JsonPrimitive)?.contentOrNull ?: return null
+                val psk = Base64Url.decodeOrNull(encoded) ?: return null
+                if (psk.size != Psk.PSK_SIZE) return null
+
+                val id = PskId.derive(psk)
+                val config = configStore.load()
+                if (id != config.pairingPskId && id in claimedPskIds()) {
+                    // One psk_id must not map to two trust levels.
+                    return Rejected(ManagementResultCode.ALREADY_EXISTS)
+                }
+                accepted = accepted.copy(rotateTo = psk)
+            }
+        }
+
+        patch.presentObjectOrFail("unpaired_access")?.let { result ->
+            val obj = result.getOrElse { return null }
+            obj.presentBoolean("enabled")?.let { enabled ->
+                accepted = accepted.copy(unpairedAccessEnabled = enabled.getOrElse { return null })
+            }
+        }
+
+        patch.presentObjectOrFail("record_mode")?.let { result ->
+            val obj = result.getOrElse { return null }
+            if (obj.containsKey("psk_id")) {
+                val pskId = (obj["psk_id"] as? JsonPrimitive)?.contentOrNull ?: return null
+                // "psk_id MUST reference a shared-PSK record ... any management
+                // request that would set psk_id to a missing or stored-pubkey
+                // record is rejected." The Sentinel and the Pairing PSK are not
+                // records at all, so they fail the same lookup.
+                val record = trustStore.findByPskId(pskId)
+                    ?: return Rejected(ManagementResultCode.INVALID)
+                if (record.serverId != null) return Rejected(ManagementResultCode.INVALID)
+                accepted = accepted.copy(recordModePskId = pskId)
+            }
+        }
+
+        return accepted
+    }
+
+    // ========== Application ==========
+
+    private fun apply(plan: Accepted): ManagementResultCode {
+        plan.rotateTo?.let { psk ->
+            when (configStore.rotatePairingPsk(psk, claimedPskIds())) {
+                PairingConfigStore.RotateResult.Ok -> Unit
+                PairingConfigStore.RotateResult.AlreadyExists ->
+                    return ManagementResultCode.ALREADY_EXISTS
+                PairingConfigStore.RotateResult.Invalid ->
+                    return ManagementResultCode.INVALID
+                PairingConfigStore.RotateResult.StorageFailed ->
+                    return ManagementResultCode.STORAGE_EXHAUSTED
+            }
+        }
+        plan.pairingPskEnabled?.let {
+            if (!configStore.setEnabled(it)) return ManagementResultCode.STORAGE_EXHAUSTED
+        }
+        plan.unpairedAccessEnabled?.let {
+            if (!configStore.setUnpairedAccess(it)) return ManagementResultCode.STORAGE_EXHAUSTED
+        }
+        plan.recordModePskId?.let {
+            if (!configStore.setRecordModePskId(it)) return ManagementResultCode.STORAGE_EXHAUSTED
+        }
+        return ManagementResultCode.OK
+    }
+
+    private fun claimedPskIds(): Set<String> =
+        trustStore.listRecords().map { it.pskId }.toSet() + SentinelPsk.psk.pskId
+
+    // ========== Presence helpers ==========
+
+    /**
+     * Presence, not nullness.
+     *
+     * An absent key means "leave this alone"; a key present with a null or
+     * non-object value is malformed. Collapsing the two - as `?.jsonObject`
+     * would - silently accepts `{"pairing_psk": null}` as a no-op, so a
+     * malformed patch reports success.
+     */
+    private fun JsonObject.presentObject(key: String): JsonObject? =
+        if (containsKey(key)) this[key] as? JsonObject else null
+
+    /** null when absent, Result.failure when present but not an object. */
+    private fun JsonObject.presentObjectOrFail(key: String): Result<JsonObject>? {
+        if (!containsKey(key)) return null
+        val obj = this[key] as? JsonObject ?: return Result.failure(MalformedPatch)
+        return Result.success(obj)
+    }
+
+    private fun JsonObject.presentBoolean(key: String): Result<Boolean>? {
+        if (!containsKey(key)) return null
+        val value = (this[key] as? JsonPrimitive)?.booleanOrNull ?: return Result.failure(MalformedPatch)
+        return Result.success(value)
+    }
+
+    private companion object {
+        val UNIMPLEMENTED_METHODS = listOf("static_pin", "dynamic_pin")
+        val MalformedPatch = IllegalArgumentException("malformed patch")
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/RecordOperations.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/management/RecordOperations.kt
@@ -1,0 +1,130 @@
+package com.sendspindroid.sendspin.protocol.management
+
+import com.sendspindroid.sendspin.crypto.Base64Url
+import com.sendspindroid.sendspin.crypto.PairingConfigStore
+import com.sendspindroid.sendspin.crypto.Psk
+import com.sendspindroid.sendspin.crypto.PskId
+import com.sendspindroid.sendspin.crypto.SentinelPsk
+import com.sendspindroid.sendspin.crypto.TrustStore
+import com.sendspindroid.sendspin.protocol.GoodbyeReason
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * `list-records`, `add-record` and `remove-record`.
+ *
+ * `management.md#records`. The delicate part is not the CRUD, it is that all
+ * three PSK categories share one `psk_id` namespace: "Two categories sharing
+ * one would make a single wire `psk_id` map to two trust levels." So the
+ * collision check covers records, the Sentinel, and our own Pairing PSK, and it
+ * lives in exactly one place.
+ */
+internal class RecordOperations(
+    private val trustStore: TrustStore,
+    private val configStore: PairingConfigStore,
+) {
+
+    fun list(): ManagementOutcome {
+        val records = buildJsonArray {
+            for (record in trustStore.listRecords()) {
+                add(
+                    buildJsonObject {
+                        put("psk_id", record.pskId)
+                        // Absent, not null, for a shared-PSK record: "present
+                        // for stored-pubkey records, absent for shared-PSK
+                        // records". A null would read as "bound to nothing"
+                        // rather than "not bound", and the two behave
+                        // differently at handshake time.
+                        record.serverId?.let { put("server_id", it) }
+                        put("used", record.used)
+                    }
+                )
+            }
+        }
+        return ManagementOutcome(
+            ManagementResultCode.OK,
+            buildJsonObject { put("records", records) },
+        )
+    }
+
+    fun add(request: ManagementRequest.AddRecord): ManagementOutcome {
+        val psk = decodePsk(request.psk)
+            ?: return ManagementOutcome(ManagementResultCode.INVALID)
+
+        // A server_id is a Curve25519 public key, so it is the same shape as a
+        // psk_id: 43 base64url characters over 32 bytes.
+        request.serverId?.let { serverId ->
+            val decoded = Base64Url.decodeOrNull(serverId)
+            if (decoded == null || decoded.size != KEY_SIZE) {
+                return ManagementOutcome(ManagementResultCode.INVALID)
+            }
+        }
+
+        if (PskId.derive(psk) in claimedPskIds()) {
+            return ManagementOutcome(ManagementResultCode.ALREADY_EXISTS)
+        }
+
+        return when (val result = trustStore.addRecord(psk, request.serverId)) {
+            is TrustStore.AddRecordResult.Ok -> ManagementOutcome(ManagementResultCode.OK)
+            TrustStore.AddRecordResult.AlreadyExists ->
+                ManagementOutcome(ManagementResultCode.ALREADY_EXISTS)
+            TrustStore.AddRecordResult.Invalid ->
+                ManagementOutcome(ManagementResultCode.INVALID)
+            TrustStore.AddRecordResult.StorageFailed ->
+                ManagementOutcome(ManagementResultCode.STORAGE_EXHAUSTED)
+        }
+    }
+
+    /** Order matters here; see the inline notes. */
+    fun remove(pskId: String, matchedPskId: String?): ManagementOutcome {
+        if (pskId.isEmpty()) return ManagementOutcome(ManagementResultCode.INVALID)
+
+        // Not-found comes before the pinned check, and covers the Sentinel and
+        // the Pairing PSK: neither is a record, so removing one is `not_found`
+        // rather than `invalid`.
+        trustStore.findByPskId(pskId)
+            ?: return ManagementOutcome(ManagementResultCode.NOT_FOUND)
+
+        if (pskId == configStore.load().recordModePskId) {
+            // "the referenced shared-PSK record cannot be removed while the
+            // reference exists".
+            return ManagementOutcome(ManagementResultCode.INVALID)
+        }
+
+        if (!trustStore.removeRecord(pskId)) {
+            // `invalid` rather than inventing a code the outcomes line for this
+            // request does not list.
+            return ManagementOutcome(ManagementResultCode.INVALID)
+        }
+
+        // "Removing the requester's own record closes the management session
+        // with client/goodbye reason 'unauthorized' AFTER the response." The
+        // reply has to go first: it is the only thing that tells the server the
+        // removal happened, and a close alone reads as a failure.
+        val ourOwn = matchedPskId != null && matchedPskId == pskId
+        return ManagementOutcome(
+            ManagementResultCode.OK,
+            closeAfterReply = if (ourOwn) GoodbyeReason.UNAUTHORIZED.wire else null,
+        )
+    }
+
+    /** Every `psk_id` already spoken for, across all three categories. */
+    private fun claimedPskIds(): Set<String> =
+        trustStore.listRecords().map { it.pskId }.toSet() +
+            SentinelPsk.psk.pskId +
+            configStore.load().pairingPskId
+
+    /** 43 base64url characters over exactly 32 bytes, no padding. */
+    private fun decodePsk(encoded: String): ByteArray? {
+        if (encoded.length != ENCODED_PSK_LENGTH) return null
+        val bytes = Base64Url.decodeOrNull(encoded) ?: return null
+        return bytes.takeIf { it.size == Psk.PSK_SIZE }
+    }
+
+    private companion object {
+        const val KEY_SIZE = 32
+        const val ENCODED_PSK_LENGTH = 43
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageBuilder.kt
@@ -2,6 +2,7 @@ package com.sendspindroid.sendspin.protocol.message
 
 import com.sendspindroid.sendspin.crypto.Base64Url
 import com.sendspindroid.sendspin.protocol.GoodbyeReason
+import com.sendspindroid.sendspin.protocol.management.ManagementResultCode
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
@@ -189,6 +190,40 @@ object MessageBuilder {
     }.toString()
 
     /** The typed form. Prefer this: a bare string can invent a reason. */
+    /**
+     * A `management/result`.
+     *
+     * Deliberately omits the `storage` accounting object. "a client whose
+     * storage is effectively unbounded or of unknown size omits the key, and
+     * the server relies on `storage_exhausted` alone" - records are roughly a
+     * hundred bytes in EncryptedSharedPreferences on a filesystem measured in
+     * gigabytes, so any capacity figure we invented would corrupt the server's
+     * free/cost arithmetic. `storage_exhausted` stays authoritative for a
+     * genuine write failure.
+     *
+     * Also carries no request identifier: replies are matched to requests by
+     * ordering alone.
+     *
+     * @param data merged into the payload, and only when the operation
+     *   succeeded. A failure that carried state would invite the server to read
+     *   it out of a reply saying the operation did not happen.
+     */
+    fun buildManagementResult(
+        code: ManagementResultCode,
+        data: JsonObject? = null,
+    ): String {
+        val message = buildJsonObject {
+            put("type", SendSpinProtocol.MessageType.MANAGEMENT_RESULT)
+            put("payload", buildJsonObject {
+                put("result", code.wire)
+                if (code == ManagementResultCode.OK && data != null) {
+                    for ((key, value) in data) put(key, value)
+                }
+            })
+        }
+        return message.toString()
+    }
+
     fun buildGoodbye(reason: GoodbyeReason): String =
         buildGoodbye(reason.wire)
 


### PR DESCRIPTION
Closes #227, closes #228, closes #229. **Stacked on #248** (which is stacked on #247) - merge those first, or set this PR's base to `main` once they land.

Three commits, one per issue. They ship together because #227 alone answers `invalid` to every real operation, which is not worth merging on its own.

## Why now

Verifying #224 turned up why MA's device-settings dialog hangs: it re-activates into `['management']`, asks for `management/get-pairing-config`, gets nothing back, waits 10 s, and closes. That dialog is the entry point to MA's whole device-management UI, so several things built this week were correct but unreachable from the only server anyone runs.

## The distinction the router protects

Management is gated twice and the two gates do different things:

| gate | trigger | result |
|---|---|---|
| activation | server declares `'management'` on a connection whose matched PSK does not permit it | **close** with `unauthorized` |
| message | a `management/` request arrives without the activity | **answer** `permission_denied`, stay open |

Conflating them either drops a usable connection or leaves an unauthorised one alive. The activation gate already existed in `ServerActivateRules` from #203 - which is why MA's activation was accepted on the tablet and only the request went unanswered.

Requests are handled to completion synchronously. Replies carry no identifier, so the Nth result on the wire *is* the answer to the Nth request; moving the work to another dispatcher would let two replies race with nothing in either frame to reveal the swap. That invariant is recorded on the method.

## The two patch traps (#228)

**Presence is not nullness.** An absent field means "leave alone"; a field present with a null or non-object value is malformed. `?.jsonObject` collapses the two, so `{"pairing_psk": null}` would pass as a silent no-op. Presence is tested with `containsKey`, the value type separately.

**A patch is atomic.** Validation runs over the whole payload before a single write. A half-applied rejected patch leaves the server's view of the client disagreeing with the client's own, with no message that says so.

`get-pairing-config` omits `static_pin` and `dynamic_pin` entirely rather than reporting them disabled - `{"enabled": false}` would advertise a method a server could ask us to turn on - and never returns the Pairing PSK itself.

## A decision worth flagging: `record_mode`

The response treats `record_mode` as non-optional and the spec requires it to name a real shared-PSK record. So the client now provisions exactly one, CSPRNG-generated per device, at first read of the config.

It is never distributed and nothing offers it to a server, so nothing can authenticate under it. D4 puts us on the stored-pubkey model and Android storage is effectively unbounded, so the storage-exhaustion path that would admit a server under record mode is unreachable. Thirty-two bytes buys a well-formed response and makes the `remove-record` referential constraint a real, tested branch. Reasoning is recorded in the `PairingConfig` KDoc.

## Ordering in `remove-record` (#229)

`not_found` is decided **before** the pinned check, so removing the Sentinel or the Pairing PSK - neither of which is a record - reports `not_found` rather than `invalid`. Removing the requester's own record answers before it closes, sequenced in one coroutine through the awaiting send, then suppresses auto-reconnect.

## Verification

52 new tests. Mutation-checked:

- Dropping the cross-category namespace check fails only the collision test.
- Dropping the pinned-record check fails only the record-mode test.

One bug the tests caught that reading would not have: the store-less fallback answered `invalid` *before* the permission gate, so an unauthorised request on a handler with no storage got the wrong reason - one that invites a retry. Permission is a property of the session, not of what we can read, so the gate now runs first.

## Storage accounting

No `storage` object on any result. Records are ~100 bytes in `EncryptedSharedPreferences` on a filesystem measured in gigabytes, so any capacity we invented would corrupt the server's `free / cost_individual` arithmetic. `storage_exhausted` stays authoritative for a genuine write failure, and setters now report whether the write committed - management answers `ok` only once "any state change has been persisted".

## Not verified against a real server

The next step is exactly the thing that motivated this: reopen MA's device-settings dialog on the tablet and see whether it renders. That is worth doing before merge if you want it, and it is the first management feature that *can* be checked end to end - unlike #224 and #226, MA does send these.
