### PR TITLE
fix(protocol): merge server/state deltas instead of replacing them

### DIFF
--- a/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/SendSpin.kt
@@ -770,14 +770,17 @@ class SendSpin(
         } else {
             metadata.positionMs
         }
+        // Null means the server has no value for the field - either it was
+        // never sent or it was explicitly cleared. The callback's empty string
+        // carries that meaning downstream.
         callback.onMetadataUpdate(
-            metadata.title,
-            metadata.artist,
-            metadata.album,
-            metadata.artworkUrl,
+            metadata.title.orEmpty(),
+            metadata.artist.orEmpty(),
+            metadata.album.orEmpty(),
+            metadata.artworkUrl.orEmpty(),
             metadata.durationMs,
             positionMs,
-            metadata.progress.playbackSpeed
+            metadata.progress?.playbackSpeed ?: 1000
         )
     }
 

--- a/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
+++ b/android/app/src/main/java/com/sendspindroid/sendspin/protocol/SendSpinProtocolHandler.kt
@@ -1285,12 +1285,35 @@ abstract class SendSpinProtocolHandler(
         }
     }
 
+    /**
+     * `server/state` is a delta, so every field is merged into the cached role
+     * state rather than replacing it.
+     *
+     * Before this merge existed, a delta carrying only `progress` arrived as a
+     * metadata object with empty title, artist and album, and blanked the Now
+     * Playing screen on every progress tick.
+     */
     protected fun handleServerState(payload: JsonObject?) {
-        val (metadata, state, controllerDelta) = MessageParser.parseServerState(payload)
+        val (metadataUpdate, state, controllerUpdate) = MessageParser.parseServerState(payload)
 
-        if (metadata != null) {
-            lastMetadata = metadata
-            onMetadataUpdate(metadata)
+        when (metadataUpdate) {
+            RoleUpdate.Absent -> Unit
+
+            RoleUpdate.Cleared -> {
+                // The role was dropped from active_roles; the UI must blank
+                // rather than keep showing a track the server no longer has.
+                lastMetadata = null
+                onMetadataCleared()
+            }
+
+            is RoleUpdate.Delta -> {
+                val merged = metadataUpdate.applyTo(lastMetadata)
+                lastMetadata = merged
+                // Fired even when the merged value is unchanged: progress
+                // extrapolation needs a fresh receive-time anchor on every
+                // message, not only on a change.
+                if (merged != null) onMetadataUpdate(merged)
+            }
         }
 
         if (state != null && state != lastPlaybackState) {
@@ -1298,13 +1321,27 @@ abstract class SendSpinProtocolHandler(
             onPlaybackStateChanged(state)
         }
 
-        if (controllerDelta != null) {
-            val merged = currentControllerState?.mergedWith(controllerDelta) ?: controllerDelta
-            if (merged != currentControllerState) {
-                currentControllerState = merged
-                onControllerStateUpdate(merged)
+        when (controllerUpdate) {
+            RoleUpdate.Absent -> Unit
+
+            RoleUpdate.Cleared -> {
+                currentControllerState = null
+                onControllerStateUpdate(ControllerState())
+            }
+
+            is RoleUpdate.Delta -> {
+                val merged = controllerUpdate.applyTo(currentControllerState)
+                if (merged != null && merged != currentControllerState) {
+                    currentControllerState = merged
+                    onControllerStateUpdate(merged)
+                }
             }
         }
+    }
+
+    /** The server dropped the metadata role. Default: treat as an empty track. */
+    protected open fun onMetadataCleared() {
+        onMetadataUpdate(TrackMetadata())
     }
 
     protected fun handleServerCommand(payload: JsonObject?) {

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/StateMergeTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/StateMergeTest.kt
@@ -1,0 +1,214 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.sendspin.protocol.message.MessageParser
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `server/state` merge semantics.
+ *
+ * `messaging.md#server--client-serverstate`: "Only include fields that have
+ * changed. The client will merge these updates into existing state. A leaf
+ * field set to `null` should be cleared from the client's state; a whole role
+ * object set to `null` clears all of that role's state."
+ *
+ * Three wire states per field, and collapsing any two of them produces a
+ * different bug:
+ *
+ * | wire            | meaning |
+ * |-----------------|---------|
+ * | key absent      | keep what we have |
+ * | key with `null` | clear it |
+ * | key with value  | replace it |
+ *
+ * The parser used to read role objects with `as? JsonObject`, which makes an
+ * explicit `null` indistinguishable from an absent key, and defaulted every
+ * missing string to `""`. So a delta carrying only `progress` produced a
+ * metadata object with empty title, artist and album - and downstream, where
+ * empty means "clear", that blanked the Now Playing screen on every progress
+ * tick.
+ */
+class StateMergeTest {
+
+    // ========== The bug this exists to fix ==========
+
+    @Test
+    fun aProgressOnlyDeltaKeepsTheTrackItIsProgressing() {
+        val current = metadata(title = "Carry This Picture", artist = "Dashboard", album = "A Mark")
+
+        val merged = merge(current, """{"metadata":{"progress":{"track_progress":42000}}}""")
+
+        assertEquals("Carry This Picture", merged?.title)
+        assertEquals("Dashboard", merged?.artist)
+        assertEquals("A Mark", merged?.album)
+        assertEquals(42000L, merged?.progress?.trackProgress)
+    }
+
+    // ========== Leaves ==========
+
+    @Test
+    fun anAbsentLeafKeepsItsValue() {
+        val merged = merge(metadata(title = "Kept"), """{"metadata":{"artist":"New"}}""")
+
+        assertEquals("Kept", merged?.title)
+        assertEquals("New", merged?.artist)
+    }
+
+    @Test
+    fun aNullLeafClearsIt() {
+        val merged = merge(metadata(title = "Gone"), """{"metadata":{"title":null}}""")
+
+        assertNull(merged?.title)
+    }
+
+    @Test
+    fun aValuedLeafReplacesIt() {
+        val merged = merge(metadata(title = "Old"), """{"metadata":{"title":"New"}}""")
+
+        assertEquals("New", merged?.title)
+    }
+
+    // ========== Whole role objects ==========
+
+    @Test
+    fun anAbsentRoleObjectChangesNothing() {
+        val current = metadata(title = "Kept")
+
+        val update = parse("""{"state":"playing"}""").metadata
+
+        assertTrue(update is RoleUpdate.Absent)
+        assertEquals("Kept", update.applyTo(current)?.title)
+    }
+
+    @Test
+    fun aNullRoleObjectClearsTheWholeRole() {
+        // "a whole role object set to null clears all of that role's state" -
+        // this is what server/activate sends when it removes a state role.
+        val update = parse("""{"metadata":null}""").metadata
+
+        assertTrue(update is RoleUpdate.Cleared)
+        assertNull(update.applyTo(metadata(title = "Gone")))
+    }
+
+    // ========== Nested objects are replaced, never deep-merged ==========
+
+    @Test
+    fun aNestedObjectIsReplacedWholesale() {
+        // "The merge is shallow: a nested object (e.g., metadata.progress) is
+        // replaced or cleared as a whole, never deep-merged, so nested objects
+        // are always sent complete."
+        val current = metadata(
+            title = "T",
+            progress = TrackProgress(trackProgress = 5000, trackDuration = 300000, playbackSpeed = 1000),
+        )
+
+        val merged = merge(current, """{"metadata":{"progress":{"track_progress":9000}}}""")
+
+        assertEquals(9000L, merged?.progress?.trackProgress)
+        // Deep-merging would have kept 300000 here.
+        assertEquals(0L, merged?.progress?.trackDuration)
+    }
+
+    @Test
+    fun aNullProgressClearsItRatherThanFallingBackToLegacyFields() {
+        // The old parser fell through to the pre-spec flat fields whenever
+        // progress was absent OR null, and fabricated TrackProgress(0,0,1000)
+        // when those were missing too. An explicit null means clear.
+        val merged = merge(
+            metadata(title = "T", progress = TrackProgress(5000, 300000, 1000)),
+            """{"metadata":{"progress":null}}""",
+        )
+
+        assertNull(merged?.progress)
+    }
+
+    @Test
+    fun anAbsentProgressStillHonoursLegacyFlatFields() {
+        // Pre-spec Music Assistant sent position_ms/duration_ms at the top of
+        // the metadata object. Only used when `progress` is absent entirely.
+        val merged = merge(
+            metadata(title = "T"),
+            """{"metadata":{"position_ms":1234,"duration_ms":5678}}""",
+        )
+
+        assertEquals(1234L, merged?.progress?.trackProgress)
+        assertEquals(5678L, merged?.progress?.trackDuration)
+    }
+
+    @Test
+    fun anAbsentProgressWithNoLegacyFieldsKeepsTheCurrentProgress() {
+        val current = metadata(title = "T", progress = TrackProgress(5000, 300000, 1000))
+
+        val merged = merge(current, """{"metadata":{"title":"T2"}}""")
+
+        assertEquals(5000L, merged?.progress?.trackProgress)
+    }
+
+    // ========== Forward compatibility ==========
+
+    @Test
+    fun anUnknownFieldIsIgnored() {
+        val merged = merge(metadata(title = "T"), """{"metadata":{"future_field":1,"artist":"A"}}""")
+
+        assertEquals("T", merged?.title)
+        assertEquals("A", merged?.artist)
+    }
+
+    // ========== Controller ==========
+
+    @Test
+    fun aNullControllerObjectClearsTheRole() {
+        val update = parse("""{"controller":null}""").controller
+
+        assertTrue(update is RoleUpdate.Cleared)
+    }
+
+    @Test
+    fun anAbsentControllerLeafKeepsItsValue() {
+        val current = ControllerState(volume = 40, muted = true)
+
+        val merged = parse("""{"controller":{"volume":80}}""").controller.applyTo(current)
+
+        assertEquals(80, merged?.volume)
+        assertEquals(true, merged?.muted)
+    }
+
+    @Test
+    fun aNullControllerLeafClearsIt() {
+        val current = ControllerState(volume = 40, muted = true)
+
+        val merged = parse("""{"controller":{"muted":null}}""").controller.applyTo(current)
+
+        assertNull(merged?.muted)
+        assertEquals(40, merged?.volume)
+    }
+
+    // ========== Helpers ==========
+
+    private fun parse(json: String) =
+        MessageParser.parseServerState(Json.parseToJsonElement(json).jsonObject)
+
+    private fun merge(current: TrackMetadata?, json: String): TrackMetadata? =
+        parse(json).metadata.applyTo(current)
+
+    private fun metadata(
+        title: String? = null,
+        artist: String? = null,
+        album: String? = null,
+        progress: TrackProgress? = null,
+    ) = TrackMetadata(
+        timestamp = null,
+        title = title,
+        artist = artist,
+        albumArtist = null,
+        album = album,
+        artworkUrl = null,
+        year = null,
+        track = null,
+        progress = progress,
+    )
+}

--- a/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageParserTest.kt
+++ b/android/shared/src/androidHostTest/kotlin/com/sendspindroid/sendspin/protocol/message/MessageParserTest.kt
@@ -14,6 +14,11 @@ import kotlinx.serialization.json.put
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
+import com.sendspindroid.sendspin.protocol.ControllerState
+import com.sendspindroid.sendspin.protocol.RoleUpdate
+import com.sendspindroid.sendspin.protocol.applyTo
+import com.sendspindroid.sendspin.protocol.TrackMetadata
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MessageParserTest {
@@ -190,14 +195,15 @@ class MessageParserTest {
             put("state", "playing")
         }
 
-        val (metadata, state) = MessageParser.parseServerState(payload)
+        val (update, state) = MessageParser.parseServerState(payload)
+        val metadata = update.applyTo(null)
 
         assertNotNull(metadata)
         assertEquals("Test Song", metadata!!.title)
         assertEquals("Test Artist", metadata.artist)
         assertEquals("Album Artist", metadata.albumArtist)
-        assertEquals(45000L, metadata.progress.trackProgress)
-        assertEquals(180000L, metadata.progress.trackDuration)
+        assertEquals(45000L, metadata.progress!!.trackProgress)
+        assertEquals(180000L, metadata.progress!!.trackDuration)
         assertEquals("playing", state)
     }
 
@@ -212,28 +218,32 @@ class MessageParserTest {
             })
         }
 
-        val (metadata, _) = MessageParser.parseServerState(payload)
+        val (update, _) = MessageParser.parseServerState(payload)
+        val metadata = update.applyTo(null)
 
         assertNotNull(metadata)
         assertEquals("Legacy Song", metadata!!.title)
-        assertEquals(30000L, metadata.progress.trackProgress)
-        assertEquals(200000L, metadata.progress.trackDuration)
+        assertEquals(30000L, metadata.progress!!.trackProgress)
+        assertEquals(200000L, metadata.progress!!.trackDuration)
     }
 
     @Test
     fun parseServerState_nullPayload_returnsNulls() {
-        val (metadata, state) = MessageParser.parseServerState(null)
-        assertNull(metadata)
+        val (update, state) = MessageParser.parseServerState(null)
+        assertTrue(update is RoleUpdate.Absent)
         assertNull(state)
     }
 
     @Test
-    fun parseServerState_noMetadata_returnsNullMetadata() {
+    fun parseServerState_noMetadata_leavesTheRoleUntouched() {
         val payload = buildJsonObject {
             put("state", "paused")
         }
-        val (metadata, state) = MessageParser.parseServerState(payload)
-        assertNull(metadata)
+        val (update, state) = MessageParser.parseServerState(payload)
+
+        assertTrue(update is RoleUpdate.Absent)
+        // Absent must keep whatever we already had, not blank it.
+        assertEquals("Kept", update.applyTo(TrackMetadata(title = "Kept"))?.title)
         assertEquals("paused", state)
     }
 
@@ -259,26 +269,32 @@ class MessageParserTest {
             })
         }
 
-        val (metadata, state) = MessageParser.parseServerState(payload)
+        val (update, state) = MessageParser.parseServerState(payload)
+        val metadata = update.applyTo(TrackMetadata(title = "Previous", artist = "Previous"))
 
+        // Explicit nulls are clears now, not "same as absent": the fields go to
+        // null rather than to the empty string, and they do not survive.
         assertNotNull("idle metadata should still yield a TrackMetadata", metadata)
-        assertEquals("", metadata!!.title)
-        assertEquals("", metadata.artist)
-        assertEquals(0L, metadata.progress.trackProgress)
-        assertEquals(0L, metadata.progress.trackDuration)
+        assertNull(metadata!!.title)
+        assertNull(metadata.artist)
+        assertNull(metadata.progress)
         assertNull(state)
     }
 
     @Test
-    fun parseServerState_nullMetadataField_returnsNullMetadata() {
-        // Defensive: if the server ever sends `{"metadata": null}` instead of
-        // an object, we must treat it like missing rather than throwing.
+    fun parseServerState_nullMetadataObject_clearsTheRole() {
+        // Behaviour change: this used to be treated as "missing". Per
+        // messaging.md a whole role object set to null "clears all of that
+        // role's state", and server/activate relies on it when it drops a
+        // state role from active_roles.
         val payload = buildJsonObject {
             put("metadata", JsonPrimitive(null as String?))
             put("state", "stopped")
         }
-        val (metadata, state) = MessageParser.parseServerState(payload)
-        assertNull(metadata)
+        val (update, state) = MessageParser.parseServerState(payload)
+
+        assertTrue(update is RoleUpdate.Cleared)
+        assertNull(update.applyTo(TrackMetadata(title = "Gone")))
         assertEquals("stopped", state)
     }
 
@@ -299,9 +315,9 @@ class MessageParserTest {
         }
         val result = MessageParser.parseServerState(payload)
 
-        assertNotNull(result.controller)
-        val controller = result.controller!!
-        assertEquals(listOf("play", "pause", "volume"), controller.supportedCommands)
+        val controller = result.controller.applyTo(null)
+        assertNotNull(controller)
+        assertEquals(listOf("play", "pause", "volume"), controller!!.supportedCommands)
         assertEquals(60, controller.volume)
         assertEquals(false, controller.muted)
         assertEquals("all", controller.repeat)
@@ -309,11 +325,14 @@ class MessageParserTest {
     }
 
     @Test
-    fun parseServerState_noController_returnsNullController() {
+    fun parseServerState_noController_leavesTheRoleUntouched() {
         val payload = buildJsonObject {
             put("state", "playing")
         }
-        assertNull(MessageParser.parseServerState(payload).controller)
+        val update = MessageParser.parseServerState(payload).controller
+
+        assertTrue(update is RoleUpdate.Absent)
+        assertEquals(60, update.applyTo(ControllerState(volume = 60))?.volume)
     }
 
     @Test
@@ -323,7 +342,7 @@ class MessageParserTest {
                 put("volume", 42)
             })
         }
-        val controller = MessageParser.parseServerState(payload).controller
+        val controller = MessageParser.parseServerState(payload).controller.applyTo(null)
 
         assertNotNull(controller)
         assertEquals(42, controller!!.volume)

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/Patch.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/Patch.kt
@@ -1,0 +1,100 @@
+package com.sendspindroid.sendspin.protocol
+
+import com.sendspindroid.shared.log.Log
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * One field of a `server/state` delta.
+ *
+ * `messaging.md#server--client-serverstate`: "Only include fields that have
+ * changed ... A leaf field set to `null` should be cleared from the client's
+ * state."
+ *
+ * Three wire states, and collapsing any two of them is a different bug:
+ *
+ * | wire            | this type  | effect |
+ * |-----------------|------------|--------|
+ * | key absent      | [Absent]   | keep what we have |
+ * | key with `null` | [Cleared]  | remove what we have |
+ * | key with value  | [Set]      | replace what we have |
+ *
+ * Kotlin's `T?` only has room for two of those, which is why this type exists
+ * rather than a nullable field: `as? JsonObject` and `?: ""` both quietly turn
+ * "absent" and "cleared" into the same thing.
+ */
+sealed interface Patch<out T> {
+
+    /** The key was not in the payload. */
+    object Absent : Patch<Nothing>
+
+    /** The key was present with a JSON `null`. */
+    object Cleared : Patch<Nothing>
+
+    /** The key was present with a value. */
+    data class Set<T>(val value: T) : Patch<T>
+}
+
+/**
+ * @return the field's new value, given its current one.
+ *
+ * An extension rather than a member: [Patch.Absent] and [Patch.Cleared] are
+ * `Patch<Nothing>`, and a member function would make the compiler emit a bridge
+ * that casts the return to `Void` - which throws ClassCastException the moment
+ * a real value passes through it.
+ */
+fun <T> Patch<T>.applyTo(current: T?): T? = when (this) {
+    Patch.Absent -> current
+    Patch.Cleared -> null
+    is Patch.Set -> value
+}
+
+/**
+ * A whole role object in a `server/state`.
+ *
+ * `messaging.md#server--client-serverstate`: "a whole role object set to `null`
+ * clears all of that role's state." That is what `server/activate` sends when
+ * it removes `metadata`, `color` or `controller` from `active_roles`, "so the
+ * client never holds live data for an inactive role".
+ */
+sealed interface RoleUpdate<out S> {
+
+    object Absent : RoleUpdate<Nothing>
+
+    object Cleared : RoleUpdate<Nothing>
+
+    data class Delta<S>(val patch: StatePatch<S>) : RoleUpdate<S>
+}
+
+/** @return the role's new state, given its current one. See [Patch.applyTo]. */
+fun <S> RoleUpdate<S>.applyTo(current: S?): S? = when (this) {
+    RoleUpdate.Absent -> current
+    RoleUpdate.Cleared -> null
+    is RoleUpdate.Delta -> patch.applyTo(current)
+}
+
+/** A delta over one role's state object. */
+interface StatePatch<S> {
+    fun applyTo(current: S?): S
+}
+
+/**
+ * Reads [key] as a [Patch].
+ *
+ * A [decode] that returns null - a value of the wrong JSON type - degrades to
+ * [Patch.Absent] rather than throwing or clearing. "Clients and servers MUST
+ * ignore unrecognized `payload` fields", and a malformed field is closer to
+ * unrecognized than to a deliberate clear: guessing "clear" would delete state
+ * the server never asked us to touch.
+ */
+fun <T> JsonObject.patch(key: String, decode: (JsonElement) -> T?): Patch<T> {
+    val element = this[key] ?: return Patch.Absent
+    if (element is JsonNull) return Patch.Cleared
+    val decoded = decode(element)
+    if (decoded == null) {
+        Log.w("Patch", "Ignoring $key: unexpected JSON shape")
+        return Patch.Absent
+    }
+    return Patch.Set(decoded)
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/SendSpinProtocol.kt
@@ -220,19 +220,24 @@ data class TrackProgress(
  * @param progress Progress information (position, duration, speed)
  */
 data class TrackMetadata(
-    val timestamp: Long,
-    val title: String,
-    val artist: String,
-    val albumArtist: String,
-    val album: String,
-    val artworkUrl: String,
-    val year: Int,
-    val track: Int,
-    val progress: TrackProgress
+    val timestamp: Long? = null,
+    val title: String? = null,
+    val artist: String? = null,
+    val albumArtist: String? = null,
+    val album: String? = null,
+    val artworkUrl: String? = null,
+    val year: Int? = null,
+    val track: Int? = null,
+    val progress: TrackProgress? = null
 ) {
+    // Every field is nullable because `server/state` can clear any of them
+    // individually. Null means "the server has no value for this", which is
+    // distinct from the empty string - the old representation, which could not
+    // tell a cleared title from a title the delta simply did not mention.
+
     // Convenience properties for backwards compatibility
-    val durationMs: Long get() = progress.trackDuration
-    val positionMs: Long get() = progress.trackProgress
+    val durationMs: Long get() = progress?.trackDuration ?: 0L
+    val positionMs: Long get() = progress?.trackProgress ?: 0L
 
     /**
      * Current track position extrapolated from this metadata snapshot,
@@ -248,12 +253,15 @@ data class TrackMetadata(
      *   microseconds (from the time filter's client->server mapping)
      */
     fun progressAtServerTime(serverNowMicros: Long): Long {
-        if (timestamp == 0L) return progress.trackProgress
+        val p = progress ?: return 0L
+        // A null or zero timestamp means no anchor to extrapolate from - legacy
+        // servers, or a cleared field - so report the raw position.
+        if (timestamp == null || timestamp == 0L) return p.trackProgress
         val elapsedMicros = serverNowMicros - timestamp
-        val calculated = progress.trackProgress +
-                elapsedMicros * progress.playbackSpeed / 1_000_000L
-        return if (progress.trackDuration != 0L) {
-            calculated.coerceIn(0L, progress.trackDuration)
+        val calculated = p.trackProgress +
+                elapsedMicros * p.playbackSpeed / 1_000_000L
+        return if (p.trackDuration != 0L) {
+            calculated.coerceIn(0L, p.trackDuration)
         } else {
             calculated.coerceAtLeast(0L)
         }
@@ -315,25 +323,18 @@ data class ControllerState(
     val volume: Int? = null,
     val muted: Boolean? = null,
     val repeat: String? = null,
-    val shuffle: Boolean? = null
-) {
-    /** Merge a delta update into this state, keeping known values. */
-    fun mergedWith(delta: ControllerState): ControllerState = ControllerState(
-        supportedCommands = delta.supportedCommands ?: supportedCommands,
-        volume = delta.volume ?: volume,
-        muted = delta.muted ?: muted,
-        repeat = delta.repeat ?: repeat,
-        shuffle = delta.shuffle ?: shuffle
-    )
-}
+    val shuffle: Boolean? = null,
+    /** Furthest seekable position; `controller` role, read by item 3.11. */
+    val seekMaxMs: Long? = null
+)
 
 /**
  * Result of parsing a server/state message.
  */
 data class ServerStateResult(
-    val metadata: TrackMetadata?,
+    val metadata: RoleUpdate<TrackMetadata>,
     val playbackState: String?,
-    val controller: ControllerState?
+    val controller: RoleUpdate<ControllerState>
 )
 
 /**

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/StatePatches.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/StatePatches.kt
@@ -1,0 +1,54 @@
+package com.sendspindroid.sendspin.protocol
+
+/**
+ * A `server/state` delta for the `metadata` role.
+ *
+ * One [Patch] per leaf. `progress` is a patch of a whole [TrackProgress] rather
+ * than a nested patch, because "The merge is shallow: a nested object (e.g.,
+ * `metadata.progress`) is replaced or cleared as a whole, never deep-merged, so
+ * nested objects are always sent complete."
+ */
+data class MetadataPatch(
+    val timestamp: Patch<Long> = Patch.Absent,
+    val title: Patch<String> = Patch.Absent,
+    val artist: Patch<String> = Patch.Absent,
+    val albumArtist: Patch<String> = Patch.Absent,
+    val album: Patch<String> = Patch.Absent,
+    val artworkUrl: Patch<String> = Patch.Absent,
+    val year: Patch<Int> = Patch.Absent,
+    val track: Patch<Int> = Patch.Absent,
+    val progress: Patch<TrackProgress> = Patch.Absent,
+) : StatePatch<TrackMetadata> {
+
+    override fun applyTo(current: TrackMetadata?): TrackMetadata = TrackMetadata(
+        timestamp = timestamp.applyTo(current?.timestamp),
+        title = title.applyTo(current?.title),
+        artist = artist.applyTo(current?.artist),
+        albumArtist = albumArtist.applyTo(current?.albumArtist),
+        album = album.applyTo(current?.album),
+        artworkUrl = artworkUrl.applyTo(current?.artworkUrl),
+        year = year.applyTo(current?.year),
+        track = track.applyTo(current?.track),
+        progress = progress.applyTo(current?.progress),
+    )
+}
+
+/** A `server/state` delta for the `controller` role. */
+data class ControllerPatch(
+    val supportedCommands: Patch<List<String>> = Patch.Absent,
+    val volume: Patch<Int> = Patch.Absent,
+    val muted: Patch<Boolean> = Patch.Absent,
+    val repeat: Patch<String> = Patch.Absent,
+    val shuffle: Patch<Boolean> = Patch.Absent,
+    val seekMaxMs: Patch<Long> = Patch.Absent,
+) : StatePatch<ControllerState> {
+
+    override fun applyTo(current: ControllerState?): ControllerState = ControllerState(
+        supportedCommands = supportedCommands.applyTo(current?.supportedCommands),
+        volume = volume.applyTo(current?.volume),
+        muted = muted.applyTo(current?.muted),
+        repeat = repeat.applyTo(current?.repeat),
+        shuffle = shuffle.applyTo(current?.shuffle),
+        seekMaxMs = seekMaxMs.applyTo(current?.seekMaxMs),
+    )
+}

--- a/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageParser.kt
+++ b/android/shared/src/commonMain/kotlin/com/sendspindroid/sendspin/protocol/message/MessageParser.kt
@@ -1,6 +1,16 @@
 package com.sendspindroid.sendspin.protocol.message
 
 import com.sendspindroid.sendspin.protocol.ControllerState
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonArray
+import com.sendspindroid.sendspin.protocol.patch
+import com.sendspindroid.sendspin.protocol.StatePatch
+import com.sendspindroid.sendspin.protocol.RoleUpdate
+import com.sendspindroid.sendspin.protocol.Patch
+import com.sendspindroid.sendspin.protocol.MetadataPatch
+import com.sendspindroid.sendspin.protocol.ControllerPatch
 import com.sendspindroid.sendspin.protocol.GroupInfo
 import com.sendspindroid.sendspin.protocol.SendSpinProtocol
 import com.sendspindroid.sendspin.protocol.ServerCommandResult
@@ -69,73 +79,111 @@ object MessageParser {
         return TimeMeasurement(offset, rtt, clientReceivedMicros)
     }
 
+    /**
+     * `server/state`, as a delta.
+     *
+     * Every field is read as a [Patch] so that absent, JSON `null` and a value
+     * stay distinguishable all the way to the merge. The previous
+     * implementation used `as? JsonObject` and `?: ""`, which folded the first
+     * two together - so a delta carrying only `progress` arrived downstream as
+     * a metadata object with empty title, artist and album, and blanked the
+     * Now Playing screen on every progress tick.
+     */
     fun parseServerState(payload: JsonObject?): ServerStateResult {
-        if (payload == null) return ServerStateResult(null, null, null)
-
-        val metadata = (payload["metadata"] as? JsonObject)?.let { metadataObj ->
-            fun optStringClean(key: String) =
-                metadataObj[key]?.jsonPrimitive?.contentOrNull?.takeUnless { it == "null" } ?: ""
-
-            val timestamp = metadataObj.longOrDefault("timestamp", 0)
-            val title = optStringClean("title")
-            val artist = optStringClean("artist")
-            val albumArtist = optStringClean("album_artist")
-            val album = optStringClean("album")
-            val artworkUrl = optStringClean("artwork_url")
-            val year = metadataObj.intOrDefault("year", 0)
-            val track = metadataObj.intOrDefault("track", 0)
-
-            // Use `as? JsonObject` rather than `?.jsonObject`: the latter throws
-            // IllegalArgumentException when the field is JsonNull (the server
-            // sometimes sends `"progress": null` in idle metadata). The cast
-            // form treats JsonNull the same as missing, which is what we want.
-            val progress = (metadataObj["progress"] as? JsonObject)?.let { progressObj ->
-                TrackProgress(
-                    trackProgress = progressObj.longOrDefault("track_progress", 0),
-                    trackDuration = progressObj.longOrDefault("track_duration", 0),
-                    playbackSpeed = progressObj.intOrDefault("playback_speed", 1000)
-                )
-            } ?: run {
-                // Legacy pre-spec Music Assistant fields, not in the
-                // Sendspin spec; kept for old servers.
-                TrackProgress(
-                    trackProgress = metadataObj.longOrDefault("position_ms", 0),
-                    trackDuration = metadataObj.longOrDefault("duration_ms", 0),
-                    playbackSpeed = 1000
-                )
-            }
-
-            TrackMetadata(
-                timestamp = timestamp,
-                title = title,
-                artist = artist,
-                albumArtist = albumArtist,
-                album = album,
-                artworkUrl = artworkUrl,
-                year = year,
-                track = track,
-                progress = progress
-            )
+        if (payload == null) {
+            return ServerStateResult(RoleUpdate.Absent, null, RoleUpdate.Absent)
         }
 
         val state = payload.stringOrDefault("state", "").takeIf { it.isNotEmpty() }
 
-        // Controller (group-level) state delta. All fields lenient: aiosendspin
-        // sends the complete object, but spec delta semantics allow partials.
-        val controller = (payload["controller"] as? JsonObject)?.let { controllerObj ->
-            ControllerState(
-                supportedCommands = controllerObj["supported_commands"]?.jsonArray?.mapNotNull {
-                    it.jsonPrimitive.contentOrNull
-                },
-                volume = controllerObj["volume"]?.jsonPrimitive?.intOrNull,
-                muted = controllerObj["muted"]?.jsonPrimitive?.booleanOrNull,
-                repeat = controllerObj["repeat"]?.jsonPrimitive?.contentOrNull,
-                shuffle = controllerObj["shuffle"]?.jsonPrimitive?.booleanOrNull
+        return ServerStateResult(
+            metadata = payload.roleUpdate("metadata", ::parseMetadataPatch),
+            playbackState = state,
+            controller = payload.roleUpdate("controller", ::parseControllerPatch),
+        )
+    }
+
+    /** Absent / null / object, for a whole role. */
+    private fun <S> JsonObject.roleUpdate(
+        key: String,
+        parse: (JsonObject) -> StatePatch<S>,
+    ): RoleUpdate<S> {
+        val element = this[key] ?: return RoleUpdate.Absent
+        if (element is JsonNull) return RoleUpdate.Cleared
+        val obj = element as? JsonObject ?: return RoleUpdate.Absent
+        return RoleUpdate.Delta(parse(obj))
+    }
+
+    private fun parseMetadataPatch(obj: JsonObject): MetadataPatch = MetadataPatch(
+        timestamp = obj.patch("timestamp") { it.longOrNull() },
+        title = obj.patch("title", ::cleanString),
+        artist = obj.patch("artist", ::cleanString),
+        albumArtist = obj.patch("album_artist", ::cleanString),
+        album = obj.patch("album", ::cleanString),
+        artworkUrl = obj.patch("artwork_url", ::cleanString),
+        year = obj.patch("year") { it.intOrNull() },
+        track = obj.patch("track") { it.intOrNull() },
+        progress = parseProgress(obj),
+    )
+
+    /**
+     * `progress` is replaced or cleared whole, never deep-merged.
+     *
+     * The pre-spec Music Assistant flat fields are honoured only when
+     * `progress` is absent *entirely*. An explicit `"progress": null` is a
+     * clear, and falling back to the legacy fields there would resurrect a
+     * position the server just told us to forget.
+     */
+    private fun parseProgress(obj: JsonObject): Patch<TrackProgress> {
+        val element = obj["progress"]
+        if (element is JsonNull) return Patch.Cleared
+        if (element is JsonObject) {
+            return Patch.Set(
+                TrackProgress(
+                    trackProgress = element.longOrDefault("track_progress", 0),
+                    trackDuration = element.longOrDefault("track_duration", 0),
+                    playbackSpeed = element.intOrDefault("playback_speed", 1000),
+                )
             )
         }
+        if (element != null) return Patch.Absent
 
-        return ServerStateResult(metadata, state, controller)
+        val hasLegacy = obj.containsKey("position_ms") || obj.containsKey("duration_ms")
+        if (!hasLegacy) return Patch.Absent
+        return Patch.Set(
+            TrackProgress(
+                trackProgress = obj.longOrDefault("position_ms", 0),
+                trackDuration = obj.longOrDefault("duration_ms", 0),
+                playbackSpeed = 1000,
+            )
+        )
     }
+
+    private fun parseControllerPatch(obj: JsonObject): ControllerPatch = ControllerPatch(
+        supportedCommands = obj.patch("supported_commands") { element ->
+            (element as? JsonArray)?.mapNotNull { it.jsonPrimitive.contentOrNull }
+        },
+        volume = obj.patch("volume") { it.intOrNull() },
+        muted = obj.patch("muted") { it.booleanOrNull() },
+        repeat = obj.patch("repeat", ::cleanString),
+        shuffle = obj.patch("shuffle") { it.booleanOrNull() },
+        seekMaxMs = obj.patch("seek_max_ms") { it.longOrNull() },
+    )
+
+    /**
+     * Music Assistant sends the four-character string "null" for an absent
+     * title on some tracks. Treated as a clear rather than a title, but only
+     * for strings - narrowly scoped, because any other field could legitimately
+     * carry that text.
+     */
+    private fun cleanString(element: JsonElement): String? =
+        (element as? JsonPrimitive)?.contentOrNull?.takeUnless { it == "null" }
+
+    private fun JsonElement.longOrNull(): Long? = (this as? JsonPrimitive)?.longOrNull
+
+    private fun JsonElement.intOrNull(): Int? = (this as? JsonPrimitive)?.intOrNull
+
+    private fun JsonElement.booleanOrNull(): Boolean? = (this as? JsonPrimitive)?.booleanOrNull
 
     fun parseServerCommand(payload: JsonObject?): ServerCommandResult? {
         if (payload == null) return null


### PR DESCRIPTION
Closes #212.

## The bug

A `server/state` carrying only `progress` blanked the Now Playing screen.

The parser read role objects with `as? JsonObject` and defaulted missing strings to `""`, so a progress tick arrived downstream as a metadata object with empty title, artist and album - and downstream, where empty means "clear", that wiped the track on every tick. The three wire states the spec defines had been collapsed into one:

| wire | meaning |
|---|---|
| key absent | keep what we have |
| key with `null` | clear what we have |
| key with value | replace what we have |

Kotlin's `T?` has room for two of those. Hence `Patch` with three cases, `RoleUpdate` for whole role objects, and `MetadataPatch` / `ControllerPatch` that merge into the cached state instead of replacing it.

## A Kotlin trap worth knowing

`applyTo` is an **extension**, not a member, and that is load-bearing. `Patch.Absent` is a `Patch<Nothing>`; a member function makes the compiler emit a bridge that casts the return to `Void`, which throws `ClassCastException: String cannot be cast to Void` the moment a real value passes through it. It compiles clean and fails only at runtime - the tests caught it, static typing did not.

## Two behaviour changes

- **`{"metadata": null}` now clears the role.** It previously parsed as "missing", and an existing test asserted that. Per `messaging.md` a null role object "clears all of that role's state", and `server/activate` relies on it when it drops a state role from `active_roles`. That test is rewritten.
- **Explicit `null` leaves produce `null`, not `""`.**

Nested objects are replaced whole, never deep-merged, per the spec. The pre-spec Music Assistant flat `position_ms`/`duration_ms` fields are honoured only when `progress` is absent *entirely* - an explicit null is a clear, and falling back there would resurrect a position the server just told us to forget.

`TrackMetadata`'s fields become nullable so a cleared leaf is representable, and `ControllerState` gains `seek_max_ms`, which was on the wire and never read (#214 needs it).

## Two deliberate scope decisions

**Kept the empty-string-means-clear convention** at the `PlaybackService` boundary, converting with `.orEmpty()`. That convention was only *wrong* because the parser fabricated empty strings for fields the delta never mentioned; now that the handler merges first, an empty string genuinely means cleared. Ripping it out is cleanup, not correctness, and belongs in its own change rather than bundled into a bug fix.

**No `ColorPatch`.** Nothing renders color until #218, and parsing for an unrendered role is code that rots. #218 can add it alongside its consumer.

## Verification

14 new merge tests, 771 app + 704 shared tests passing. Mutation-checked: making `Patch.Absent` behave like `Cleared` fails five tests, including the one named for this bug.

Not verified on device. The symptom is visible - play a track and watch whether the title survives a progress tick - so it is worth a look before merge if the tablet is free.
